### PR TITLE
Feature/kak/profile page#22

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -57,9 +57,10 @@ Accounts:
   Voucher: Voucher Number
 Profile:
   AddAddress: Add another destination
+  Address: Address
+  AddressMissing: All destinations should have an address. Please set or remove any empty destinations.
   DeleteAddress: Delete this address
   DeletePrimaryAddressError: Cannot delete primary destination. Set another as the primary first.
-  Address: Address
   Cancel: Cancel
   Delete: Delete
   DeleteProfileError: Failed to delete profile. Please try again.

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -46,11 +46,15 @@ Header:
   New: New
   Edit: Edit
 Accounts:
-  Title: Accounts
+  Create: Create new profile
+  CreateError: Failed to create profile. Please try again.
   Name: Name of Head of Household
-  Voucher: Voucher Number
   Search: Search
-  Create: Create new account
+  SearchError: Failed to search profiles. Please try again.
+  SelectError: Failed to set profile. Please try again.
+  NoResults: No profile found for that voucher number. Create new profile now?
+  Title: Profiles
+  Voucher: Voucher Number
 Profile:
   AddAddress: Add another destination
   DeleteAddress: Delete this address
@@ -65,6 +69,7 @@ Profile:
   Rooms: Number of rooms in voucher
   HasVehicle: Will have a car
   Go: Go
+  NameRequired: Please enter a name for the head of household.
   SaveError: Failed to save profile. Please try again.
   Title: Profile
 TripPurpose:

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -18,7 +18,9 @@ NewTrip: New Trip
 Geocoding:
   StartPlaceholder: Search the map
   EndPlaceholder: Choose destination, or click on the map
+  FindingLocation: Locating you...
   PromptText: Type to find a location
+  UseCurrentLocation: Use current location
 Log:
   Title: Log
 Map:

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -56,6 +56,7 @@ Profile:
   Cancel: Cancel
   Delete: Delete
   Destinations: Frequent destinations
+  Primary: Primary
   Purpose: Purpose
   Rooms: Number of rooms in voucher
   HasCar: Will have a car

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -52,6 +52,7 @@ Accounts:
 Profile:
   AddAddress: Add another destination
   DeleteAddress: Delete this address
+  DeletePrimaryAddressError: Cannot delete primary address. Set another address as the primary first.
   Address: Address
   Cancel: Cancel
   Delete: Delete

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -54,7 +54,7 @@ Accounts:
 Profile:
   AddAddress: Add another destination
   DeleteAddress: Delete this address
-  DeletePrimaryAddressError: Cannot delete primary address. Set another address as the primary first.
+  DeletePrimaryAddressError: Cannot delete primary destination. Set another as the primary first.
   Address: Address
   Cancel: Cancel
   Delete: Delete

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -63,7 +63,7 @@ Profile:
   Primary: Primary
   Purpose: Purpose
   Rooms: Number of rooms in voucher
-  HasCar: Will have a car
+  HasVehicle: Will have a car
   Go: Go
   SaveError: Failed to save profile. Please try again.
   Title: Profile

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -40,9 +40,28 @@ Units:
 Agency: Boston Housing Authority
 SignIn:
   Greeting: At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga.
+Header:
+  New: New
+  Edit: Edit
 Accounts:
   Title: Accounts
   Name: Name of Head of Household
   Voucher: Voucher Number
   Search: Search
   Create: Create new account
+Profile:
+  AddAddress: Add another destination
+  DeleteAddress: Delete this address
+  Address: Address
+  Cancel: Cancel
+  Delete: Delete
+  Destinations: Frequent destinations
+  Purpose: Purpose
+  Rooms: Number of rooms in voucher
+  HasCar: Will have a car
+  Go: Go
+  Title: Profile
+TripPurpose:
+  Daycare: Day care
+  Other: Other
+  Work: Work

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -58,12 +58,14 @@ Profile:
   Address: Address
   Cancel: Cancel
   Delete: Delete
+  DeleteProfileError: Failed to delete profile. Please try again.
   Destinations: Frequent destinations
   Primary: Primary
   Purpose: Purpose
   Rooms: Number of rooms in voucher
   HasCar: Will have a car
   Go: Go
+  SaveError: Failed to save profile. Please try again.
   Title: Profile
 TripPurpose:
   Daycare: Day care

--- a/taui/src/components/application.js
+++ b/taui/src/components/application.js
@@ -12,6 +12,7 @@ import type {
   UIStore
 } from '../types'
 
+import EditProfile from './edit-profile'
 import MainPage from './main-page'
 import SelectAccount from './select-account'
 
@@ -126,6 +127,9 @@ export default class Application extends Component<Props, State> {
           {...props}
           headOfHousehold={props.headOfHousehold}
           voucherNumber={props.voucherNumber} />} />
+        <Route path='/profile' render={() => (
+          profileLoading || userProfile
+            ? (<EditProfile {...props} profile={userProfile} />) : (<Redirect to='/search' />))} />
       </Switch>
     )
   }

--- a/taui/src/components/application.js
+++ b/taui/src/components/application.js
@@ -129,7 +129,7 @@ export default class Application extends Component<Props, State> {
           voucherNumber={props.voucherNumber} />} />
         <Route path='/profile' render={() => (
           profileLoading || userProfile
-            ? (<EditProfile {...props} profile={userProfile} />) : (<Redirect to='/search' />))} />
+            ? (<EditProfile {...props} />) : (<Redirect to='/search' />))} />
       </Switch>
     )
   }

--- a/taui/src/components/custom-header-bar.js
+++ b/taui/src/components/custom-header-bar.js
@@ -2,6 +2,7 @@
 import { Greetings } from 'aws-amplify-react/dist/Auth'
 import message from '@conveyal/woonerf/message'
 import React from 'react'
+import { Link } from 'react-router-dom'
 
 import type {AccountProfile} from '../types'
 
@@ -34,6 +35,12 @@ export default class CustomHeaderBar extends Greetings {
       <div className='app-header__user-info'>
         <span className='app-header__user-name'>{userProfile.headOfHousehold}</span>
         <span className='app-header__voucher-number'># {userProfile.voucherNumber}</span>
+        <span className='app-header__button'>
+          <Link to='/profile'>{message('Header.Edit')}</Link>
+        </span>
+        <span className='app-header__button'>
+          <Link to='/search'>{message('Header.New')}</Link>
+        </span>
       </div>
     ) : null
 

