### PR TITLE
Fix header message after login

### DIFF
--- a/taui/src/components/custom-header-bar.js
+++ b/taui/src/components/custom-header-bar.js
@@ -41,7 +41,7 @@ export default class CustomHeaderBar extends Greetings {
     const signedIn = (authState === 'signedIn')
     if (!signedIn) { return null }
     const userProfile: AccountProfile = this.props.userProfile || this.state.userProfile
-    const isAnonymous = !userProfile || userProfile.key === ANONYMOUS_USERNAME
+    const isAnonymous = userProfile && userProfile.key === ANONYMOUS_USERNAME
     const signIn = this.signIn
     const theme = this.props.theme
 


### PR DESCRIPTION
## Overview

Fix log in message being shown immediately after login, before user profile has been set.

## Testing Instructions

 * Log out, if logged in
 * Log in
 * Should be directed to profile search page, with header message to 'sign out'
 * Clicking to continue anonymously instead of logging in should show message to 'sign in'
 

Fixes #105