### PR TITLE
Pass environment on deploy to mastarm

### DIFF
--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -34,6 +34,6 @@ then
         # Deploy CSS and JS with Mastarm
         docker-compose -f docker-compose.yml \
                        -f docker-compose.ci.yml \
-                       run --rm taui run deploy --minify --config "${TAUI_CONFIG_DIR}"
+                       run --rm taui run deploy --minify --config "${TAUI_CONFIG_DIR}" --env "${ENV}"
     fi
 fi


### PR DESCRIPTION
Not sure if this will address #15, but `mastarm` uses the environment variable.