--- a/taui/src/components/custom-header-bar.js
+++ b/taui/src/components/custom-header-bar.js
@@ -36,7 +36,7 @@ export default class CustomHeaderBar extends Greetings {
         <span className='app-header__user-name'>{userProfile.headOfHousehold}</span>
         <span className='app-header__voucher-number'># {userProfile.voucherNumber}</span>
         <span className='app-header__button'>
-          <Link to='/profile'>{message('Header.Edit')}</Link>
+          <Link to={{pathname: '/profile', state: {fromApp: true}}}>{message('Header.Edit')}</Link>
         </span>
         <span className='app-header__button'>
           <Link to='/search'>{message('Header.New')}</Link>

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -17,7 +17,10 @@ type Props = {
 }
 
 const firstAddress: AccountAddress = {
-  address: '',
+  location: {
+    label: '',
+    position: null
+  },
   primary: true,
   purpose: DEFAULT_PROFILE_DESTINATION_TYPE
 }
@@ -126,7 +129,10 @@ export default class EditProfile extends PureComponent<Props> {
   addAddress () {
     const destinations = this.state.destinations.slice()
     const newAddress: AccountAddress = {
-      address: '',
+      location: {
+        label: '',
+        position: null
+      },
       primary: !destinations.length,
       purpose: DEFAULT_PROFILE_DESTINATION_TYPE
     }
@@ -205,12 +211,13 @@ export default class EditProfile extends PureComponent<Props> {
           <Geocoder
             className='account-profile__input'
             geocode={geocode}
-            onChange={(result) => editAddress(index,
-              'address',
-              result['place_name'])}
+            onChange={(result) => editAddress(index, 'location', {
+              label: result ? result['place_name'] : '',
+              position: result ? {lat: result['center'][0], lon: result['center'][1]} : {}
+            })}
             placeholder={message('Geocoding.PromptText')}
             reverseGeocode={reverseGeocode}
-            value={{label: destination.address}}
+            value={destination.location}
           />
         </div>
         <div className='account-profile__destination_narrow_field'>

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -46,6 +46,7 @@ export default class EditProfile extends PureComponent<Props> {
     this.save = this.save.bind(this)
     this.setGeocodeLocation = this.setGeocodeLocation.bind(this)
     this.setPrimaryAddress = this.setPrimaryAddress.bind(this)
+    this.validDestinations = this.validDestinations.bind(this)
 
     const profile = props.userProfile
 
@@ -104,6 +105,9 @@ export default class EditProfile extends PureComponent<Props> {
       return
     } else if (!profile.headOfHousehold) {
       this.setState({errorMessage: message('Profile.NameRequired')})
+      return
+    } else if (!this.validDestinations(profile.destinations)) {
+      this.setState({errorMessage: message('Profile.AddressMissing')})
       return
     } else {
       this.setState({errorMessage: ''})
@@ -188,6 +192,22 @@ export default class EditProfile extends PureComponent<Props> {
       return destination
     })
     this.setState({destinations: newDestinations})
+  }
+
+  // Return true if all destinations have their location set and there is at least one.
+  validDestinations (destinations: Array<AccountAddress>): boolean {
+    if (!destinations || !destinations.length) {
+      return false
+    }
+
+    var valid = true
+    destinations.forEach(destination => {
+      if (!destination || !destination.location || !destination.location.position ||
+        !destination.location.label) {
+        valid = false
+      }
+    })
+    return valid
   }
 
   tripPurposeOptions (props) {

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -2,6 +2,7 @@
 import Storage from '@aws-amplify/storage'
 import lonlat from '@conveyal/lonlat'
 import message from '@conveyal/woonerf/message'
+import range from 'lodash/range'
 import {PureComponent} from 'react'
 
 import {
@@ -312,7 +313,7 @@ export default class EditProfile extends PureComponent<Props> {
   roomOptions (props) {
     const { changeField, rooms } = props
     const maxRooms = 4
-    const roomCountOptions = Array.from(new Array(maxRooms + 1), (val, i) => i)
+    const roomCountOptions = range(maxRooms + 1)
     const roomOptions = roomCountOptions.map((num) => {
       const strVal = num.toString()
       return <option key={strVal} value={strVal}>{strVal}</option>

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -15,6 +15,7 @@ export default class EditProfile extends PureComponent<Props> {
 
     this.addAddress = this.addAddress.bind(this)
     this.deleteAddress = this.deleteAddress.bind(this)
+    this.deleteProfile = this.deleteProfile.bind(this)
     this.editAddress = this.editAddress.bind(this)
     this.cancel = this.cancel.bind(this)
     this.changeField = this.changeField.bind(this)
@@ -86,8 +87,7 @@ export default class EditProfile extends PureComponent<Props> {
       .catch(err => console.error(err))
   }
 
-  deleteAccount (event) {
-    const key = this.state.key
+  deleteProfile (key, event) {
     console.log('delete profile for key ' + key)
     if (!key) {
       console.error('Cannot delete account without key')
@@ -100,7 +100,7 @@ export default class EditProfile extends PureComponent<Props> {
       .catch(err => console.error(err))
   }
 
-  addAddress (event) {
+  addAddress () {
     const destinations = this.state.destinations.slice()
     const newAddress: AccountAddress = {
       address: '',
@@ -167,6 +167,10 @@ export default class EditProfile extends PureComponent<Props> {
       destinations,
       setPrimaryAddress,
       TripPurposeOptions } = props
+
+    if (!destinations.length) {
+      addAddress()
+    }
     const listItems = destinations.map((destination: AccountAddress, index) => {
       return <li
         key={index}
@@ -313,14 +317,18 @@ export default class EditProfile extends PureComponent<Props> {
               }
               <div className='account-profile__destination_row'>
                 <button
-                  className='account-profile__button account-profile__button--primary account-profile__destination_narrow_field'
+                  className='account-profile__button account-profile__button--primary
+                    account-profile__destination_narrow_field'
                   onClick={save}>{message('Profile.Go')}</button>
                 <button
-                  className='account-profile__button account-profile__button--secondary account-profile__destination_narrow_field'
+                  className='account-profile__button account-profile__button--secondary
+                    account-profile__destination_narrow_field'
                   onClick={cancel}>{message('Profile.Cancel')}</button>
                 <button
-                  className='account-profile__button account-profile__button--secondary account-profile__destination_narrow_field'
-                  onClick={deleteProfile}>{message('Profile.Delete')}</button>
+                  className='account-profile__button account-profile__button--secondary
+                    account-profile__destination_narrow_field'
+                  onClick={(e) => deleteProfile(key, e)}
+                >{message('Profile.Delete')}</button>
               </div>
             </div>}
           </div>

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -1,5 +1,6 @@
 // @flow
 import Storage from '@aws-amplify/storage'
+import lonlat from '@conveyal/lonlat'
 import message from '@conveyal/woonerf/message'
 import {PureComponent} from 'react'
 
@@ -42,6 +43,7 @@ export default class EditProfile extends PureComponent<Props> {
     this.changeField = this.changeField.bind(this)
     this.getProfileFromState = this.getProfileFromState.bind(this)
     this.save = this.save.bind(this)
+    this.setGeocodeLocation = this.setGeocodeLocation.bind(this)
     this.setPrimaryAddress = this.setPrimaryAddress.bind(this)
 
     const profile = props.userProfile
@@ -167,6 +169,16 @@ export default class EditProfile extends PureComponent<Props> {
     this.setState({destinations})
   }
 
+  // Extract co-ordinates and address string from geocode result, similar to
+  // `_setStartWithFeature` in `main-page.js`
+  // If `feature` is null, the field was cleared (search terms without results cannot be selected)
+  setGeocodeLocation (index: number, editAddress, feature?: MapboxFeature) {
+    editAddress(index, 'location', {
+      label: feature ? feature.place_name : '',
+      position: feature ? lonlat(feature.geometry.coordinates) : null
+    })
+  }
+
   // Set which destination is the primary and unset any previous primary address
   setPrimaryAddress (index: number, event) {
     const destinations = this.state.destinations.slice()
@@ -204,6 +216,7 @@ export default class EditProfile extends PureComponent<Props> {
       editAddress,
       destinations,
       reverseGeocode,
+      setGeocodeLocation,
       setPrimaryAddress,
       TripPurposeOptions } = props
 
@@ -218,10 +231,7 @@ export default class EditProfile extends PureComponent<Props> {
           <Geocoder
             className='account-profile__input'
             geocode={geocode}
-            onChange={(result) => editAddress(index, 'location', {
-              label: result ? result['place_name'] : '',
-              position: result ? {lat: result['center'][0], lon: result['center'][1]} : {}
-            })}
+            onChange={(e) => setGeocodeLocation(index, editAddress, e)}
             placeholder={message('Geocoding.PromptText')}
             reverseGeocode={reverseGeocode}
             value={destination.location}
@@ -286,8 +296,7 @@ export default class EditProfile extends PureComponent<Props> {
             <div className='account-profile__destination_narrow_field'>
               <label
                 className='account-profile__label'
-                htmlFor='deleteAddress'>
-              </label>
+                htmlFor='deleteAddress' />
             </div>
           </li>
           {listItems}
@@ -323,6 +332,7 @@ export default class EditProfile extends PureComponent<Props> {
     const addAddress = this.addAddress
     const deleteAddress = this.deleteAddress
     const editAddress = this.editAddress
+    const setGeocodeLocation = this.setGeocodeLocation
     const setPrimaryAddress = this.setPrimaryAddress
     const cancel = this.cancel
     const changeField = this.changeField
@@ -373,6 +383,7 @@ export default class EditProfile extends PureComponent<Props> {
                   editAddress={editAddress}
                   geocode={geocode}
                   reverseGeocode={reverseGeocode}
+                  setGeocodeLocation={setGeocodeLocation}
                   setPrimaryAddress={setPrimaryAddress}
                   TripPurposeOptions={TripPurposeOptions}
                 />

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -311,17 +311,18 @@ export default class EditProfile extends PureComponent<Props> {
               {errorMessage &&
                 <p className='account-profile__error'>{errorMessage}</p>
               }
-              <button
-                className='account-profile__button account-profile__button--primary'
-                onClick={save}>{message('Profile.Go')}</button>
-              <button
-                className='account-profile__button account-profile__button--secondary'
-                onClick={cancel}>{message('Profile.Cancel')}</button>
+              <div className='account-profile__destination_row'>
+                <button
+                  className='account-profile__button account-profile__button--primary account-profile__destination_narrow_field'
+                  onClick={save}>{message('Profile.Go')}</button>
+                <button
+                  className='account-profile__button account-profile__button--secondary account-profile__destination_narrow_field'
+                  onClick={cancel}>{message('Profile.Cancel')}</button>
+                <button
+                  className='account-profile__button account-profile__button--secondary account-profile__destination_narrow_field'
+                  onClick={deleteProfile}>{message('Profile.Delete')}</button>
+              </div>
             </div>}
-            <br />
-            <button
-              className='account-profile__button account-profile__button--secondary'
-              onClick={deleteProfile}>{message('Profile.Delete')}</button>
           </div>
         </div>
       </div>

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -66,6 +66,7 @@ export default class EditProfile extends PureComponent<Props> {
   componentWillReceiveProps (nextProps) {
     // Listen for when profile to appear on props, because it is not present
     // on initial load. Only load once by checking state.
+    console.log(nextProps)
     if (!nextProps.isLoading && nextProps.userProfile && !this.state.key) {
       if (!nextProps.userProfile.destinations.length) {
         nextProps.userProfile.destinations = [Object.assign({}, firstAddress)]
@@ -76,7 +77,13 @@ export default class EditProfile extends PureComponent<Props> {
 
   cancel (event) {
     // Navigate back to the last page visited, discarding any changes.
-    this.props.history.goBack()
+    console.log(this.props.location.state)
+    if (this.props.location.state && this.props.location.state.fromApp) {
+      this.props.history.goBack()
+    } else {
+      // User navigated to this page directly
+      window.location.reload()
+    }
   }
 
   changeField (field, value) {

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -19,17 +19,7 @@ export default class EditProfile extends PureComponent<Props> {
     this.changeField = this.changeField.bind(this)
     this.getProfileFromState = this.getProfileFromState.bind(this)
     this.save = this.save.bind(this)
-
-    /*
-    profile: AccountProfile = {
-      destinations: [],
-      hasVehicle: false,
-      headOfHousehold: name,
-      key: key,
-      rooms: 0,
-      voucherNumber: voucher
-    }
-    */
+    this.setPrimaryAddress = this.setPrimaryAddress.bind(this)
 
     const profile = props.userProfile
 
@@ -86,25 +76,6 @@ export default class EditProfile extends PureComponent<Props> {
       this.setState({errorMessage: ''})
     }
 
-    ///////////////////////////
-    /*
-    console.log('FIXME: setting test destinations')
-    const newState = {'profile': this.state.profile}
-    const addr1: AccountAddress = {
-      address: '123 Main Street',
-      primary: true,
-      purpose: 'foo'
-    }
-
-    const addr2: AccountAddress = {
-      address: '443 Other Blvd',
-      primary: false,
-      purpose: 'bar'
-    }
-    newState['profile']['destinations'] = [addr1, addr2]
-    this.setState(newState)
-    */
-
     Storage.put(profile.key, JSON.stringify(profile))
       .then(result => {
         console.log(result)
@@ -152,31 +123,59 @@ export default class EditProfile extends PureComponent<Props> {
     this.setState(newState)
   }
 
+  // Set which destination is the primary and unset any previous primary address
+  setPrimaryAddress (index: number, event) {
+    const destinations = this.state.destinations.slice()
+    const newDestinations = destinations.map((destination: AccountAddress, i) => {
+      destination.primary = i === index
+      return destination
+    })
+    this.setState({destinations: newDestinations})
+  }
+
   destinationsList (props) {
-    const { addAddress, deleteAddress, editAddress, destinations } = props
+    const { addAddress, deleteAddress, editAddress, destinations, setPrimaryAddress } = props
     const listItems = destinations.map((destination: AccountAddress, index) => {
       return <li
         key={index}
-        className=''>
-        <label
-          className='account-profile__label'
-          htmlFor='address'>
-          {message('Profile.Address')}
-        </label>
-        <input
-          className='account-profile__input'
-          id='address'
-          type='text'
-          onChange={(e) => editAddress(index, e)}
-          defaultValue={destination ? destination.address : ''}
-        />
-        <button
-          className='account-profile__button account-profile__button--secondary'
-          data-id={index}
-          onClick={(e) => deleteAddress(index, e)}
-          title={message('Profile.DeleteAddress')}>
-          <img src='assets/trash-alt.svg' width='16' alt={message('Profile.Delete')} />
-        </button>
+        className='account-profile__destination_row'>
+        <div className='account-profile__destination_field'>
+          <label
+            className='account-profile__label'
+            htmlFor='address'>
+            {message('Profile.Address')}
+          </label>
+          <input
+            className='account-profile__input'
+            id='address'
+            type='text'
+            onChange={(e) => editAddress(index, e)}
+            defaultValue={destination ? destination.address : ''}
+          />
+        </div>
+        <div className='account-profile__destination_field'>
+          <label
+            className='account-profile__label'
+            htmlFor='primary'>
+            {message('Profile.Primary')}
+          </label>
+          <input
+            className='account-profile__input'
+            id='primary'
+            type='radio'
+            onChange={(e) => setPrimaryAddress(index, e)}
+            checked={!!destination.primary}
+          />
+        </div>
+        <div className='account-profile__destination_field'>
+          <button
+            className='account-profile__button account-profile__button--secondary'
+            data-id={index}
+            onClick={(e) => deleteAddress(index, e)}
+            title={message('Profile.DeleteAddress')}>
+            <img src='assets/trash-alt.svg' width='16' alt={message('Profile.Delete')} />
+          </button>
+        </div>
       </li>
     })
 
@@ -215,6 +214,7 @@ export default class EditProfile extends PureComponent<Props> {
     const addAddress = this.addAddress
     const deleteAddress = this.deleteAddress
     const editAddress = this.editAddress
+    const setPrimaryAddress = this.setPrimaryAddress
     const cancel = this.cancel
     const changeField = this.changeField
     const deleteProfile = this.deleteProfile
@@ -258,7 +258,9 @@ export default class EditProfile extends PureComponent<Props> {
                   addAddress={addAddress}
                   deleteAddress={deleteAddress}
                   destinations={destinations}
-                  editAddress={editAddress} />
+                  editAddress={editAddress}
+                  setPrimaryAddress={setPrimaryAddress}
+                />
               </div>
               {errorMessage &&
                 <p className='Error'>Error: {errorMessage}</p>

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -70,7 +70,8 @@ export default class EditProfile extends PureComponent<Props> {
   }
 
   cancel (event) {
-    console.log('TODO: implement cancel')
+    // Navigate back to the last page visited, discarding any changes.
+    this.props.history.goBack()
   }
 
   changeField (field, event) {

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -208,11 +208,6 @@ export default class EditProfile extends PureComponent<Props> {
         key={index}
         className='account-profile__destination_row'>
         <div className='account-profile__destination_field'>
-          <label
-            className='account-profile__label'
-            htmlFor='address'>
-            {message('Profile.Address')}
-          </label>
           <Geocoder
             className='account-profile__input'
             geocode={geocode}
@@ -226,11 +221,6 @@ export default class EditProfile extends PureComponent<Props> {
           />
         </div>
         <div className='account-profile__destination_narrow_field'>
-          <label
-            className='account-profile__label'
-            htmlFor='purpose'>
-            {message('Profile.Purpose')}
-          </label>
           <TripPurposeOptions
             destination={destination}
             editAddress={editAddress}
@@ -238,11 +228,6 @@ export default class EditProfile extends PureComponent<Props> {
           />
         </div>
         <div className='account-profile__destination_narrow_field'>
-          <label
-            className='account-profile__label'
-            htmlFor='primary'>
-            {message('Profile.Primary')}
-          </label>
           <input
             className='account-profile__input'
             id='primary'
@@ -253,6 +238,7 @@ export default class EditProfile extends PureComponent<Props> {
         </div>
         <div className='account-profile__destination_narrow_field'>
           <button
+            id='deleteAddress'
             className='account-profile__button account-profile__button--secondary'
             data-id={index}
             onClick={(e) => deleteAddress(index, e)}
@@ -266,6 +252,37 @@ export default class EditProfile extends PureComponent<Props> {
     return (
       <div className=''>
         <ul className=''>
+          <li
+            key='header'
+            className='account-profile__destination_row'>
+            <div className='account-profile__destination_field'>
+              <label
+                className='account-profile__label'
+                htmlFor='address'>
+                {message('Profile.Address')}
+              </label>
+            </div>
+            <div className='account-profile__destination_narrow_field'>
+              <label
+                className='account-profile__label'
+                htmlFor='purpose'>
+                {message('Profile.Purpose')}
+              </label>
+            </div>
+            <div className='account-profile__destination_narrow_field'>
+              <label
+                className='account-profile__label'
+                htmlFor='primary'>
+                {message('Profile.Primary')}
+              </label>
+            </div>
+            <div className='account-profile__destination_narrow_field'>
+              <label
+                className='account-profile__label'
+                htmlFor='deleteAddress'>
+              </label>
+            </div>
+          </li>
           {listItems}
         </ul>
         {destinations.length < maxAddressesAllowed && <button

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -112,7 +112,12 @@ export default class EditProfile extends PureComponent<Props> {
 
   deleteAddress (index: number, event) {
     const destinations = this.state.destinations.slice()
-    destinations.splice(index, 1)
+    const removedDestination = destinations.splice(index, 1)[0]
+    if (removedDestination.primary) {
+      console.error('Attempted to delete primary destination')
+      this.setState({errorMessage: message('Profile.DeletePrimaryAddressError')})
+      return
+    }
     const newState = {destinations: destinations, errorMessage: ''}
     this.setState(newState)
   }
@@ -304,7 +309,7 @@ export default class EditProfile extends PureComponent<Props> {
                 />
               </div>
               {errorMessage &&
-                <p className='Error'>Error: {errorMessage}</p>
+                <p className='account-profile__error'>{errorMessage}</p>
               }
               <button
                 className='account-profile__button account-profile__button--primary'

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -94,12 +94,9 @@ export default class EditProfile extends PureComponent<Props> {
 
   save () {
     const profile: AccountProfile = this.getProfileFromState()
-    console.log('save profile')
-    console.log(profile)
     if (!profile || !profile.key) {
-      console.error('Missing profile or key')
-      this.setState({errorMessage:
-        'FIXME: should not happen.'})
+      console.error('Cannot save profile: missing profile or its key.')
+      this.setState({errorMessage: message('Profile.SaveError')})
       return
     } else {
       this.setState({errorMessage: ''})
@@ -107,22 +104,27 @@ export default class EditProfile extends PureComponent<Props> {
 
     Storage.put(profile.key, JSON.stringify(profile))
       .then(result => {
-        console.log(result)
         this.props.changeUserProfile(profile)
-        //this.props.history.push('/map')
+        this.props.history.push('/map')
       })
-      .catch(err => console.error(err))
+      .catch(err => {
+        console.error(err)
+        this.setState({errorMessage: message('Profile.SaveError')})
+      })
   }
 
   deleteProfile (key, event) {
-    console.log('delete profile for key ' + key)
     if (!key) {
       console.error('Cannot delete account without key')
+      this.setState({errorMessage: message('Profile.SaveError')})
+      return
     }
 
     Storage.remove(key)
       .then(result => {
-        console.log('deleted')
+        // FIXME: also unset profile in storage/props
+        this.props.changeUserProfile(null)
+        this.props.history.push('/search')
       })
       .catch(err => console.error(err))
   }
@@ -357,16 +359,13 @@ export default class EditProfile extends PureComponent<Props> {
               }
               <div className='account-profile__destination_row'>
                 <button
-                  className='account-profile__button account-profile__button--primary
-                    account-profile__destination_narrow_field'
+                  className='account-profile__button account-profile__button--primary account-profile__destination_narrow_field'
                   onClick={save}>{message('Profile.Go')}</button>
                 <button
-                  className='account-profile__button account-profile__button--secondary
-                    account-profile__destination_narrow_field'
+                  className='account-profile__button account-profile__button--secondary account-profile__destination_narrow_field'
                   onClick={cancel}>{message('Profile.Cancel')}</button>
                 <button
-                  className='account-profile__button account-profile__button--secondary
-                    account-profile__destination_narrow_field'
+                  className='account-profile__button account-profile__button--secondary account-profile__destination_narrow_field'
                   onClick={(e) => deleteProfile(key, e)}
                 >{message('Profile.Delete')}</button>
               </div>

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -47,7 +47,8 @@ export default class EditProfile extends PureComponent<Props> {
     const profile = props.userProfile
 
     this.state = {
-      destinations: profile ? profile.destinations : [firstAddress],
+      destinations: profile && profile.destinations.length
+        ? profile.destinations : [Object.assign({}, firstAddress)],
       hasVehicle: profile ? profile.hasVehicle : false,
       headOfHousehold: profile ? profile.headOfHousehold : '',
       key: profile ? profile.key : '',
@@ -63,7 +64,7 @@ export default class EditProfile extends PureComponent<Props> {
     // on initial load. Only load once by checking state.
     if (!nextProps.isLoading && nextProps.userProfile && !this.state.key) {
       if (!nextProps.userProfile.destinations.length) {
-        nextProps.userProfile.destinations = [firstAddress]
+        nextProps.userProfile.destinations = [Object.assign({}, firstAddress)]
       }
       this.setState(nextProps.userProfile)
     }
@@ -94,9 +95,12 @@ export default class EditProfile extends PureComponent<Props> {
 
   save () {
     const profile: AccountProfile = this.getProfileFromState()
-    if (!profile || !profile.key) {
-      console.error('Cannot save profile: missing profile or its key.')
+    if (!profile || !profile.key || !profile.voucherNumber) {
+      console.error('Cannot save profile: missing profile or its voucher number.')
       this.setState({errorMessage: message('Profile.SaveError')})
+      return
+    } else if (!profile.headOfHousehold) {
+      this.setState({errorMessage: message('Profile.NameRequired')})
       return
     } else {
       this.setState({errorMessage: ''})
@@ -125,7 +129,10 @@ export default class EditProfile extends PureComponent<Props> {
         this.props.changeUserProfile(null)
         this.props.history.push('/search')
       })
-      .catch(err => console.error(err))
+      .catch(err => {
+        console.error(err)
+        this.setState({errorMessage: message('Profile.SaveError')})
+      })
   }
 
   addAddress () {

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -3,6 +3,7 @@ import Storage from '@aws-amplify/storage'
 import message from '@conveyal/woonerf/message'
 import {PureComponent} from 'react'
 
+import {DEFAULT_PROFILE_DESTINATION_TYPE, PROFILE_DESTINATION_TYPES} from '../constants'
 import type {AccountAddress, AccountProfile} from '../types'
 
 /**
@@ -104,7 +105,7 @@ export default class EditProfile extends PureComponent<Props> {
     const newAddress: AccountAddress = {
       address: '',
       primary: !destinations.length,
-      purpose: 'Work'
+      purpose: DEFAULT_PROFILE_DESTINATION_TYPE
     }
     this.setState({destinations: [...destinations, newAddress]})
   }
@@ -116,9 +117,10 @@ export default class EditProfile extends PureComponent<Props> {
     this.setState(newState)
   }
 
-  editAddress (index: number, event) {
+  // Set a `property` on a destination at `index`
+  editAddress (index: number, property: string, event) {
     const destinations = this.state.destinations.slice()
-    destinations[index]['address'] = event.currentTarget.value
+    destinations[index][property] = event.currentTarget.value
     const newState = {destinations: destinations}
     this.setState(newState)
   }
@@ -133,8 +135,33 @@ export default class EditProfile extends PureComponent<Props> {
     this.setState({destinations: newDestinations})
   }
 
+  tripPurposeOptions (props) {
+    const { destination, index, editAddress } = props
+    const options = PROFILE_DESTINATION_TYPES.map((key) => {
+      // expects each type in constants to have a label in messages
+      const messageKey = 'TripPurpose.' + key
+      return <option key={key}>{message(messageKey)}</option>
+    })
+
+    return (
+      <select
+        className='account-profile__input'
+        defaultValue={destination.purpose || DEFAULT_PROFILE_DESTINATION_TYPE}
+        onChange={(e) => editAddress(index, 'purpose', e)}
+        id='purpose'>
+        {options}
+      </select>
+    )
+  }
+
   destinationsList (props) {
-    const { addAddress, deleteAddress, editAddress, destinations, setPrimaryAddress } = props
+    const {
+      addAddress,
+      deleteAddress,
+      editAddress,
+      destinations,
+      setPrimaryAddress,
+      TripPurposeOptions } = props
     const listItems = destinations.map((destination: AccountAddress, index) => {
       return <li
         key={index}
@@ -149,11 +176,23 @@ export default class EditProfile extends PureComponent<Props> {
             className='account-profile__input'
             id='address'
             type='text'
-            onChange={(e) => editAddress(index, e)}
+            onChange={(e) => editAddress(index, 'address', e)}
             defaultValue={destination ? destination.address : ''}
           />
         </div>
-        <div className='account-profile__destination_field'>
+        <div className='account-profile__destination_narrow_field'>
+          <label
+            className='account-profile__label'
+            htmlFor='purpose'>
+            {message('Profile.Purpose')}
+          </label>
+          <TripPurposeOptions
+            destination={destination}
+            editAddress={editAddress}
+            index={index}
+          />
+        </div>
+        <div className='account-profile__destination_narrow_field'>
           <label
             className='account-profile__label'
             htmlFor='primary'>
@@ -167,7 +206,7 @@ export default class EditProfile extends PureComponent<Props> {
             checked={!!destination.primary}
           />
         </div>
-        <div className='account-profile__destination_field'>
+        <div className='account-profile__destination_narrow_field'>
           <button
             className='account-profile__button account-profile__button--secondary'
             data-id={index}
@@ -223,6 +262,7 @@ export default class EditProfile extends PureComponent<Props> {
 
     const DestinationsList = this.destinationsList
     const RoomOptions = this.roomOptions
+    const TripPurposeOptions = this.tripPurposeOptions
 
     return (
       <div className='form-screen'>
@@ -260,6 +300,7 @@ export default class EditProfile extends PureComponent<Props> {
                   destinations={destinations}
                   editAddress={editAddress}
                   setPrimaryAddress={setPrimaryAddress}
+                  TripPurposeOptions={TripPurposeOptions}
                 />
               </div>
               {errorMessage &&

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -142,8 +142,8 @@ export default class EditProfile extends PureComponent<Props> {
   deleteAddress (index: number, event) {
     const destinations = this.state.destinations.slice()
     const removedDestination = destinations.splice(index, 1)[0]
+    // Do not allow deleting the current primary address
     if (removedDestination.primary) {
-      console.error('Attempted to delete primary destination')
       this.setState({errorMessage: message('Profile.DeletePrimaryAddressError')})
       return
     }
@@ -197,6 +197,9 @@ export default class EditProfile extends PureComponent<Props> {
       reverseGeocode,
       setPrimaryAddress,
       TripPurposeOptions } = props
+
+    // Maximum number of destinations user may add
+    const maxAddressesAllowed = 3
 
     const listItems = destinations.map((destination: AccountAddress, index) => {
       return <li
@@ -263,9 +266,10 @@ export default class EditProfile extends PureComponent<Props> {
         <ul className=''>
           {listItems}
         </ul>
-        <button
+        {destinations.length < maxAddressesAllowed && <button
           className='account-profile__button account-profile__button--secondary'
-          onClick={addAddress}>{message('Profile.AddAddress')}</button>
+          onClick={addAddress}>{message('Profile.AddAddress')}
+        </button>}
       </div>
     )
   }

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -1,0 +1,282 @@
+// @flow
+import Storage from '@aws-amplify/storage'
+import message from '@conveyal/woonerf/message'
+import {PureComponent} from 'react'
+
+import type {AccountAddress, AccountProfile} from '../types'
+
+/**
+ * Edit voucher holder profile.
+ */
+export default class EditProfile extends PureComponent<Props> {
+  constructor (props) {
+    super(props)
+
+    this.addAddress = this.addAddress.bind(this)
+    this.deleteAddress = this.deleteAddress.bind(this)
+    this.editAddress = this.editAddress.bind(this)
+    this.cancel = this.cancel.bind(this)
+    this.changeField = this.changeField.bind(this)
+    this.getProfileFromState = this.getProfileFromState.bind(this)
+    this.save = this.save.bind(this)
+
+    /*
+    profile: AccountProfile = {
+      destinations: [],
+      hasVehicle: false,
+      headOfHousehold: name,
+      key: key,
+      rooms: 0,
+      voucherNumber: voucher
+    }
+    */
+
+    const profile = props.userProfile
+
+    this.state = {
+      destinations: profile ? profile.destinations : [],
+      hasVehicle: profile ? profile.hasVehicle : false,
+      headOfHousehold: profile ? profile.headOfHousehold : '',
+      key: profile ? profile.key : '',
+      rooms: profile ? profile.rooms : 0,
+      voucherNumber: profile ? profile.voucherNumber : '',
+      componentError: null,
+      errorMessage: ''
+    }
+  }
+
+  componentWillReceiveProps (nextProps) {
+    if (!nextProps.isLoading && nextProps.userProfile) {
+      this.setState(nextProps.userProfile)
+    }
+  }
+
+  cancel (event) {
+    console.log('TODO: implement cancel')
+  }
+
+  changeField (field, event) {
+    const newState = {errorMessage: ''}
+    newState[field] = event.currentTarget.value
+    this.setState(newState)
+  }
+
+  getProfileFromState (): AccountProfile {
+    const {destinations, hasVehicle, headOfHousehold, key, rooms, voucherNumber} = this.state
+    return {
+      destinations,
+      hasVehicle,
+      headOfHousehold,
+      key,
+      rooms,
+      voucherNumber
+    }
+  }
+
+  save () {
+    const profile: AccountProfile = this.getProfileFromState()
+    console.log('save profile')
+    console.log(profile)
+    if (!profile || !profile.key) {
+      console.error('Missing profile or key')
+      this.setState({errorMessage:
+        'FIXME: should not happen.'})
+      return
+    } else {
+      this.setState({errorMessage: ''})
+    }
+
+    ///////////////////////////
+    /*
+    console.log('FIXME: setting test destinations')
+    const newState = {'profile': this.state.profile}
+    const addr1: AccountAddress = {
+      address: '123 Main Street',
+      primary: true,
+      purpose: 'foo'
+    }
+
+    const addr2: AccountAddress = {
+      address: '443 Other Blvd',
+      primary: false,
+      purpose: 'bar'
+    }
+    newState['profile']['destinations'] = [addr1, addr2]
+    this.setState(newState)
+    */
+
+    Storage.put(profile.key, JSON.stringify(profile))
+      .then(result => {
+        console.log(result)
+        this.props.changeUserProfile(profile)
+        //this.props.history.push('/map')
+      })
+      .catch(err => console.error(err))
+  }
+
+  deleteAccount (event) {
+    const key = this.state.key
+    console.log('delete profile for key ' + key)
+    if (!key) {
+      console.error('Cannot delete account without key')
+    }
+
+    Storage.remove(key)
+      .then(result => {
+        console.log('deleted')
+      })
+      .catch(err => console.error(err))
+  }
+
+  addAddress (event) {
+    const destinations = this.state.destinations.slice()
+    const newAddress: AccountAddress = {
+      address: '',
+      primary: !destinations.length,
+      purpose: 'Work'
+    }
+    this.setState({destinations: [...destinations, newAddress]})
+  }
+
+  deleteAddress (index: number, event) {
+    const destinations = this.state.destinations.slice()
+    destinations.splice(index, 1)
+    const newState = {destinations: destinations, errorMessage: ''}
+    this.setState(newState)
+  }
+
+  editAddress (index: number, event) {
+    const destinations = this.state.destinations.slice()
+    destinations[index]['address'] = event.currentTarget.value
+    const newState = {destinations: destinations}
+    this.setState(newState)
+  }
+
+  destinationsList (props) {
+    const { addAddress, deleteAddress, editAddress, destinations } = props
+    const listItems = destinations.map((destination: AccountAddress, index) => {
+      return <li
+        key={index}
+        className=''>
+        <label
+          className='account-profile__label'
+          htmlFor='address'>
+          {message('Profile.Address')}
+        </label>
+        <input
+          className='account-profile__input'
+          id='address'
+          type='text'
+          onChange={(e) => editAddress(index, e)}
+          defaultValue={destination ? destination.address : ''}
+        />
+        <button
+          className='account-profile__button account-profile__button--secondary'
+          data-id={index}
+          onClick={(e) => deleteAddress(index, e)}
+          title={message('Profile.DeleteAddress')}>
+          <img src='assets/trash-alt.svg' width='16' alt={message('Profile.Delete')} />
+        </button>
+      </li>
+    })
+
+    return (
+      <div className=''>
+        <ul className=''>
+          {listItems}
+        </ul>
+        <button
+          className='account-profile__button account-profile__button--secondary'
+          onClick={addAddress}>{message('Profile.AddAddress')}</button>
+      </div>
+    )
+  }
+
+  roomOptions (props) {
+    const { changeField, rooms } = props
+    const maxRooms = 4
+    const roomCountOptions = Array.from(new Array(maxRooms + 1), (val, i) => i)
+    const roomOptions = roomCountOptions.map((num) => {
+      const strVal = num.toString()
+      return <option key={strVal} value={strVal}>{strVal}</option>
+    })
+
+    return (
+      <select
+        className='account-profile__input'
+        defaultValue={rooms}
+        onChange={(e) => changeField('rooms', e)}>
+        {roomOptions}
+      </select>
+    )
+  }
+
+  render () {
+    const addAddress = this.addAddress
+    const deleteAddress = this.deleteAddress
+    const editAddress = this.editAddress
+    const cancel = this.cancel
+    const changeField = this.changeField
+    const deleteProfile = this.deleteProfile
+    const save = this.save
+    const { destinations, headOfHousehold, errorMessage, key, rooms } = this.state
+
+    const DestinationsList = this.destinationsList
+    const RoomOptions = this.roomOptions
+
+    return (
+      <div className='form-screen'>
+        <h2 className='form-screen__heading'>{message('Profile.Title')}</h2>
+        <div className='form-screen__main'>
+          <div className='account-profile'>
+            {key && <div className='account-profile__main'>
+              <div className='account-profile__field'>
+                <label
+                  className='account-profile__label'
+                  htmlFor='headOfHousehold'>
+                  {message('Accounts.Name')}
+                </label>
+                <input
+                  className='account-profile__input'
+                  id='headOfHousehold'
+                  type='text'
+                  onChange={(e) => changeField('headOfHousehold', e)}
+                  defaultValue={headOfHousehold || ''}
+                />
+              </div>
+              <div className='account-profile__field'>
+                <label
+                  className='account-profile__label'
+                  htmlFor='rooms'>{message('Profile.Rooms')}</label>
+                <RoomOptions
+                  rooms={rooms}
+                  changeField={changeField} />
+              </div>
+              <div className=''>
+                <h2>{message('Profile.Destinations')}</h2>
+                <DestinationsList
+                  addAddress={addAddress}
+                  deleteAddress={deleteAddress}
+                  destinations={destinations}
+                  editAddress={editAddress} />
+              </div>
+              {errorMessage &&
+                <p className='Error'>Error: {errorMessage}</p>
+              }
+              <button
+                className='account-profile__button account-profile__button--primary'
+                onClick={save}>{message('Profile.Go')}</button>
+              <button
+                className='account-profile__button account-profile__button--secondary'
+                onClick={cancel}>{message('Profile.Cancel')}</button>
+            </div>}
+            <br />
+            <button
+              className='account-profile__button account-profile__button--secondary'
+              onClick={deleteProfile}>{message('Profile.Delete')}</button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -74,9 +74,9 @@ export default class EditProfile extends PureComponent<Props> {
     this.props.history.goBack()
   }
 
-  changeField (field, event) {
+  changeField (field, value) {
     const newState = {errorMessage: ''}
-    newState[field] = event.currentTarget.value
+    newState[field] = value
     this.setState(newState)
   }
 
@@ -122,7 +122,6 @@ export default class EditProfile extends PureComponent<Props> {
 
     Storage.remove(key)
       .then(result => {
-        // FIXME: also unset profile in storage/props
         this.props.changeUserProfile(null)
         this.props.history.push('/search')
       })
@@ -290,7 +289,7 @@ export default class EditProfile extends PureComponent<Props> {
       <select
         className='account-profile__input'
         defaultValue={rooms}
-        onChange={(e) => changeField('rooms', e)}>
+        onChange={(e) => changeField('rooms', e.currentTarget.value)}>
         {roomOptions}
       </select>
     )
@@ -307,7 +306,7 @@ export default class EditProfile extends PureComponent<Props> {
     const save = this.save
 
     const { geocode, reverseGeocode } = this.props
-    const { destinations, headOfHousehold, errorMessage, key, rooms } = this.state
+    const { destinations, hasVehicle, headOfHousehold, errorMessage, key, rooms } = this.state
 
     const DestinationsList = this.destinationsList
     const RoomOptions = this.roomOptions
@@ -329,7 +328,7 @@ export default class EditProfile extends PureComponent<Props> {
                   className='account-profile__input'
                   id='headOfHousehold'
                   type='text'
-                  onChange={(e) => changeField('headOfHousehold', e)}
+                  onChange={(e) => changeField('headOfHousehold', e.currentTarget.value)}
                   defaultValue={headOfHousehold || ''}
                 />
               </div>
@@ -352,6 +351,20 @@ export default class EditProfile extends PureComponent<Props> {
                   reverseGeocode={reverseGeocode}
                   setPrimaryAddress={setPrimaryAddress}
                   TripPurposeOptions={TripPurposeOptions}
+                />
+              </div>
+              <div className='account-profile__field'>
+                <label
+                  className='account-profile__label'
+                  htmlFor='hasVehicle'>
+                  {message('Profile.HasVehicle')}
+                </label>
+                <input
+                  className='account-profile__input'
+                  id='hasVehicle'
+                  type='checkbox'
+                  onChange={(e) => changeField('hasVehicle', e.currentTarget.checked)}
+                  defaultChecked={hasVehicle}
                 />
               </div>
               {errorMessage &&

--- a/taui/src/components/geocoder.js
+++ b/taui/src/components/geocoder.js
@@ -61,10 +61,7 @@ export default class Geocoder extends Component<Props> {
     const p = this.props
     const geolocateOptions = p.geolocate && 'geolocation' in navigator
       ? [{
-        label: message(
-          'Geocoding.UseCurrentLocation',
-          'Use Current Location'
-        ),
+        label: message('Geocoding.UseCurrentLocation'),
         value: GEOLOCATE_VALUE
       }]
       : []
@@ -110,7 +107,7 @@ export default class Geocoder extends Component<Props> {
     if (value && value.value === GEOLOCATE_VALUE) {
       this.setState({
         value: {
-          label: message('Geocoding.FindingLocation', 'Locating you...')
+          label: message('Geocoding.FindingLocation')
         }
       })
       window.navigator.geolocation.getCurrentPosition(position => {

--- a/taui/src/components/main-page.js
+++ b/taui/src/components/main-page.js
@@ -23,7 +23,7 @@ import RouteCard from './route-card'
 import RouteSegments from './route-segments'
 
 /**
- *
+ * Displays map and sidebar.
  */
 export default class MainPage extends React.PureComponent<Props> {
   state = {

--- a/taui/src/components/select-account.js
+++ b/taui/src/components/select-account.js
@@ -1,14 +1,14 @@
 // @flow
 import Storage from '@aws-amplify/storage'
 import message from '@conveyal/woonerf/message'
-import React from 'react'
+import {PureComponent} from 'react'
 
 import type {AccountProfile} from '../types'
 
 /**
  * Search and select from accounts on S3.
  */
-export default class SelectAccount extends React.PureComponent<Props> {
+export default class SelectAccount extends PureComponent<Props> {
   state = {
     accounts: [],
     componentError: null,
@@ -29,12 +29,12 @@ export default class SelectAccount extends React.PureComponent<Props> {
   }
 
   changeHeadOfHousehold (event) {
-    this.setState({headOfHousehold: event.target.value})
+    this.setState({headOfHousehold: event.currentTarget.value})
     this.setState({errorMessage: ''})
   }
 
   changeVoucherNumber (event) {
-    this.setState({'voucherNumber': event.target.value})
+    this.setState({'voucherNumber': event.currentTarget.value})
     this.setState({errorMessage: ''})
   }
 
@@ -125,7 +125,7 @@ export default class SelectAccount extends React.PureComponent<Props> {
       const text = result.Body.toString('utf-8')
       const profile: AccountProfile = JSON.parse(text)
       this.props.changeUserProfile(profile)
-      this.props.history.push('/map')
+      this.props.history.push('/profile')
     }).catch(err => {
       console.error('Failed to fetch account profile from S3 for key ' + key)
       console.error(err)
@@ -141,8 +141,7 @@ export default class SelectAccount extends React.PureComponent<Props> {
         <button
           className='account-list__button account-list__button--select'
           data-id={account.key}
-          onClick={selectAccount}
-        >
+          onClick={selectAccount}>
           <span className='account-list__name'>{account.headOfHousehold}</span>
           <span className='account-list__voucher-number'>{account.voucherNumber}</span>
         </button>
@@ -150,8 +149,7 @@ export default class SelectAccount extends React.PureComponent<Props> {
           className='account-list__button account-list__button--delete'
           data-id={account.key}
           onClick={deleteAccount}
-          title='Delete this account'
-        >
+          title='Delete this account'>
           <img src='assets/trash-alt.svg' width='16' alt='Delete' />
         </button>
       </li>

--- a/taui/src/components/select-account.js
+++ b/taui/src/components/select-account.js
@@ -101,7 +101,7 @@ export default class SelectAccount extends PureComponent<Props> {
       const text = result.Body.toString('utf-8')
       const profile: AccountProfile = JSON.parse(text)
       this.props.changeUserProfile(profile)
-      this.props.history.push('/profile')
+      this.props.history.push({pathname: '/profile', state: {fromApp: true}})
     }).catch(err => {
       console.error('Failed to fetch account profile from S3 for key ' + key)
       console.error(err)

--- a/taui/src/components/select-account.js
+++ b/taui/src/components/select-account.js
@@ -10,51 +10,42 @@ import type {AccountProfile} from '../types'
  */
 export default class SelectAccount extends PureComponent<Props> {
   state = {
-    accounts: [],
     componentError: null,
     errorMessage: '',
-    headOfHousehold: '',
+    noResults: false,
     voucherNumber: ''
   }
 
   constructor (props) {
     super(props)
 
-    this.changeHeadOfHousehold = this.changeHeadOfHousehold.bind(this)
     this.changeVoucherNumber = this.changeVoucherNumber.bind(this)
     this.createAccount = this.createAccount.bind(this)
-    this.deleteAccount = this.deleteAccount.bind(this)
     this.selectAccount = this.selectAccount.bind(this)
     this.search = this.search.bind(this)
   }
 
-  changeHeadOfHousehold (event) {
-    this.setState({headOfHousehold: event.currentTarget.value})
-    this.setState({errorMessage: ''})
-  }
-
   changeVoucherNumber (event) {
     this.setState({'voucherNumber': event.currentTarget.value})
-    this.setState({errorMessage: ''})
+    this.setState({errorMessage: '', noResults: false})
   }
 
   createAccount () {
     const search = this.search
-    const name = this.state.headOfHousehold
     const voucher = this.state.voucherNumber
 
-    if (!name || !voucher) {
-      console.error('Missing name or voucher')
+    // TODO: #61 validate voucher number
+
+    if (!voucher) {
+      console.error('Missing voucher')
       this.setState({errorMessage:
-        'Enter both name and voucher to create account.'})
+        'Enter a voucher number to create a profile.'})
       return
     } else {
       this.setState({errorMessage: ''})
     }
 
-    const key = name.toUpperCase() + '_' + voucher.toUpperCase()
-    console.log('Creating account profile for ' + key)
-
+    const key = voucher.toUpperCase()
     const profile: AccountProfile = {
       destinations: [],
       hasVehicle: false,
@@ -66,61 +57,46 @@ export default class SelectAccount extends PureComponent<Props> {
 
     Storage.put(key, JSON.stringify(profile))
       .then(result => {
-        console.log(result)
-        search() // refresh results
+        search() // Refresh results; will find and go to the new profile
       })
-      .catch(err => console.error(err))
+      .catch(err => {
+        console.error('Failed to post new profile to S3')
+        console.error(err)
+        this.setState({errorMessage: 'Accounts.CreateError'})
+      })
   }
 
   search () {
-    this.setState({errorMessage: ''})
-    const searchName = this.state.headOfHousehold.toUpperCase()
-    const searchVoucher = this.state.voucherNumber.toUpperCase()
+    // Capitalize and strip whitespace from voucher numbers to normalize
+    const searchVoucher = this.state.voucherNumber.toUpperCase().replace(/\s+/g, '')
+    if (!searchVoucher) {
+      this.setState({errorMessage: message('Accounts.SearchError')})
+      return
+    } else {
+      this.setState({errorMessage: ''})
+    }
 
-    const accounts = []
+    var found = false
     Storage.list('')
       .then(result => {
         const keys = result.map((r) => r.key)
-        let name
-        let voucher
         keys.forEach((key) => {
-          [name, voucher] = key.split('_')
-          if (searchName && name.indexOf(searchName) === -1) {
-            return
+          if (searchVoucher && key === searchVoucher) {
+            this.selectAccount(key)
+            found = true
           }
-          if (searchVoucher && voucher.indexOf(searchVoucher) === -1) {
-            return
-          }
-          accounts.push({
-            'headOfHousehold': name,
-            'key': key,
-            'voucherNumber': voucher
-          })
         })
-        this.setState({'accounts': accounts})
+        if (!found) {
+          this.setState({noResults: true})
+        }
       })
       .catch(err => {
         console.error(err)
-        this.setState({errorMessage: err})
+        this.setState({errorMessage: message('Accounts.SearchError')})
       })
   }
 
-  deleteAccount (event) {
-    const key = event.currentTarget.dataset.id
-    const search = this.search
-
-    console.log('Deleting account profile for ' + key)
-
-    Storage.remove(key)
-      .then(result => {
-        search() // refresh search results
-      })
-      .catch(err => console.error(err))
-  }
-
-  selectAccount (event) {
-    const key = event.currentTarget.dataset.id
-    console.log('Select account ' + key)
+  selectAccount (key) {
     Storage.get(key, {download: true, expires: 60}).then(result => {
       const text = result.Body.toString('utf-8')
       const profile: AccountProfile = JSON.parse(text)
@@ -129,46 +105,15 @@ export default class SelectAccount extends PureComponent<Props> {
     }).catch(err => {
       console.error('Failed to fetch account profile from S3 for key ' + key)
       console.error(err)
+      this.setState({errorMessage: message('Accounts.SelectError')})
     })
   }
 
-  accountList (props) {
-    const accountList = props.accounts
-    const deleteAccount = props.deleteAccount
-    const selectAccount = props.selectAccount
-    const listItems = accountList.map((account) =>
-      <li key={account.key} className='account-list__item'>
-        <button
-          className='account-list__button account-list__button--select'
-          data-id={account.key}
-          onClick={selectAccount}>
-          <span className='account-list__name'>{account.headOfHousehold}</span>
-          <span className='account-list__voucher-number'>{account.voucherNumber}</span>
-        </button>
-        <button
-          className='account-list__button account-list__button--delete'
-          data-id={account.key}
-          onClick={deleteAccount}
-          title='Delete this account'>
-          <img src='assets/trash-alt.svg' width='16' alt='Delete' />
-        </button>
-      </li>
-    )
-    return (
-      <ul className='account-list'>{listItems}</ul>
-    )
-  }
-
   render () {
-    const changeHeadOfHousehold = this.changeHeadOfHousehold
     const changeVoucherNumber = this.changeVoucherNumber
     const createAccount = this.createAccount
-    const deleteAccount = this.deleteAccount
-    const selectAccount = this.selectAccount
     const search = this.search
     const state = this.state
-
-    const AccountList = this.accountList
 
     return (
       <div className='form-screen'>
@@ -179,23 +124,7 @@ export default class SelectAccount extends PureComponent<Props> {
               <div className='account-search__field'>
                 <label
                   className='account-search__label'
-                  htmlFor='headOfHousehold'
-                >
-                  {message('Accounts.Name')}
-                </label>
-                <input
-                  className='account-search__input'
-                  id='headOfHousehold'
-                  type='text'
-                  onChange={changeHeadOfHousehold}
-                  value={state.headOfHousehold}
-                />
-              </div>
-              <div className='account-search__field'>
-                <label
-                  className='account-search__label'
-                  htmlFor='voucher'
-                >
+                  htmlFor='voucher'>
                   {message('Accounts.Voucher')}
                 </label>
                 <input
@@ -208,25 +137,22 @@ export default class SelectAccount extends PureComponent<Props> {
               </div>
               <button
                 className='account-search__button account-search__button--search'
-                onClick={search}
-              >
+                onClick={search}>
                 {message('Accounts.Search')}
               </button>
             </div>
             {state.errorMessage &&
               <p className='account-search__error'>{state.errorMessage}</p>
             }
-            <button
-              className='account-search__button account-search__button--create'
-              onClick={createAccount}
-            >
-              {message('Accounts.Create')}
-            </button>
+            {state.noResults && <div className='account-search__no_results'>
+              <h2>{message('Accounts.NoResults')}</h2>
+              <button
+                className='account-search__button account-search__button--create'
+                onClick={createAccount}>
+                {message('Accounts.Create')}
+              </button>
+            </div>}
           </div>
-          <AccountList
-            accounts={state.accounts}
-            deleteAccount={deleteAccount}
-            selectAccount={selectAccount} />
         </div>
       </div>
     )

--- a/taui/src/components/select-account.js
+++ b/taui/src/components/select-account.js
@@ -214,7 +214,7 @@ export default class SelectAccount extends PureComponent<Props> {
               </button>
             </div>
             {state.errorMessage &&
-              <p className='account-search__error'>Error: {state.errorMessage}</p>
+              <p className='account-search__error'>{state.errorMessage}</p>
             }
             <button
               className='account-search__button account-search__button--create'

--- a/taui/src/components/with-authenticator.js
+++ b/taui/src/components/with-authenticator.js
@@ -47,6 +47,10 @@ export default function withAuthenticator (Comp, includeGreetings = false,
 
     handleAuthStateChange (state, data) {
       this.setState({ authState: state, authData: data })
+      // Unset user profile on logout
+      if (state === 'signedOut') {
+        this.changeUserProfile(null)
+      }
     }
 
     render () {

--- a/taui/src/constants.js
+++ b/taui/src/constants.js
@@ -2,6 +2,16 @@
 export const ACCESSIBILITY_IS_EMPTY = 'accessibility-is-empty'
 export const ACCESSIBILITY_IS_LOADING = 'accessibility-is-loading'
 
+// Account profile destination types.
+// Each of these should have a translatable string label in `messages.yml`,
+// defined under `TripPurpose`.
+export const DEFAULT_PROFILE_DESTINATION_TYPE = 'Work'
+export const PROFILE_DESTINATION_TYPES = [
+  'Work',
+  'Daycare',
+  'Other'
+]
+
 // URLS
 export const MAPBOX_GEOCODING_URL =
   'https://api.mapbox.com/geocoding/v5/mapbox.places'

--- a/taui/src/sass/06_components/_account-profile.scss
+++ b/taui/src/sass/06_components/_account-profile.scss
@@ -61,19 +61,21 @@
 
   &__button {
     min-width: 12rem;
-    max-width: 20rem;
+    max-width: 22rem;
     height: 4rem;
+    line-height: 2.5rem;
 
     &--primary {
       @include button($color: $white, $background: $brand-blue);
       @include light-on-dark();
       @include font-weight(bold);
       flex: auto;
+      margin: 4rem auto 1.6rem;
     }
 
     &--secondary {
       @include button($color: $black, $background: $gray-300);
-      display: block;
+      flex: auto;
       margin: 4rem auto 1.6rem;
     }
   }

--- a/taui/src/sass/06_components/_account-profile.scss
+++ b/taui/src/sass/06_components/_account-profile.scss
@@ -1,5 +1,23 @@
 .account-profile {
 
+  &__destination_row {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: flex-start;
+    align-items: flex-end;
+  }
+
+  &__destination_field {
+    display: flex;
+    flex: auto;
+    flex-flow: column nowrap;
+    justify-content: flex-start;
+    align-items: stretch;
+    min-width: 24rem;
+    max-width: 32rem;
+    margin-right: 2.4rem;
+  }
+
   &__main {
     width: 100%
   }

--- a/taui/src/sass/06_components/_account-profile.scss
+++ b/taui/src/sass/06_components/_account-profile.scss
@@ -1,0 +1,51 @@
+.account-profile {
+
+  &__main {
+    width: 100%
+  }
+
+  &__field {
+    width: 100%;
+    margin-right: 2.4rem;
+    margin-bottom: 1rem;
+  }
+
+  &__label {
+    @include text(300);
+    @include font-weight(bold);
+    width: 100%;
+    margin-bottom: 0.8rem;
+  }
+
+  &__input {
+    height: 4rem;
+    padding: 0 0.8rem;
+  }
+
+  &__error {
+    @include text(400);
+    margin-top: 1.6rem;
+    padding: 1.6rem;
+    background-color: $gray-100;
+    color: $error;
+  }
+
+  &__button {
+    min-width: 12rem;
+    max-width: 20rem;
+    height: 4rem;
+
+    &--primary {
+      @include button($color: $white, $background: $brand-blue);
+      @include light-on-dark();
+      @include font-weight(bold);
+      flex: auto;
+    }
+
+    &--secondary {
+      @include button($color: $black, $background: $gray-300);
+      display: block;
+      margin: 4rem auto 1.6rem;
+    }
+  }
+}

--- a/taui/src/sass/06_components/_account-profile.scss
+++ b/taui/src/sass/06_components/_account-profile.scss
@@ -18,6 +18,17 @@
     margin-right: 2.4rem;
   }
 
+  &__destination_narrow_field {
+    display: flex;
+    flex: auto;
+    flex-flow: column nowrap;
+    justify-content: flex-start;
+    align-items: stretch;
+    min-width: 8rem;
+    max-width: 16rem;
+    margin-right: 2.4rem;
+  }
+
   &__main {
     width: 100%
   }

--- a/taui/src/sass/06_components/_app-header.scss
+++ b/taui/src/sass/06_components/_app-header.scss
@@ -14,6 +14,11 @@
     margin-right: 8rem;
   }
 
+  &__button {
+    margin-left: 1.6rem;
+    margin-right: 1.6rem;
+  }
+
   &__logo {
     flex: none;
     height: 3.2rem;

--- a/taui/src/sass/main.scss
+++ b/taui/src/sass/main.scss
@@ -12,6 +12,7 @@
 '05_base/_base.scss',
 '06_components/_auth-header.scss',
 '06_components/_app-header.scss',
+'06_components/_account-profile.scss',
 '06_components/_account-search.scss',
 '06_components/_account-list.scss',
 '07_layouts/_auth-screen.scss',

--- a/taui/src/types.js
+++ b/taui/src/types.js
@@ -1,25 +1,6 @@
 // @flow
 
 /**
- * Voucher holder account profile
- */
-
-export type AccountAddress = {
-  address: string,
-  primary: boolean,
-  purpose: string
-}
-
-export type AccountProfile = {
-  destinations: Array<AccountAddress>,
-  hasVehicle: boolean,
-  headOfHousehod: string,
-  key: string,
-  rooms: number,
-  voucherNumber: string
-}
-
-/**
  * Map data
  */
 export type Coordinate = [number, number]
@@ -60,6 +41,25 @@ export type Query = {
   west: number,
   width: number,
   zoom: number
+}
+
+/**
+ * Voucher holder account profile
+ */
+
+export type AccountAddress = {
+  location: Location,
+  primary: boolean,
+  purpose: string
+}
+
+export type AccountProfile = {
+  destinations: Array<AccountAddress>,
+  hasVehicle: boolean,
+  headOfHousehod: string,
+  key: string,
+  rooms: number,
+  voucherNumber: string
 }
 
 /**


### PR DESCRIPTION
## Overview

Add page with a form to enter or edit user profile. Modify search to only use voucher number and match exactly. (See discussion on #55).

Also adds header links to the search and profile pages, and clears profile on logout.


### Demo

New profile page:
![image](https://user-images.githubusercontent.com/960264/53996431-5436d680-4106-11e9-8e72-3618d275471c.png)

Search page:
![image](https://user-images.githubusercontent.com/960264/53996473-80eaee00-4106-11e9-9553-fde8a09ee747.png)

On voucher not found:
![image](https://user-images.githubusercontent.com/960264/53996489-96f8ae80-4106-11e9-988f-37147f7951e8.png)


### Notes

The voucher holder name is now an editable field on the profile page, as it is no longer a search/create key.


## Testing Instructions

 * Should be able to edit profile at `/profile`
 * Should be able to add up to three addresses
 * Address geocoder should work as expected
 * Changes should be saved to `localStorage` and to S3 on clicking 'go'
 * Navigating back to profile page after editing should reflect saved changes
 * Clicking 'cancel' should discard changes and navigate to the previous page (search or map)
 * 'Edit' header button should redirect to profile page
 * 'New' header button should redirect to search page
 * Profile should be unset on logout
 * Search should go to profile page on exact voucher number match
 * Search should prompt to create account if voucher number not found


Closes #22 
Closes #31 
Closes #59 
