### PR TITLE
Feature/kak/map view sidebar#24

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -24,6 +24,7 @@ Geocoding:
 Log:
   Title: Log
 Map:
+  SelectNetwork: Set time of day
   SetLocationPopup:
     SetStart: Set start
     SetEnd: Set end

--- a/taui/src/components/main-page.js
+++ b/taui/src/components/main-page.js
@@ -191,12 +191,8 @@ export default class MainPage extends React.PureComponent<Props> {
             boundary={p.geocoder.boundary}
             end={p.geocoder.end}
             geocode={p.geocode}
-            onTimeCutoffChange={this._onTimeCutoffChange}
-            onChangeEnd={this._setEndWithFeature}
-            onChangeStart={this._setStartWithFeature}
-            pointsOfInterest={p.pointsOfInterestOptions}
+            networks={p.data.networks}
             reverseGeocode={p.reverseGeocode}
-            selectedTimeCutoff={p.timeCutoff.selected}
             start={p.geocoder.start}
             updateEnd={p.updateEnd}
             updateStart={p.updateStart}

--- a/taui/src/components/main-page.js
+++ b/taui/src/components/main-page.js
@@ -200,6 +200,7 @@ export default class MainPage extends React.PureComponent<Props> {
             start={p.geocoder.start}
             updateEnd={p.updateEnd}
             updateStart={p.updateStart}
+            userProfile={p.userProfile}
           />
           {p.data.networks.map((network, index) => (
             <RouteCard

--- a/taui/yarn.lock
+++ b/taui/yarn.lock
@@ -3538,7 +3538,7 @@ debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@~4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -5712,7 +5712,7 @@ import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -7228,11 +7228,6 @@ lodash-es@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
   integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -7241,32 +7236,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
@@ -7337,11 +7310,6 @@ lodash.mergewith@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
   integrity sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -10698,7 +10666,7 @@ readable-stream@~2.0.0:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=


### PR DESCRIPTION
## Overview

Replaces map page form origin/destination geocoder inputs with select inputs on for profile destinations and networks (times of day). Defaults to the profile primary destination and the first listed network ('Late Night', for our currently configured [r5](https://github.com/conveyal/r5) output.)


### Demo

![image](https://user-images.githubusercontent.com/960264/54230713-5d94ba00-44dd-11e9-87d4-f7a3ce8b1b4c.png)


### Notes

The other sidebar content apart from these inputs will be replaced in #25, and the map page behavior for loading data will change considerably, so other aspects of the map page behavior broken by this can generally be ignored, as it will be removed in #25 (i.e., start location marker doesn't show on full page reload now.)

I haven't added a control for modes yet as in the wireframe, as we haven't determined if that is something the static router results will practically support as a search parameter. If it is, those options are available from the `request.json` file for the network in the `transitModes` property.


## Testing Instructions

 * Add multiple destinations to a profile and click 'go'
 * Should redirect to map page and load primary destination and 'Late Night' networks as defaults
 * Destination and network select fields should have expected entries
 * Destination and network select fields should update on change
 * Changing destination should update start location

Closes #24 
