### PR TITLE
Feature/kak/amplify theme#35

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -33,7 +33,10 @@ Strings:
   HighlightAreaAccessibleWithin: Show the area accessible within
   Welcome: Search for your address above or click on the map to get started.
 Slower: slower
-Title: BHA ECHOLocator
+Title: ECHO Locator
 Units:
   Minutes: minutes
   Mins: min
+Agency: Boston Housing Authority
+SignIn:
+  Greeting: At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga.

--- a/taui/src/amplify-theme.js
+++ b/taui/src/amplify-theme.js
@@ -1,0 +1,16 @@
+// @flow
+
+// custom Amplify component styling
+export const CustomAuthenticatorTheme = {
+  formContainer: {'margin': '0'},
+  sectionFooter: {'display': 'block'},
+  button: {'backgroundColor': 'var(--blue)', 'width': '100%'},
+  nav: {
+    'display': 'flex',
+    'justifyContent': 'space-between',
+    'backgroundColor': 'lightgrey',
+    'padding': 0},
+  navBar: {'border': 0},
+  navItem: {'lineHeight': '300%'},
+  navButton: {'backgroundColor': 'var(--blue)'}
+}

--- a/taui/src/components/application.js
+++ b/taui/src/components/application.js
@@ -112,10 +112,8 @@ export default class Application extends Component<Props, State> {
 const Main = () => (
   <div>
     <div className='Splash'>
-      <div className='Logo' />
-      <h4>Boston Housing Authority</h4>
-      <h2>ECHO Locator</h2>
-      <div className='Splash-Box'>
+      <h2 className='SplashBoxHeader'>New Search</h2>
+      <div className='SplashBox'>
         <Link to='/map'>Go to map</Link>
         <br />
         <Link to='/test'>Test route</Link>

--- a/taui/src/components/custom-header-bar.js
+++ b/taui/src/components/custom-header-bar.js
@@ -1,0 +1,47 @@
+// @flow
+import { Greetings } from 'aws-amplify-react'
+import {
+  NavBar,
+  Nav,
+  NavItem
+} from 'aws-amplify-react/dist/Amplify-UI/Amplify-UI-Components-React'
+import AmplifyTheme from 'aws-amplify-react/dist/Amplify-UI/Amplify-UI-Theme'
+import message from '@conveyal/woonerf/message'
+import React from 'react'
+
+export default class CustomHeaderBar extends Greetings {
+  getUserName () {
+    const user = this.props.authData
+    // get name from attributes first
+    const nameFromAttr = user.attributes
+      ? (user.attributes.name ||
+      (user.attributes.given_name
+        ? (user.attributes.given_name + ' ' + user.attributes.family_name) : undefined))
+      : undefined
+    return nameFromAttr || user.name || user.username
+  }
+
+  // based on:
+  // https://github.com/aws-amplify/amplify-js/blob/master/packages/aws-amplify-react/src/Auth/Greetings.jsx#L131
+  render () {
+    const authState = this.props.authState || this.state.authState
+    const signedIn = (authState === 'signedIn')
+    if (!signedIn) { return null }
+    const theme = this.props.theme || AmplifyTheme
+    // TODO: #21 display selected account holder name (not logged-in user)
+    const name = this.getUserName()
+    return (
+      <NavBar theme={theme}>
+        <Nav theme={theme}>
+          <NavItem theme={theme}>
+            <div className='LogoNavbar'>
+              <span className='TitleNavbar'>{message('Title')}</span>
+            </div>
+          </NavItem>
+          <NavItem theme={theme}>{name}</NavItem>
+          <NavItem theme={theme}>{this.renderSignOutButton(theme)}</NavItem>
+        </Nav>
+      </NavBar>
+    )
+  }
+}

--- a/taui/src/components/custom-sign-in.js
+++ b/taui/src/components/custom-sign-in.js
@@ -1,0 +1,113 @@
+// @flow
+import { I18n } from '@aws-amplify/core'
+import {
+  FederatedButtons,
+  ForgotPassword,
+  SignIn,
+  SignUp
+} from 'aws-amplify-react'
+import {
+  FormSection,
+  FormField,
+  SectionHeader,
+  SectionBody,
+  SectionFooter,
+  Button,
+  Link,
+  Hint,
+  Input,
+  InputLabel,
+  SectionFooterPrimaryContent,
+  SectionFooterSecondaryContent
+} from 'aws-amplify-react/dist/Amplify-UI/Amplify-UI-Components-React'
+import message from '@conveyal/woonerf/message'
+import React from 'react'
+
+class SignInHeader extends React.Component {
+  render () {
+    return <div className='Splash'>
+      <div className='Logo' />
+      <h3>{message('Agency')}</h3>
+      <h2>{message('Title')}</h2>
+      <p>{message('SignIn.Greeting')}</p>
+    </div>
+  }
+}
+
+export default class CustomSignIn extends SignIn {
+  // Have to copy showComponent here, because `hide` non-mutable property
+  // results in null being returned from call to super.
+  // Issue: https://github.com/aws-amplify/amplify-js/issues/1603
+  // Based on source:
+  // https://github.com/aws-amplify/amplify-js/blob/master/packages/aws-amplify-react/src/Auth/SignIn.jsx#L120
+  showComponent (theme) {
+    console.log('custom signin showComponent')
+
+    const { authState, hide = [], federated, onStateChange, onAuthEvent, override = [] } = this.props
+    const hideSignUp = !override.includes('SignUp') && hide.some(component => component === SignUp)
+    const hideForgotPassword = !override.includes('ForgotPassword') &&
+      hide.some(component => component === ForgotPassword)
+
+    return (
+      <div>
+        <SignInHeader />
+        <FormSection theme={theme}>
+          <SectionBody theme={theme}>
+            <FederatedButtons
+              federated={federated}
+              theme={theme}
+              authState={authState}
+              onStateChange={onStateChange}
+              onAuthEvent={onAuthEvent}
+            />
+            <FormField theme={theme}>
+              <InputLabel>{I18n.get('Username')} *</InputLabel>
+              <Input
+                autoFocus
+                placeholder={I18n.get('Enter your username')}
+                theme={theme}
+                key='username'
+                name='username'
+                onChange={this.handleInputChange}
+              />
+            </FormField>
+            <FormField theme={theme}>
+              <InputLabel>{I18n.get('Password')} *</InputLabel>
+              <Input
+                placeholder={I18n.get('Enter your password')}
+                theme={theme}
+                key='password'
+                type='password'
+                name='password'
+                onChange={this.handleInputChange}
+              />
+              {
+                !hideForgotPassword && <Hint theme={theme}>
+                  {I18n.get('Forget your password? ')}
+                  <Link theme={theme} onClick={() => this.changeState('forgotPassword')}>
+                    {I18n.get('Reset password')}
+                  </Link>
+                </Hint>
+              }
+            </FormField>
+          </SectionBody>
+          <SectionFooter theme={theme}>
+            <SectionFooterPrimaryContent theme={theme}>
+              <Button theme={theme} onClick={this.signIn} disabled={this.state.loading}>
+                {I18n.get('Sign In')}
+              </Button>
+            </SectionFooterPrimaryContent>
+            {
+              !hideSignUp && <SectionFooterSecondaryContent theme={theme}>
+                {I18n.get('No account? ')}
+                <Link theme={theme} onClick={() => this.changeState('signUp')}>
+                  {I18n.get('Create account')}
+                </Link>
+              </SectionFooterSecondaryContent>
+            }
+          </SectionFooter>
+        </FormSection>
+      </div>
+    )
+  }
+}

--- a/taui/src/components/custom-sign-in.js
+++ b/taui/src/components/custom-sign-in.js
@@ -9,7 +9,6 @@ import {
 import {
   FormSection,
   FormField,
-  SectionHeader,
   SectionBody,
   SectionFooter,
   Button,
@@ -37,12 +36,9 @@ class SignInHeader extends React.Component {
 export default class CustomSignIn extends SignIn {
   // Have to copy showComponent here, because `hide` non-mutable property
   // results in null being returned from call to super.
-  // Issue: https://github.com/aws-amplify/amplify-js/issues/1603
   // Based on source:
   // https://github.com/aws-amplify/amplify-js/blob/master/packages/aws-amplify-react/src/Auth/SignIn.jsx#L120
   showComponent (theme) {
-    console.log('custom signin showComponent')
-
     const { authState, hide = [], federated, onStateChange, onAuthEvent, override = [] } = this.props
     const hideSignUp = !override.includes('SignUp') && hide.some(component => component === SignUp)
     const hideForgotPassword = !override.includes('ForgotPassword') &&

--- a/taui/src/components/with-authenticator.js
+++ b/taui/src/components/with-authenticator.js
@@ -1,0 +1,79 @@
+// @flow
+import { Component, Fragment } from 'react'
+import { Authenticator } from 'aws-amplify-react'
+
+import CustomHeaderBar from './custom-header-bar'
+
+// Override authentication wrapper to use custom header bar
+// based on:
+// https://github.com/aws-amplify/amplify-js/blob/master/packages/aws-amplify-react/src/Auth/index.jsx
+export default function withAuthenticator (Comp, includeGreetings = false,
+  authenticatorComponents = [], federated = null, theme = null, signUpConfig = {}) {
+  return class extends Component {
+    constructor (props) {
+      super(props)
+
+      this.handleAuthStateChange = this.handleAuthStateChange.bind(this)
+
+      this.state = {
+        authState: props.authState || null,
+        authData: props.authData || null
+      }
+
+      this.authConfig = {}
+
+      if (typeof includeGreetings === 'object' && includeGreetings !== null) {
+        this.authConfig = Object.assign(this.authConfig, includeGreetings)
+      } else {
+        this.authConfig = {
+          includeGreetings,
+          authenticatorComponents,
+          federated,
+          theme,
+          signUpConfig
+        }
+      }
+    }
+
+    handleAuthStateChange (state, data) {
+      this.setState({ authState: state, authData: data })
+    }
+
+    render () {
+      const { authState, authData } = this.state
+      const signedIn = (authState === 'signedIn')
+      if (signedIn) {
+        return (
+          <Fragment>
+            {
+              this.authConfig.includeGreetings ? <CustomHeaderBar
+                authState={authState}
+                authData={authData}
+                federated={this.authConfig.federated || this.props.federated || {}}
+                onStateChange={this.handleAuthStateChange}
+                theme={theme}
+              /> : null
+            }
+            <Comp
+              {...this.props}
+              authState={authState}
+              authData={authData}
+              onStateChange={this.handleAuthStateChange}
+            />
+          </Fragment>
+        )
+      }
+
+      return <Authenticator
+        {...this.props}
+        theme={this.authConfig.theme}
+        federated={this.authConfig.federated || this.props.federated}
+        hideDefault={this.authConfig.authenticatorComponents &&
+            this.authConfig.authenticatorComponents.length > 0}
+        signUpConfig={this.authConfig.signUpConfig}
+        onStateChange={this.handleAuthStateChange}
+        children={this.authConfig.authenticatorComponents || []}
+      />
+    }
+  }
+}

--- a/taui/src/index.css
+++ b/taui/src/index.css
@@ -299,6 +299,13 @@ table.CardContent td:first-of-type {
 
 .Splash {
   text-align: center;
+  margin-left: 20%;
+  margin-right: 20%;
+}
+
+.Splash h1, h2, h3, h4 {
+  margin-top: 0;
+  margin-bottom: 0;
 }
 
 .Splash-Box {

--- a/taui/src/index.css
+++ b/taui/src/index.css
@@ -51,7 +51,6 @@ html, body {
 
 .Taui-Dock {
   background-color: var(--dark-blue);
-  position: absolute;
   width: 414px;
   top: 0;
   left: 0;
@@ -289,12 +288,20 @@ table.CardContent td:first-of-type {
 
 .Logo {
   background: url(/src/BHAlogo.png) no-repeat;
-  width: 100%
+  width: 100%;
   padding-top: 5rem;
   background-size: 4rem;
   background-position: center;
   background-position-x: center;
   background-position-y: center;
+}
+
+.LogoNavbar {
+  background: url(/src/BHAlogo.png) no-repeat;
+  background-size: 4rem;
+  width: 10rem;
+  height: 3rem;
+  text-align: right;
 }
 
 .Splash {
@@ -303,18 +310,15 @@ table.CardContent td:first-of-type {
   margin-right: 20%;
 }
 
-.Splash h1, h2, h3, h4 {
-  margin-top: 0;
-  margin-bottom: 0;
+.SplashBoxHeader {
+  text-align: left;
 }
 
-.Splash-Box {
+.SplashBox {
   background-color: white;
-  width: 40%;
-  margin-left: 30%;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
   align-content: center;
+  padding-top: 2rem;
+  padding-bottom: 2rem;
 }
 
 .Popup button {

--- a/taui/src/index.js
+++ b/taui/src/index.js
@@ -7,16 +7,38 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { BrowserRouter, withRouter } from 'react-router-dom'
 import {
+  ConfirmSignIn,
+  ConfirmSignUp,
+  ForgotPassword,
+  Loading,
+  RequireNewPassword,
   SignIn,
-  withAuthenticator
+  TOTPSetup,
+  VerifyContact
 } from 'aws-amplify-react'
 
 import actions from './actions'
 import awsmobile from './aws-exports'
 import Application from './components/application'
 import CustomSignIn from './components/custom-sign-in'
+import withAuthenticator from './components/with-authenticator'
 import reducers from './reducers'
 import * as select from './selectors'
+
+// custom Amplify component styling
+const CustomAuthenticatorTheme = {
+  formContainer: {'margin': '0'},
+  sectionFooter: {'display': 'block'},
+  button: {'backgroundColor': 'var(--blue)', 'width': '100%'},
+  nav: {
+    'display': 'flex',
+    'justifyContent': 'space-between',
+    'backgroundColor': 'lightgrey',
+    'padding': 0},
+  navBar: {'border': 0},
+  navItem: {'lineHeight': '300%'},
+  navButton: {'backgroundColor': 'var(--blue)'}
+}
 
 // Set the title
 document.title = message('Title')
@@ -46,14 +68,18 @@ function mapStateToProps (state, ownProps) {
   }
 }
 
-const CustomAuthenticatorTheme = {
-  formContainer: {'margin': '0'},
-  sectionFooter: {'display': 'block'},
-  button: {'backgroundColor': 'var(--blue)', 'width': '100%'}
-}
-
 const ConnectedApplication = withAuthenticator(withRouter(
-  connect(mapStateToProps, actions)(Application)), true, [<CustomSignIn override={SignIn} />], null, CustomAuthenticatorTheme)
+  connect(mapStateToProps, actions)(Application)), true,
+[
+  <CustomSignIn override={SignIn} />,
+  <ConfirmSignIn />,
+  <ConfirmSignUp />,
+  <ForgotPassword />,
+  <Loading />,
+  <RequireNewPassword />,
+  <TOTPSetup />,
+  <VerifyContact />
+], null, CustomAuthenticatorTheme)
 
 // Create an Application wrapper
 class InitializationWrapper extends React.Component {

--- a/taui/src/index.js
+++ b/taui/src/index.js
@@ -19,26 +19,12 @@ import {
 
 import actions from './actions'
 import awsmobile from './aws-exports'
+import { CustomAuthenticatorTheme } from './amplify-theme'
 import Application from './components/application'
 import CustomSignIn from './components/custom-sign-in'
 import withAuthenticator from './components/with-authenticator'
 import reducers from './reducers'
 import * as select from './selectors'
-
-// custom Amplify component styling
-const CustomAuthenticatorTheme = {
-  formContainer: {'margin': '0'},
-  sectionFooter: {'display': 'block'},
-  button: {'backgroundColor': 'var(--blue)', 'width': '100%'},
-  nav: {
-    'display': 'flex',
-    'justifyContent': 'space-between',
-    'backgroundColor': 'lightgrey',
-    'padding': 0},
-  navBar: {'border': 0},
-  navItem: {'lineHeight': '300%'},
-  navButton: {'backgroundColor': 'var(--blue)'}
-}
 
 // Set the title
 document.title = message('Title')

--- a/taui/src/index.js
+++ b/taui/src/index.js
@@ -6,11 +6,15 @@ import get from 'lodash/get'
 import React from 'react'
 import { connect } from 'react-redux'
 import { BrowserRouter, withRouter } from 'react-router-dom'
-import { withAuthenticator } from 'aws-amplify-react'
+import {
+  SignIn,
+  withAuthenticator
+} from 'aws-amplify-react'
 
 import actions from './actions'
 import awsmobile from './aws-exports'
 import Application from './components/application'
+import CustomSignIn from './components/custom-sign-in'
 import reducers from './reducers'
 import * as select from './selectors'
 
@@ -42,8 +46,14 @@ function mapStateToProps (state, ownProps) {
   }
 }
 
+const CustomAuthenticatorTheme = {
+  formContainer: {'margin': '0'},
+  sectionFooter: {'display': 'block'},
+  button: {'backgroundColor': 'var(--blue)', 'width': '100%'}
+}
+
 const ConnectedApplication = withAuthenticator(withRouter(
-  connect(mapStateToProps, actions)(Application)))
+  connect(mapStateToProps, actions)(Application)), true, [<CustomSignIn override={SignIn} />], null, CustomAuthenticatorTheme)
 
 // Create an Application wrapper
 class InitializationWrapper extends React.Component {


### PR DESCRIPTION
## Overview

Customizes sign-in page and adds a customized navbar with a logout button.

## Demo

![echo_custom_signin](https://user-images.githubusercontent.com/960264/52881058-91c0c900-3131-11e9-969d-eee0a0b1be97.png)

![bha_splash_page](https://user-images.githubusercontent.com/960264/52881086-a8672000-3131-11e9-9ffc-08740c591f3c.png)

![image](https://user-images.githubusercontent.com/960264/52881118-c0d73a80-3131-11e9-89ef-6295cdee884d.png)

## Notes

This will need some styling cleanup (i.e., the existing taui blue probably isn't the BHA blue we want), but sets up the customized sign-in and header bar components alongside a custom Amplify theme that readies the app for further styling work and header bar customization.

The logged-in user name is currently displayed in the header bar; as part of implementing account selection/switching, that should be changed to match the current account, as in the wireframes.

The Amplify theme styling is currently defined near the top of `index.js`, defined as `CustomAuthenticatorTheme`. Ideally, these rules would go in a CSS file instead. I'm not sure how best to handle that.


## Testing

 - `./scripts/serve`
 - Clear local storage for http://localhost:9966
 - Should get customized login page
 - On login, should have customized header and be able to use it to log out


Closes #35 
Closes #23 
