### PR TITLE
Mount entire Taui directory into Docker guest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   taui:
     build: ./taui
     volumes:
-      - ./taui/src:/usr/local/src/src
+      - ./taui:/usr/local/src
     working_dir: /usr/local/src
     ports:
       - "9966:9966"


### PR DESCRIPTION
## Overview

Instead of only mounting `taui/src/` into the Taui container, mount the entire `taui` directory. This allows assets and other directories to be passed between the host and the guest.

## Notes

* I believe this change was preventing updates from getting deployed to the staging site.

## Testing instructions

* Run `./scripts/server` to rebuild
* Confirm that everything looks good