### PR TITLE
Add page-not-found message

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -29,6 +29,7 @@ Map:
     SetStart: Set start
     SetEnd: Set end
     ClearMarkers: Clear markers
+PageNotFound: Oops! There is no page at
 Strings:
   ApplicationReady: Application is ready!
   SearchForStartAddress: Start location

--- a/taui/src/components/application.js
+++ b/taui/src/components/application.js
@@ -1,4 +1,5 @@
 // @flow
+import message from '@conveyal/woonerf/message'
 import React, {Component} from 'react'
 import { Switch, Redirect, Route } from 'react-router-dom'
 
@@ -104,6 +105,16 @@ export default class Application extends Component<Props, State> {
     }
   }
 
+  noMatch ({location}) {
+    return (
+      <div>
+        <h1>
+          {message('PageNotFound')} <code>{location.pathname}</code>
+        </h1>
+      </div>
+    )
+  }
+
   /**
    *
    */
@@ -115,6 +126,7 @@ export default class Application extends Component<Props, State> {
     // Can navigate to map once at least one destination set on the profile.
     const canViewMap = userProfile && userProfile.destinations && userProfile.destinations.length
     const isAnonymous = userProfile && userProfile.key === ANONYMOUS_USERNAME
+    const NoMatch = this.noMatch
     return (
       <Switch>
         <Route exact path='/' render={() => (
@@ -131,6 +143,7 @@ export default class Application extends Component<Props, State> {
         <Route path='/profile' render={() => (
           profileLoading || userProfile
             ? (<EditProfile {...props} />) : (<Redirect to='/search' />))} />
+        <Route component={NoMatch} />
       </Switch>
     )
   }


### PR DESCRIPTION
## Overview

Handle unmatched routes in the React router. Display a message if the user navigates to a non-extant page.


### Demo

![image](https://user-images.githubusercontent.com/960264/54548477-6292b700-497e-11e9-80f4-ea8edbb37341.png)


### Notes

This returns a `200` and not a `404`, as the routing is handled by the front-end in the "single-page" app.


## Testing Instructions

 * Navigating to a page that does not exist should display expected no-match message
 * Other routes should continue to function as expected


Closes #60.
