### PR TITLE
Get user profile directly from S3

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -54,7 +54,6 @@ Accounts:
   CreateError: Failed to create profile. Please try again.
   Name: Name of Head of Household
   Search: Search
-  SearchError: Failed to search profiles. Please try again.
   SelectError: Failed to set profile. Please try again.
   NoResults: No profile found for that voucher number. Create new profile now?
   Title: Profiles


### PR DESCRIPTION
## Overview

Instead of searching directory contents, attempt to get file directly. Check error result to see if it was not found.


## Testing Instructions

 * Account search and selection should still work as expected
 * Attempting to search for a non-extant account should still prompt to create account

Closes #66.
