### PR TITLE
Hide drive times

### DIFF
--- a/taui/src/components/dock.js
+++ b/taui/src/components/dock.js
@@ -13,11 +13,18 @@ import RouteCard from './route-card'
 
 type Props = {
   activeNetworkIndex: number,
+  detailNeighborhood: any,
+  endingOffset: number,
+  haveAnotherPage: boolean,
   isLoading: boolean,
+  neighborhoodPage: any[],
   neighborhoodRoutes: any,
   neighborhoods: Array<PointFeature>,
-  showSpinner: boolean,
-  travelTimes: number[]
+  origin: any,
+  page: number,
+  showDetails: boolean,
+  showFavorites: boolean,
+  userProfile: AccountProfile
 }
 
 /**

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -37,10 +37,72 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
     }
   }
 
+  neighborhoodDetailsTable (props) {
+    const { neighborhood } = props
+    const labels: NeighborhoodLabels = getNeighborhoodPropertyLabels(neighborhood.properties)
+
+    // Overall score is a derived value and not a neighborhood property (so not in `labels`).
+    const overallScore = neighborhood.score
+      ? neighborhood.score.toLocaleString('en-US', {style: 'percent'})
+      : message('UnknownValue')
+
+    return (
+      <table className='neighborhood-details__facts'>
+        <tbody>
+          <tr className='neighborhood-details__row'>
+            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.Score')}:</td>
+            <td className='neighborhood-details__cell'>{overallScore}</td>
+          </tr>
+          <tr className='neighborhood-details__row'>
+            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.Affordability')}:</td>
+            <td className='neighborhood-details__cell'>{labels.affordability}</td>
+          </tr>
+          <tr className='neighborhood-details__row'>
+            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.ViolentCrime')}:</td>
+            <td className='neighborhood-details__cell'>{labels.violentCrime}</td>
+          </tr>
+          <tr className='neighborhood-details__row'>
+            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.EducationCategory')}:</td>
+            <td className='neighborhood-details__cell'>{labels.education}</td>
+          </tr>
+          <tr className='neighborhood-details__row'>
+            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.EducationPercentile')}:</td>
+            <td className='neighborhood-details__cell'>{labels.educationPercentile}</td>
+          </tr>
+          <tr className='neighborhood-details__row'>
+            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.Population')}:</td>
+            <td className='neighborhood-details__cell'>{labels.population}</td>
+          </tr>
+          <tr className='neighborhood-details__row'>
+            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.PercentCollegeGraduates')}:</td>
+            <td className='neighborhood-details__cell'>{labels.percentCollegeGraduates}</td>
+          </tr>
+          <tr className='neighborhood-details__row'>
+            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.HasTransitStop')}:</td>
+            <td className='neighborhood-details__cell'>{labels.hasTransitStop}</td>
+          </tr>
+          <tr className='neighborhood-details__row'>
+            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.NearTransit')}:</td>
+            <td className='neighborhood-details__cell'>{labels.nearTransitStop}</td>
+          </tr>
+          <tr className='neighborhood-details__row'>
+            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.NearRailStation')}:</td>
+            <td className='neighborhood-details__cell'>{labels.nearRailStation}</td>
+          </tr>
+          <tr className='neighborhood-details__row'>
+            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.NearPark')}:</td>
+            <td className='neighborhood-details__cell'>{labels.nearPark}</td>
+          </tr>
+        </tbody>
+      </table>
+    )
+  }
+
   render () {
     const { changeUserProfile, neighborhood, origin, setFavorite, userProfile } = this.props
     const isFavorite = this.state.isFavorite
     const hasVehicle = userProfile ? userProfile.hasVehicle : false
+    const NeighborhoodDetailsTable = this.neighborhoodDetailsTable
 
     if (!neighborhood || !userProfile) {
       return null
@@ -49,17 +111,10 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
     // Look up the currently selected user profile destination from the origin
     const originLabel = origin ? origin.label || '' : ''
     const currentDestination = userProfile.destinations.find(d => d.location.label === originLabel)
-    const labels: NeighborhoodLabels = getNeighborhoodPropertyLabels(neighborhood.properties)
     const { id, town } = neighborhood.properties
-    const { time } = neighborhood
 
     const bestJourney = neighborhood.segments && neighborhood.segments.length
       ? neighborhood.segments[0] : null
-
-    // Overall score is a derived value and not a neighborhood property (so not in `labels`).
-    const overallScore = neighborhood.score
-      ? neighborhood.score.toLocaleString('en-US', {style: 'percent'})
-      : message('UnknownValue')
 
     // lat,lon strings for Google Directions link from neighborhood to current destination
     const destinationCoordinateString = origin.position.lat + ',' + origin.position.lon
@@ -77,18 +132,18 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
           {town} &ndash; {id}
           <Icon className='neighborhood-details__marker' type='map-marker' />
         </header>
-        <div className='neighborhood-details__trip'>
-          {Math.round(time)}&nbsp;
+        {!hasVehicle && <div className='neighborhood-details__trip'>
+          {Math.round(neighborhood.time)}&nbsp;
           {message('Units.Mins')}&nbsp;
           <ModesList segments={bestJourney} />&nbsp;
           {message('NeighborhoodDetails.FromOrigin')}&nbsp;
           {currentDestination && currentDestination.purpose.toLowerCase()}
-        </div>
-        <RouteSegments
+        </div>}
+        {hasVehicle && <RouteSegments
           hasVehicle={hasVehicle}
           routeSegments={neighborhood.segments}
           travelTime={neighborhood.time}
-        />
+        />}
         <div className='neighborhood-details__images'>
           <img
             className='neighborhood-details__image'
@@ -145,54 +200,7 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
             {message('NeighborhoodDetails.GoogleMapsLink')}
           </a>
         </div>
-        <table className='neighborhood-details__facts'>
-          <tbody>
-            <tr className='neighborhood-details__row'>
-              <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.Score')}:</td>
-              <td className='neighborhood-details__cell'>{overallScore}</td>
-            </tr>
-            <tr className='neighborhood-details__row'>
-              <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.Affordability')}:</td>
-              <td className='neighborhood-details__cell'>{labels.affordability}</td>
-            </tr>
-            <tr className='neighborhood-details__row'>
-              <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.ViolentCrime')}:</td>
-              <td className='neighborhood-details__cell'>{labels.violentCrime}</td>
-            </tr>
-            <tr className='neighborhood-details__row'>
-              <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.EducationCategory')}:</td>
-              <td className='neighborhood-details__cell'>{labels.education}</td>
-            </tr>
-            <tr className='neighborhood-details__row'>
-              <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.EducationPercentile')}:</td>
-              <td className='neighborhood-details__cell'>{labels.educationPercentile}</td>
-            </tr>
-            <tr className='neighborhood-details__row'>
-              <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.Population')}:</td>
-              <td className='neighborhood-details__cell'>{labels.population}</td>
-            </tr>
-            <tr className='neighborhood-details__row'>
-              <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.PercentCollegeGraduates')}:</td>
-              <td className='neighborhood-details__cell'>{labels.percentCollegeGraduates}</td>
-            </tr>
-            <tr className='neighborhood-details__row'>
-              <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.HasTransitStop')}:</td>
-              <td className='neighborhood-details__cell'>{labels.hasTransitStop}</td>
-            </tr>
-            <tr className='neighborhood-details__row'>
-              <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.NearTransit')}:</td>
-              <td className='neighborhood-details__cell'>{labels.nearTransitStop}</td>
-            </tr>
-            <tr className='neighborhood-details__row'>
-              <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.NearRailStation')}:</td>
-              <td className='neighborhood-details__cell'>{labels.nearRailStation}</td>
-            </tr>
-            <tr className='neighborhood-details__row'>
-              <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.NearPark')}:</td>
-              <td className='neighborhood-details__cell'>{labels.nearPark}</td>
-            </tr>
-          </tbody>
-        </table>
+        <NeighborhoodDetailsTable neighborhood={neighborhood} />
       </div>
     )
   }

--- a/taui/src/components/route-card.js
+++ b/taui/src/components/route-card.js
@@ -63,9 +63,9 @@ export default class RouteCard extends React.PureComponent<Props> {
               alt=''
             />
             <div className='neighborhood-summary__trip'>
-              <div className='neighborhood-summary__duration'>
+              {!userProfile.hasVehicle && <div className='neighborhood-summary__duration'>
                 {Math.round(time)} {message('Units.Mins')}
-              </div>
+              </div>}
               <div className='neighborhood-summary__trajectory'>
                 <span className='neighborhood-summary__mode'>
                   {message(modeKey)}


### PR DESCRIPTION
## Overview

Fix reversion from styling that added display of drive times. These estimated values should not be displayed to the user anywhere.


### Demo

Show mode and origin in drive mode list card, but not (estimated) travel time:
![image](https://user-images.githubusercontent.com/960264/55512355-e9a78680-5630-11e9-97eb-dac5f119c97d.png)

Time/mode/origin line hidden entirely in drive mode on detail view:
![image](https://user-images.githubusercontent.com/960264/55512418-1b205200-5631-11e9-93a7-ea05db6938b1.png)

Transit mode detail, for reference:
![image](https://user-images.githubusercontent.com/960264/55512442-2b383180-5631-11e9-898d-dfec71434e96.png)



## Testing Instructions

 * List and detail views in driving mode should not display drive times
 * List and detail views in transit mode should still display times and route summaries


Fixes #113
