### PR TITLE
Initialize Terraform with CloudFront CDN and S3 origin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,12 @@ typings/
 
 # next.js build output
 .next
+
+# Compiled Terraform files
+*.tfstate
+*.tfstate.backup
+*.tfvars
+*.tfplan
+
+# Terraform module directory
+.terraform/

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,37 @@
+# Deployment
+
+* [AWS Credentials](#aws-credentials)
+* [Terraform](#terraform)
+
+## AWS Credentials
+
+Using the AWS CLI, create an AWS profile named `echo-locator`:
+
+```bash
+$ vagrant ssh
+vagrant@vagrant-ubuntu-trusty-64:~$ aws --profile echo-locator configure
+AWS Access Key ID [****************F2DQ]:
+AWS Secret Access Key [****************TLJ/]:
+Default region name [us-east-1]: us-east-1
+Default output format [None]:
+```
+
+You will be prompted to enter your AWS credentials, along with a default region. These credentials will be used to authenticate calls to the AWS API when using Terraform and the AWS CLI.
+
+## Terraform
+
+To deploy this project's core infrastructure, use the `infra` wrapper script to lookup the remote state of the infrastructure and assemble a plan for work to be done:
+
+```bash
+vagrant@vagrant-ubuntu-trusty-64:~$ export ECHOLOCATOR_SETTINGS_BUCKET="echo-locator-staging-config-us-east-1"
+vagrant@vagrant-ubuntu-trusty-64:~$ export AWS_PROFILE="echo-locator"
+vagrant@vagrant-ubuntu-trusty-64:~$ docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan
+```
+
+Once the plan has been assembled, and you agree with the changes, apply it:
+
+```bash
+vagrant@vagrant-ubuntu-trusty-64:~$ docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply
+```
+
+This will attempt to apply the plan assembled in the previous step using Amazon's APIs. In order to change specific attributes of the infrastructure, inspect the contents of the environment's configuration file in Amazon S3.

--- a/deployment/terraform/cdn.tf
+++ b/deployment/terraform/cdn.tf
@@ -5,8 +5,9 @@ resource "aws_cloudfront_distribution" "cdn" {
   }
 
   enabled             = true
+  is_ipv6_enabled     = true
   http_version        = "http2"
-  comment             = "EchoLocator (${var.environment})"
+  comment             = "${var.project} (${var.environment})"
   default_root_object = "index.html"
   retain_on_delete    = true
 
@@ -69,7 +70,12 @@ resource "aws_cloudfront_distribution" "cdn" {
 
   viewer_certificate {
     acm_certificate_arn      = "${module.cert.arn}"
-    minimum_protocol_version = "TLSv1"
+    minimum_protocol_version = "TLSv1.2_2018"
     ssl_support_method       = "sni-only"
+  }
+
+  tags {
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
   }
 }

--- a/deployment/terraform/cdn.tf
+++ b/deployment/terraform/cdn.tf
@@ -1,0 +1,75 @@
+resource "aws_cloudfront_distribution" "cdn" {
+  origin {
+    domain_name = "${module.origin.site_bucket}.s3.amazonaws.com"
+    origin_id   = "originEastId"
+  }
+
+  enabled             = true
+  http_version        = "http2"
+  comment             = "EchoLocator (${var.environment})"
+  default_root_object = "index.html"
+  retain_on_delete    = true
+
+  price_class = "PriceClass_100"
+  aliases     = ["${var.r53_public_hosted_zone_name}"]
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "originEastId"
+
+    forwarded_values {
+      query_string = true
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+
+    # Only applies if the origin adds Cache-Control headers. The
+    # CloudFront default is also 0.
+    min_ttl = 0
+
+    # Five minutes, and only applies when the origin DOES NOT
+    # supply Cache-Control headers.
+    default_ttl = 300
+
+    # One day, but only applies if the origin adds Cache-Control
+    # headers. The CloudFront default is 31536000 (one year).
+    max_ttl = 86400
+  }
+
+  custom_error_response {
+    error_caching_min_ttl = "0"
+    error_code            = "403"
+    response_code         = "200"
+    response_page_path    = "/index.html"
+  }
+
+  custom_error_response {
+    error_caching_min_ttl = "0"
+    error_code            = "404"
+    response_code         = "200"
+    response_page_path    = "/index.html"
+  }
+
+  logging_config {
+    include_cookies = false
+    bucket          = "${module.origin.logs_bucket}.s3.amazonaws.com"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = "${module.cert.arn}"
+    minimum_protocol_version = "TLSv1"
+    ssl_support_method       = "sni-only"
+  }
+}

--- a/deployment/terraform/certificate.tf
+++ b/deployment/terraform/certificate.tf
@@ -1,0 +1,8 @@
+module "cert" {
+  source = "github.com/azavea/terraform-aws-acm-certificate?ref=0.1.0"
+
+  domain_name               = "${var.r53_public_hosted_zone_name}"
+  subject_alternative_names = ["*.${var.r53_public_hosted_zone_name}"]
+  hosted_zone_id            = "${aws_route53_zone.external.zone_id}"
+  validation_record_ttl     = "60"
+}

--- a/deployment/terraform/config.tf
+++ b/deployment/terraform/config.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  region  = "${var.aws_region}"
+  version = "~> 1.56.0"
+}
+
+provider "template" {
+  version = "~> 1.0.0"
+}
+
+terraform {
+  backend "s3" {
+    region  = "us-east-1"
+    encrypt = "true"
+  }
+}

--- a/deployment/terraform/dns.tf
+++ b/deployment/terraform/dns.tf
@@ -1,0 +1,20 @@
+resource "aws_route53_zone" "external" {
+  name = "${var.r53_public_hosted_zone_name}"
+
+  tags {
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+resource "aws_route53_record" "site" {
+  zone_id = "${aws_route53_zone.external.id}"
+  name    = "${var.r53_public_hosted_zone_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_cloudfront_distribution.cdn.domain_name}"
+    zone_id                = "${aws_cloudfront_distribution.cdn.hosted_zone_id}"
+    evaluate_target_health = false
+  }
+}

--- a/deployment/terraform/dns.tf
+++ b/deployment/terraform/dns.tf
@@ -18,3 +18,15 @@ resource "aws_route53_record" "site" {
     evaluate_target_health = false
   }
 }
+
+resource "aws_route53_record" "site_ipv6" {
+  zone_id = "${aws_route53_zone.external.id}"
+  name    = "${var.r53_public_hosted_zone_name}"
+  type    = "AAAA"
+
+  alias {
+    name                   = "${aws_cloudfront_distribution.cdn.domain_name}"
+    zone_id                = "${aws_cloudfront_distribution.cdn.hosted_zone_id}"
+    evaluate_target_health = false
+  }
+}

--- a/deployment/terraform/storage.tf
+++ b/deployment/terraform/storage.tf
@@ -1,0 +1,15 @@
+module "origin" {
+  source = "github.com/azavea/terraform-aws-s3-origin?ref=0.3.0"
+
+  bucket_name      = "echo-locator-${lower(var.environment)}-site-${var.aws_region}"
+  logs_bucket_name = "echo-locator-${lower(var.environment)}-logs-${var.aws_region}"
+
+  cors_allowed_headers = ["Authorization"]
+  cors_allowed_methods = ["GET"]
+  cors_allowed_origins = ["*"]
+  cors_max_age_seconds = "3000"
+
+  project     = "${var.project}"
+  environment = "${var.environment}"
+  region      = "${var.aws_region}"
+}

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -1,0 +1,13 @@
+variable "project" {
+  default = "EchoLocator"
+}
+
+variable "environment" {
+  default = "Staging"
+}
+
+variable "aws_region" {
+  default = "us-east-1"
+}
+
+variable "r53_public_hosted_zone_name" {}

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -1,5 +1,5 @@
 variable "project" {
-  default = "EchoLocator"
+  default = "ECHOLocator"
 }
 
 variable "environment" {

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  terraform:
+    image: quay.io/azavea/terraform:0.11.11
+    volumes:
+      - ./:/usr/local/src
+      - $HOME/.aws:/root/.aws:ro
+    environment:
+      - AWS_PROFILE=echo-locator
+      - GIT_COMMIT=${GIT_COMMIT:-latest}
+      - ECHOLOCATOR_DEBUG=1
+      - ECHOLOCATOR_SETTINGS_BUCKET=${ECHOLOCATOR_SETTINGS_BUCKET:-echo-locator-staging-config-us-east-1}
+      - ECHOLOCATOR_SITE_BUCKET=${ECHOLOCATOR_SITE_BUCKET:-echo-locator-staging-site-us-east-1}
+    working_dir: /usr/local/src
+    entrypoint: bash

--- a/scripts/infra
+++ b/scripts/infra
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${ECHOLOCATOR_DEBUG}" ]]; then
+    set -x
+fi
+
+DIR="$(dirname "$0")"
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0") COMMAND OPTION[S]
+
+Execute Terraform subcommands with remote state management.
+"
+}
+
+if [[ -n "${GIT_COMMIT}" ]]; then
+    GIT_COMMIT="${GIT_COMMIT:0:7}"
+else
+    GIT_COMMIT="$(git rev-parse --short HEAD)"
+fi
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        TERRAFORM_DIR="${DIR}/../deployment/terraform"
+        echo
+        echo "Attempting to deploy application version [${GIT_COMMIT}]..."
+        echo "-----------------------------------------------------"
+        echo
+    fi
+
+    if [[ -n "${ECHOLOCATOR_SETTINGS_BUCKET}" ]]; then
+        pushd "${TERRAFORM_DIR}"
+
+        aws s3 cp "s3://${ECHOLOCATOR_SETTINGS_BUCKET}/terraform/terraform.tfvars" \
+                  "${ECHOLOCATOR_SETTINGS_BUCKET}.tfvars"
+
+        case "${1}" in
+            plan)
+                # Clear stale modules & remote state, then re-initialize
+                rm -rf .terraform terraform.tfstate*
+                terraform init \
+                  -backend-config="bucket=${ECHOLOCATOR_SETTINGS_BUCKET}" \
+                  -backend-config="key=terraform/state"
+
+                terraform plan \
+                  -var-file="${ECHOLOCATOR_SETTINGS_BUCKET}.tfvars" \
+                  -out="${ECHOLOCATOR_SETTINGS_BUCKET}.tfplan"
+                ;;
+            apply)
+                terraform apply "${ECHOLOCATOR_SETTINGS_BUCKET}.tfplan"
+                ;;
+            *)
+                echo "ERROR: I don't have support for that Terraform subcommand!"
+                exit 1
+                ;;
+        esac
+
+        popd
+    else
+        echo "ERROR: No ECHOLOCATOR_SETTINGS_BUCKET variable defined."
+        exit 1
+    fi
+fi


### PR DESCRIPTION
## Overview

Perform initial Terraform setup, including a CloudFront CDN and S3 origin for the app. In addition, set up the foundation for the staging site at https://echolocator.azavea.com.

Closes #2.

## Demo

Visit https://echolocator.azavea.com to see a hello world message:

<img width="912" alt="screen shot 2019-01-23 at 1 18 00 pm" src="https://user-images.githubusercontent.com/14170650/51627848-628fb100-1f11-11e9-82be-99f3606acb32.png">


## Testing instructions

* Create an `echo-locator` AWS profile using access credentials for the Professional Services account:

```
aws configure --profile echo-locator
```

* Run Terraform plan: 

```
docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan
```

* Confirm that the plan comes out clean
* Visit https://echolocator.azavea and confirm:
    * Page loads properly
    * Certificate valid
    * Content is the same as http://echo-locator-staging-site-us-east-1.s3.amazonaws.com/index.html