### PR TITLE
Implement driving mode

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -39,6 +39,7 @@ Dock:
   ShowAllButton: All
   ShowSavedButton: Saved
 NeighborhoodDetails:
+  DriveMode: driving
   FromOrigin: from
   GoogleMapsLink: See on Google Maps
   ModeSummary: via

--- a/taui/src/components/dock.js
+++ b/taui/src/components/dock.js
@@ -50,11 +50,13 @@ export default class Dock extends PureComponent<Props> {
     }
   }
 
-  backFromDetails () {
+  backFromDetails (e) {
+    e.stopPropagation()
     this.props.setShowDetails(false)
   }
 
-  goPreviousPage () {
+  goPreviousPage (e) {
+    e.stopPropagation()
     const page = this.state.page
     if (page >= 1) {
       this.setState({page: page - 1})
@@ -64,12 +66,14 @@ export default class Dock extends PureComponent<Props> {
     }
   }
 
-  goNextPage () {
+  goNextPage (e) {
+    e.stopPropagation()
     const page = this.state.page
     this.setState({page: page + 1})
   }
 
-  goToDetails (neighborhood) {
+  goToDetails (e, neighborhood) {
+    e.stopPropagation()
     this.props.setActiveNeighborhood(neighborhood.properties.id)
     this.props.setShowDetails(true)
   }
@@ -154,6 +158,7 @@ export default class Dock extends PureComponent<Props> {
     const {
       activeNetworkIndex,
       changeUserProfile,
+      hasVehicle,
       neighborhoods,
       setActiveNeighborhood,
       setFavorite,
@@ -170,27 +175,28 @@ export default class Dock extends PureComponent<Props> {
 
     return (
       neighborhoodPage.map((neighborhood, index) =>
-        neighborhood.segments && neighborhood.segments.length
-          ? (<RouteCard
-            cardColor={neighborhood.active ? 'green' : NETWORK_COLORS[activeNetworkIndex]}
-            goToDetails={goToDetails}
-            index={index}
-            isFavorite={userProfile.favorites.indexOf(neighborhood.properties.id) !== -1}
-            key={`${index}-route-card`}
+        <RouteCard
+          cardColor={neighborhood.active ? 'green' : NETWORK_COLORS[activeNetworkIndex]}
+          goToDetails={(e) => goToDetails(e, neighborhood)}
+          index={index}
+          isFavorite={userProfile.favorites.indexOf(neighborhood.properties.id) !== -1}
+          key={`${index}-route-card`}
+          neighborhood={neighborhood}
+          setActiveNeighborhood={setActiveNeighborhood}
+          setFavorite={(e) => setFavorite(neighborhood.properties.id,
+            userProfile, changeUserProfile)}
+          title={neighborhood.properties.town + ': ' + neighborhood.properties.id}
+          userProfile={userProfile}>
+          <RouteSegments
+            hasVehicle={hasVehicle}
+            routeSegments={neighborhood.segments}
+            travelTime={neighborhood.time}
+          />
+          <NeighborhoodListInfo
             neighborhood={neighborhood}
-            setActiveNeighborhood={setActiveNeighborhood}
-            setFavorite={(e) => setFavorite(neighborhood.properties.id,
-              userProfile, changeUserProfile)}
-            title={neighborhood.properties.town + ': ' + neighborhood.properties.id}
-            userProfile={userProfile}>
-            <RouteSegments
-              routeSegments={neighborhood.segments}
-              travelTime={neighborhood.time}
-            />
-            <NeighborhoodListInfo
-              neighborhood={neighborhood}
-            />
-          </RouteCard>) : null)
+          />
+        </RouteCard>
+      )
     )
   }
 
@@ -279,6 +285,7 @@ export default class Dock extends PureComponent<Props> {
           <NeighborhoodSection
             {...this.props}
             changeUserProfile={changeUserProfile}
+            hasVehicle={userProfile ? userProfile.hasVehicle : false}
             neighborhoods={neighborhoods}
             endingOffset={endingOffset}
             setFavorite={setFavorite}

--- a/taui/src/components/main-page.js
+++ b/taui/src/components/main-page.js
@@ -111,7 +111,8 @@ export default class MainPage extends React.PureComponent<Props> {
 
   _showNeighborhoodRoutes () {
     const p = this.props
-    return !p.isLoading && !!get(p, 'neighborhoodRoutes[0]')
+    const useTransit = !p.userProfile || !p.userProfile.hasVehicle
+    return !p.isLoading && useTransit && !!get(p, 'neighborhoodRoutes[0]')
   }
 
   _showRoutes () {

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -62,7 +62,9 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
         <table className='CardContent'>
           <tbody>
             <tr className='BestTrip'>
-              <td><span><strong>{time}</strong> {message('Units.Mins')}</span></td>
+              <td>{!userProfile.hasVehicle &&
+                <span><strong>{time}</strong> {message('Units.Mins')}</span>}
+              </td>
               <td>
                 <span>{message('NeighborhoodDetails.ModeSummary')} </span>
                 <ModesList segments={bestJourney} />
@@ -88,6 +90,6 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
 }
 
 // Builds list of unqiue transit modes used in a trip
-const ModesList = ({segments}) => (
+const ModesList = ({segments}) => segments && segments.length ? (
   <span>{uniq(segments.map(s => s.type)).join('/')}</span>
-)
+) : <span>{message('NeighborhoodDetails.DriveMode')}</span>

--- a/taui/src/components/neighborhood-list-info.js
+++ b/taui/src/components/neighborhood-list-info.js
@@ -11,7 +11,7 @@ export default function NeighborhoodListInfo ({neighborhood}) {
         <td />
         <td>
           <span>{message('NeighborhoodInfo.RentDiff')}:
-            {neighborhood.properties.rent_diff.toLocaleString(
+            {neighborhood.properties.rent_diff && neighborhood.properties.rent_diff.toLocaleString(
               'en-US', {style: 'currency', currency: 'USD'})}</span>
         </td>
         <td>
@@ -22,12 +22,14 @@ export default function NeighborhoodListInfo ({neighborhood}) {
         <td />
         <td>
           <span>{message('NeighborhoodInfo.Education')}:
-            {(neighborhood.properties.education_percentile / 100).toLocaleString(
+            {neighborhood.properties.education_percentile &&
+            (neighborhood.properties.education_percentile / 100).toLocaleString(
               'en-US', {style: 'percent'})}</span>
         </td>
         <td>
           <span>{message('NeighborhoodInfo.Score')}:
-            {neighborhood.score.toLocaleString('en-US', {style: 'percent'})}</span>
+            {neighborhood.score &&
+              neighborhood.score.toLocaleString('en-US', {style: 'percent'})}</span>
         </td>
       </tr>
     </tbody>

--- a/taui/src/components/route-card.js
+++ b/taui/src/components/route-card.js
@@ -32,7 +32,7 @@ export default class RouteCard extends React.PureComponent<Props> {
       >
         <div
           className='CardTitle'
-          onClick={(e) => goToDetails(neighborhood)}
+          onClick={(e) => goToDetails(e, neighborhood)}
           onMouseOver={(e) => setActiveNeighborhood(neighborhood.properties.id)}
           style={{
             backgroundColor: cardColor,

--- a/taui/src/components/route-segments.js
+++ b/taui/src/components/route-segments.js
@@ -1,12 +1,15 @@
 // @flow
-import Icon from '@conveyal/woonerf/components/icon'
 import message from '@conveyal/woonerf/message'
 
 import Alert from './tr-alert'
 
-export default function RouteSegments ({routeSegments, oldTravelTime, travelTime}) {
+export default function RouteSegments ({hasVehicle, routeSegments, travelTime}) {
   if (routeSegments.length === 0) {
-    return <Alert>{message('Systems.TripsEmpty')}</Alert>
+    if (!hasVehicle) {
+      return <Alert>{message('Systems.TripsEmpty')}</Alert>
+    } else {
+      return null
+    }
   }
 
   const [bestJourney, ...alternateJourneys] = routeSegments
@@ -24,10 +27,6 @@ export default function RouteSegments ({routeSegments, oldTravelTime, travelTime
             ? <span className='decrease'>inaccessible within 120 minutes</span>
             : <span>in
               <strong> {travelTime}</strong> {message('Units.Mins')}
-              <TripDiff
-                baseTravelTime={oldTravelTime}
-                travelTime={travelTime}
-              />
             </span>}
         </td>
       </tr>
@@ -63,32 +62,3 @@ const Segment = ({segment}) => (
     <i className={`fa fa-${segment.type}`} /> {segment.name}
   </span>
 )
-
-function TripDiff ({baseTravelTime, travelTime}) {
-  if (baseTravelTime === 2147483647) {
-    return (
-      <span className='increase'>&nbsp;({message('NewTrip')} <Icon type='star' />)</span>
-    )
-  } else if (travelTime === 2147483647) {
-    return (
-      <span className='decrease'>&nbsp;(<strong>> {120 - baseTravelTime}</strong>% <span className='fa fa-level-up' />)</span>
-    )
-  }
-
-  const diff = (travelTime - baseTravelTime) / baseTravelTime * 100
-  if (isNaN(diff) || Math.abs(diff) < 0.1) return null
-
-  if (diff > 0) {
-    return (
-      <span className='decrease'>
-        (<strong>{diff.toFixed(1)}</strong>% <span className='fa fa-level-up' />)
-      </span>
-    )
-  }
-
-  return (
-    <span className='increase'>
-      (<strong>{diff.toFixed(1)}</strong>% <span className='fa fa-level-up fa-rotate-180' />)
-    </span>
-  )
-}

--- a/taui/src/selectors/neighborhoods-sorted-with-routes.js
+++ b/taui/src/selectors/neighborhoods-sorted-with-routes.js
@@ -1,3 +1,5 @@
+// @flow
+import lonlat from '@conveyal/lonlat'
 import filter from 'lodash/filter'
 import get from 'lodash/get'
 import orderBy from 'lodash/orderBy'
@@ -6,6 +8,8 @@ import {createSelector} from 'reselect'
 import selectNeighborhoodRoutes from './network-neighborhood-routes'
 import neighborhoodTravelTimes from './neighborhood-travel-times'
 
+// ~130km estimate of maximum straight-line distance drivable in area within 120 minutes
+const MAX_DISTANCE = 130000
 const MAX_TRAVEL_TIME = 120
 const RENT_DIFF_RANGE = 2000
 
@@ -17,16 +21,19 @@ export default createSelector(
   selectNeighborhoodRoutes,
   neighborhoodTravelTimes,
   state => get(state, 'data.neighborhoods'),
-  (neighborhoodRoutes, travelTimes, neighborhoods) => {
+  state => get(state, 'data.origin'),
+  state => get(state, 'data.userProfile'),
+  (neighborhoodRoutes, travelTimes, neighborhoods, origin, profile) => {
     if (!neighborhoods || !neighborhoods.features || !neighborhoods.features.length ||
       !neighborhoodRoutes || !neighborhoodRoutes.length) {
       return []
     }
+    const useTransit = !profile || !profile.hasVehicle
     const neighborhoodsWithRoutes = filter(neighborhoods.features.map((n, index) => {
       const route = neighborhoodRoutes[index]
       const active = route.active
-      const segments = route.routeSegments
-      const time = travelTimes[index]
+      const segments = useTransit ? route.routeSegments : []
+      const time = useTransit ? travelTimes[index] : distanceTime(origin, n)
 
       // Map weighting values to percentages
 
@@ -51,11 +58,21 @@ export default createSelector(
       const score = (timeWeight * TIME_SORT_WEIGHT) + (rentWeight * RENT_SORT_WEIGHT)
 
       return Object.assign({active, rentWeight, score, segments, time, timeWeight}, n)
-    }), n => n.segments && n.segments.length && n.time < MAX_TRAVEL_TIME)
+    }), n => !useTransit || (n.segments && n.segments.length && n.time < MAX_TRAVEL_TIME))
 
     return orderBy(neighborhoodsWithRoutes, ['score'], ['desc'])
   }
 )
+
+// Estimate drive time, using straight-line distance
+const distanceTime = (origin, neighborhood) => {
+  // First get distance in meters between origin and a neighborhood point
+  const destination = lonlat.toLeaflet(neighborhood.geometry.coordinates)
+  const distance = destination.distanceTo(origin.position)
+  const normalized = distance < MAX_DISTANCE ? distance : MAX_DISTANCE
+  // Then map the distance to the travel time range
+  return scale(normalized, 0, MAX_DISTANCE, 0, MAX_TRAVEL_TIME)
+}
 
 // Map value from one range to another
 const scale = (num, startMin, startMax, rangeMin, rangeMax) => {


### PR DESCRIPTION
## Overview

Estimate travel times using straight-line distance. Do not show user estimated travel times or transit routes in driving mode.

The static result files from `r5` do not contain non-transit travel times or routes, so instead, estimate times using distance as a proxy and hide routes in driving mode.


### Demo

Driving mode list:
![image](https://user-images.githubusercontent.com/960264/55031693-7de86c80-4fe5-11e9-9171-86ebe9adf8ca.png)

Details in driving mode (no travel time or route info displayed):
![image](https://user-images.githubusercontent.com/960264/55031726-948ec380-4fe5-11e9-8923-859b82b3ff4d.png)


### Notes

Based on #28; I'll rebase before merge.

These results seem to be somewhat more sensitive to rent differences than transit mode is. I checked that distance ordering was working properly by setting the weights to only use time, and results were ordered as expected strictly by distance from origin.


## Testing Instructions

 * Site should continue to work as before with 'will have a car' unchecked on the user profile
 * Check 'will have a car' on the user profile
 * Routes should not display on map
 * Neighborhoods should be ordered as expected, taking distance and rental cost into account
 * Travel times and route information should not display in sidebar
 * Details card should indicate driving as the mode


Closes #71.
