### PR TITLE
Configure production resources

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -25,15 +25,17 @@ You will be prompted to enter your AWS credentials, along with a default region.
 To deploy this project's core infrastructure, use the `infra` wrapper script to lookup the remote state of the infrastructure and assemble a plan for work to be done:
 
 ```bash
-vagrant@vagrant-ubuntu-trusty-64:~$ export ECHOLOCATOR_SETTINGS_BUCKET="echo-locator-staging-config-us-east-1"
-vagrant@vagrant-ubuntu-trusty-64:~$ export AWS_PROFILE="echo-locator"
-vagrant@vagrant-ubuntu-trusty-64:~$ docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan
+$ export ECHOLOCATOR_SETTINGS_BUCKET="echo-locator-staging-config-us-east-1"
+$ export AWS_PROFILE="echo-locator"
+$ docker-compose -f docker-compose.yml -f docker-compose.ci.yml \
+    run --rm terraform ./scripts/infra plan
 ```
 
 Once the plan has been assembled, and you agree with the changes, apply it:
 
 ```bash
-vagrant@vagrant-ubuntu-trusty-64:~$ docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply
+$ docker-compose -f docker-compose.yml -f docker-compose.ci.yml \
+    run --rm terraform ./scripts/infra apply
 ```
 
 This will attempt to apply the plan assembled in the previous step using Amazon's APIs. In order to change specific attributes of the infrastructure, inspect the contents of the environment's configuration file in Amazon S3.
@@ -52,6 +54,12 @@ output the IDs of both resources. Take these IDs and put them in the
 if you're deploying a staging instance of Taui, edit
 `taui/configurations/staging/settings.yml` and update the `cloudfront` and
 `s3bucket` properties to point to your new resources.
+
+Taui requires one secret configuration file, `env.yml`, to be stored in remote
+state. CI will pull down this configuration file when it builds a bundle
+for a given environment. When standing up a new stack, remember to create
+an `env.yml` file based on the template in `taui/configurations/default/env.yml.tmp`
+and push it up to the remote state bucket under the path `/taui/env.yml`.
 
 ## Amplify
 

--- a/taui/configurations/production/settings.yml
+++ b/taui/configurations/production/settings.yml
@@ -1,0 +1,8 @@
+cloudfront: E22HN48FLR2YMR
+entries:
+  - src/index.js:assets/index.js
+  - src/index.css:assets/index.css
+  - src/BHAlogo.png:assets/BHAlogo.png
+env: production
+flyle: true
+s3bucket: echo-locator-production-site-us-east-1

--- a/taui/configurations/staging/settings.yml
+++ b/taui/configurations/staging/settings.yml
@@ -1,4 +1,4 @@
-cloudfront: E2CSIKFLWDFPC9
+cloudfront: E3A0YNQDZRFX9J
 entries:
   - src/index.js:assets/index.js
   - src/index.css:assets/index.css


### PR DESCRIPTION
## Overview

Make a few small changes to support a new production deployment, including:

* Update deployment README to reflect lessons learned from standing up production resources
* Add new production settings file for Taui

Closes #5.
 
## Notes

* We still don't have a production domain. I pushed up resources using the domain https://echolocator-prd.azavea.com, but we'll have to either A) consider this PR blocked or B) go with the temporary domain while we wait for the real domain.

## Testing instructions

* Run a production deployment locally:

```console
# Taui uses AWS JS SDK and needs the key pair to live in environment variables
$ export AWS_ACCESS_KEY=<echo-locator-access-key>
$ export AWS_SECRET_ACCESS_KEY=<echo-locator-secret-access-key>
$ export ENV=production
$ ./scripts/cipublish
```

* Navigate to https://echolocator-prd.azavea.com and confirm that it looks good