### PR TITLE
Allow using the site anonymously

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -41,10 +41,13 @@ Units:
   Mins: min
 Agency: Boston Housing Authority
 SignIn:
+  Anonymous: Continue without an account
+  AnonymousExplanation: Don't have an account?
   Greeting: At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga.
 Header:
   New: New
   Edit: Edit
+  SignIn: Sign In
 Accounts:
   Create: Create new profile
   CreateError: Failed to create profile. Please try again.

--- a/taui/src/components/application.js
+++ b/taui/src/components/application.js
@@ -112,14 +112,16 @@ export default class Application extends Component<Props, State> {
     const profileLoading = this.props.data.profileLoading === undefined ? true
       : this.props.data.profileLoading
     const userProfile = this.props.data.userProfile
+    // Can navigate to map once at least one destination set on the profile.
+    const canViewMap = userProfile && userProfile.destinations && userProfile.destinations.length
     const isAnonymous = userProfile && userProfile.key === ANONYMOUS_USERNAME
     return (
       <Switch>
         <Route exact path='/' render={() => (
-          profileLoading || userProfile
+          profileLoading || canViewMap
             ? (<Redirect to='/map' />) : (<Redirect to='/search' />))} />
         <Route path='/map' render={() => (
-          profileLoading || userProfile
+          profileLoading || canViewMap
             ? (<MainPage {...props} />) : (<Redirect to='/search' />))} />
         <Route path='/search' render={() => (
           isAnonymous ? (<Redirect to='/profile' />) : <SelectAccount

--- a/taui/src/components/application.js
+++ b/taui/src/components/application.js
@@ -2,6 +2,7 @@
 import React, {Component} from 'react'
 import { Switch, Redirect, Route } from 'react-router-dom'
 
+import {ANONYMOUS_USERNAME} from '../constants'
 import type {
   AccountProfile,
   Coordinate,
@@ -101,9 +102,6 @@ export default class Application extends Component<Props, State> {
     if (window) {
       window.Application = this
     }
-
-    // Load the selected user profile from localStorage, if any
-    this.props.loadProfile()
   }
 
   /**
@@ -114,7 +112,7 @@ export default class Application extends Component<Props, State> {
     const profileLoading = this.props.data.profileLoading === undefined ? true
       : this.props.data.profileLoading
     const userProfile = this.props.data.userProfile
-
+    const isAnonymous = userProfile && userProfile.key === ANONYMOUS_USERNAME
     return (
       <Switch>
         <Route exact path='/' render={() => (
@@ -123,10 +121,11 @@ export default class Application extends Component<Props, State> {
         <Route path='/map' render={() => (
           profileLoading || userProfile
             ? (<MainPage {...props} />) : (<Redirect to='/search' />))} />
-        <Route path='/search' render={() => <SelectAccount
-          {...props}
-          headOfHousehold={props.headOfHousehold}
-          voucherNumber={props.voucherNumber} />} />
+        <Route path='/search' render={() => (
+          isAnonymous ? (<Redirect to='/profile' />) : <SelectAccount
+            {...props}
+            headOfHousehold={props.headOfHousehold}
+            voucherNumber={props.voucherNumber} />)} />
         <Route path='/profile' render={() => (
           profileLoading || userProfile
             ? (<EditProfile {...props} />) : (<Redirect to='/search' />))} />

--- a/taui/src/components/custom-header-bar.js
+++ b/taui/src/components/custom-header-bar.js
@@ -1,12 +1,19 @@
 // @flow
 import { Greetings } from 'aws-amplify-react/dist/Auth'
+import { NavButton } from 'aws-amplify-react/dist/Amplify-UI/Amplify-UI-Components-React'
 import message from '@conveyal/woonerf/message'
 import React from 'react'
 import { Link } from 'react-router-dom'
 
+import {ANONYMOUS_USERNAME} from '../constants'
 import type {AccountProfile} from '../types'
 
 export default class CustomHeaderBar extends Greetings {
+  constructor (props) {
+    super(props)
+    this.signIn = this.signIn.bind(this)
+  }
+
   componentDidMount () {
     super.componentDidMount()
   }
@@ -22,6 +29,11 @@ export default class CustomHeaderBar extends Greetings {
     return nameFromAttr || user.name || user.username
   }
 
+  signIn () {
+    // Redirect to login page
+    this.changeState('signedOut')
+  }
+
   // based on:
   // https://github.com/aws-amplify/amplify-js/blob/master/packages/aws-amplify-react/src/Auth/Greetings.jsx#L131
   render () {
@@ -29,18 +41,20 @@ export default class CustomHeaderBar extends Greetings {
     const signedIn = (authState === 'signedIn')
     if (!signedIn) { return null }
     const userProfile: AccountProfile = this.props.userProfile || this.state.userProfile
+    const isAnonymous = !userProfile || userProfile.key === ANONYMOUS_USERNAME
+    const signIn = this.signIn
     const theme = this.props.theme
 
     const userInfo = userProfile ? (
       <div className='app-header__user-info'>
-        <span className='app-header__user-name'>{userProfile.headOfHousehold}</span>
-        <span className='app-header__voucher-number'># {userProfile.voucherNumber}</span>
+        {!isAnonymous && <span className='app-header__user-name'>{userProfile.headOfHousehold}</span>}
+        {!isAnonymous && <span className='app-header__voucher-number'># {userProfile.voucherNumber}</span>}
         <span className='app-header__button'>
           <Link to={{pathname: '/profile', state: {fromApp: true}}}>{message('Header.Edit')}</Link>
         </span>
-        <span className='app-header__button'>
+        {!isAnonymous && <span className='app-header__button'>
           <Link to='/search'>{message('Header.New')}</Link>
-        </span>
+        </span>}
       </div>
     ) : null
 
@@ -51,7 +65,13 @@ export default class CustomHeaderBar extends Greetings {
           <span className='app-header__app-name'>{message('Title')}</span>
         </div>
         {userInfo}
-        <div className='app-header__actions'>{this.renderSignOutButton(theme)}</div>
+        {!isAnonymous && <div className='app-header__actions'>{this.renderSignOutButton(theme)}</div>}
+        {isAnonymous &&
+          <div className='app-header__actions'>
+            <NavButton theme={theme} onClick={(e) => signIn(e)}>
+              {message('Header.SignIn')}
+            </NavButton>
+          </div>}
       </header>
     )
   }

--- a/taui/src/components/custom-sign-in.js
+++ b/taui/src/components/custom-sign-in.js
@@ -3,8 +3,7 @@ import { I18n } from '@aws-amplify/core'
 import {
   FederatedButtons,
   ForgotPassword,
-  SignIn,
-  SignUp
+  SignIn
 } from 'aws-amplify-react/dist/Auth'
 import {
   FormSection,
@@ -42,7 +41,6 @@ export default class CustomSignIn extends SignIn {
   // https://github.com/aws-amplify/amplify-js/blob/master/packages/aws-amplify-react/src/Auth/SignIn.jsx#L120
   showComponent (theme) {
     const { authState, hide = [], federated, onStateChange, onAuthEvent, override = [] } = this.props
-    const hideSignUp = !override.includes('SignUp') && hide.some(component => component === SignUp)
     const hideForgotPassword = !override.includes('ForgotPassword') &&
       hide.some(component => component === ForgotPassword)
 
@@ -93,14 +91,12 @@ export default class CustomSignIn extends SignIn {
                 {I18n.get('Sign In')}
               </Button>
             </SectionFooterPrimaryContent>
-            {
-              !hideSignUp && <SectionFooterSecondaryContent theme={theme}>
-                {I18n.get('No account? ')}
-                <Link theme={theme} onClick={() => this.changeState('signUp')}>
-                  {I18n.get('Create account')}
-                </Link>
-              </SectionFooterSecondaryContent>
-            }
+            <SectionFooterSecondaryContent theme={theme}>
+              {message('SignIn.AnonymousExplanation') + ' '}
+              <Link theme={theme} onClick={() => this.changeState('useAnonymous')}>
+                {message('SignIn.Anonymous')}
+              </Link>
+            </SectionFooterSecondaryContent>
           </SectionFooter>
         </FormSection>
       </div>

--- a/taui/src/config.js
+++ b/taui/src/config.js
@@ -1,5 +1,6 @@
 // @flow
 
+export const clearLocalStorage = () => window.localStorage.clear()
 export const retrieveConfig = (key) => JSON.parse(window.localStorage.getItem(key))
 export const storeConfig = (key, json) =>
   window.localStorage.setItem(key, JSON.stringify(json, null, '  '))

--- a/taui/src/constants.js
+++ b/taui/src/constants.js
@@ -2,6 +2,8 @@
 export const ACCESSIBILITY_IS_EMPTY = 'accessibility-is-empty'
 export const ACCESSIBILITY_IS_LOADING = 'accessibility-is-loading'
 
+export const ANONYMOUS_USERNAME = 'ANONYMOUS'
+
 // Account profile destination types.
 // Each of these should have a translatable string label in `messages.yml`,
 // defined under `TripPurpose`.


### PR DESCRIPTION
## Overview

Allow bypassing login to browse anonymously instead. Store profile in `localStorage` without using S3 for anonymous user. (Profile settings will survive a page refresh but cannot be stored to a remote account when browsing the site anonymously.)

Hide voucher number and voucher holder name, and change "sign out" button to "sign in" in the header when browsing anonymously.


### Demo

New anonymous sign-in page option:
![image](https://user-images.githubusercontent.com/960264/54150888-f230e680-440f-11e9-9007-2c57e50ac118.png)


Anonymous user's profile page and header:
![image](https://user-images.githubusercontent.com/960264/54150817-cdd50a00-440f-11e9-9b17-0db6ee55cad0.png)


### Notes

For our use, it is not necessary to enable [unauthenticated roles](https://docs.aws.amazon.com/cognito/latest/developerguide/identity-pools.html) for the Cognito identity pool, as the anonymous user does not need any access to AWS resources. If the anonymous user did need access to S3 or other AWS resources but with different permissions than those granted to authenticated users, we would need to set up using credentials for the unauthenticated Cognito role. The Amplify JS library does not provide tools for any kind of anonymous/unauthenticated user support.


## Testing Instructions

 * Click to 'continue without an account' from the sign-in page
 * Should be taken directly to the profile page (not search)
 * Attempting to navigate directly to `/search` when anonymous should redirect to `/profile`
 * Voucher number and voucher holder name should be hidden in header and on forms
 * 'Sign in' header button should redirect as expected to log in
 * Switching between being signed and and browsing anonymously should behave as expected


Closes #64.
