### PR TITLE
Fix finding details neighborhood

### DIFF
--- a/taui/src/selectors/detail-neighborhood.js
+++ b/taui/src/selectors/detail-neighborhood.js
@@ -4,12 +4,12 @@ import {createSelector} from 'reselect'
 
 import getNeighborhoodById from '../utils/get-neighborhood'
 
-import listNeighborhoods from './list-neighborhoods'
+import neighborhoodsSortedWithRoutes from './neighborhoods-sorted-with-routes'
 
 // Returns current active neighborhood
 export default createSelector(
   state => get(state, 'data.activeNeighborhood'),
-  listNeighborhoods,
+  neighborhoodsSortedWithRoutes,
   (activeNeighborhood, neighborhoods) => {
     return neighborhoods && getNeighborhoodById(neighborhoods, activeNeighborhood)
   }


### PR DESCRIPTION
## Overview

Always look up detail view neighborhood from full list of routable neighborhoods.


## Testing Instructions

 * Go to 'saved' sidebar sub-list on map page
 * Click the marker for a routable neighborhood that is not saved
 * Should get details for neighborhood in sidebar


Fixes #111
