### PR TITLE
Feature/kak/push images#112

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ To run the data processing scripts and copy the output into the app directory:
  - `cd neighborhood_data`
  - `./update_data.sh`
 
+The downloaded thumbnail images need to be deployed separately from the other app data.
+To publish the neighborhood thumbnail images:
+
+```
+`./scripts/imagepublish ENVIRONMENT`
+```
+
+where `ENVIRONMENT` is either `staging` or `production`.
+
 
 ### About the data processing scripts
 
@@ -99,3 +108,5 @@ and will deploy to production on commits to the `master` branch.
 
 For instructions on how to update core infrastructure, see the [README in the
 deployment directory](./deployment/README.md).
+
+Note that the neighborhood thumbnail images are not deployed by CI, but need to be pushed manually after running the data processing script `fetch_images.py` that downloads them. See [the data section](#data) for more information.

--- a/neighborhood_data/update_data.sh
+++ b/neighborhood_data/update_data.sh
@@ -9,4 +9,7 @@ python generate_neighborhood_json.py
 
 cp neighborhoods.json neighborhood_bounds.json ../taui/
 
+mkdir -p ../taui/assets/neighborhoods/
+cp images/* ../taui/assets/neighborhoods/
+
 echo 'All done updating app data!'

--- a/neighborhood_data/update_data.sh
+++ b/neighborhood_data/update_data.sh
@@ -12,4 +12,4 @@ cp neighborhoods.json neighborhood_bounds.json ../taui/
 mkdir -p ../taui/assets/neighborhoods/
 cp images/* ../taui/assets/neighborhoods/
 
-echo 'All done updating app data!'
+echo 'All done updating app data! Use scripts/imagepublish to publish the downloaded images.'

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -30,9 +30,6 @@ then
 
         echo "LOGROCKET_RELEASE: '${TRAVIS_COMMIT}'" >> "taui/${TAUI_CONFIG_DIR}/env.yml"
 
-        # Mastarm doesn't copy over index.html
-        aws s3 cp taui/index.html "${TAUI_SITE_BUCKET}/index.html"
-
         # Move the Amplify config for the proper env into the source dir
         cp "deployment/amplify/${ENV}/aws-exports.js" taui/src/aws-exports.js
 
@@ -40,5 +37,11 @@ then
         docker-compose -f docker-compose.yml \
                        -f docker-compose.ci.yml \
                        run --rm taui run deploy --minify --config "${TAUI_CONFIG_DIR}"
+
+        # Mastarm doesn't copy over index.html
+        aws s3 cp taui/index.html "${TAUI_SITE_BUCKET}/index.html"
+
+        # Copy images separately
+        aws s3 cp --recursive taui/src/img/ "${TAUI_SITE_BUCKET}/assets/"
     fi
 fi

--- a/scripts/imagepublish
+++ b/scripts/imagepublish
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${ECHOLOCATOR_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+         "Usage: $(basename "$0") ENVIRONMENT
+
+Publish neighborhood thumbnail images.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    elif [ "${1:-}" != "staging" ] && [ "${1:-}" != "production" ]
+        then
+            echo "ERROR: Unrecognized environment ${1}. Should be 'staging' or 'production'."
+            exit 1
+    else
+        TAUI_SITE_BUCKET="s3://echo-locator-${1}-site-us-east-1"
+        aws s3 cp --profile echo-locator --recursive neighborhood_data/images/ "${TAUI_SITE_BUCKET}/assets/neighborhoods/"
+    fi
+fi

--- a/taui/configurations/default/settings.yml
+++ b/taui/configurations/default/settings.yml
@@ -1,7 +1,6 @@
 cloudfront: EJKZ46R7IC1BB
 entries:
   - src/index.js:assets/index.js
-  - src/img/BHAlogo.png:assets/BHAlogo.png
   - config.json:assets/config.json
   - neighborhoods.json:assets/neighborhoods.json
   - neighborhood_bounds.json:assets/neighborhood_bounds.json

--- a/taui/configurations/production/settings.yml
+++ b/taui/configurations/production/settings.yml
@@ -1,7 +1,6 @@
 cloudfront: E22HN48FLR2YMR
 entries:
   - src/index.js:assets/index.js
-  - src/img/BHAlogo.png:assets/BHAlogo.png
   - config.json:assets/config.json
   - neighborhoods.json:assets/neighborhoods.json
   - neighborhood_bounds.json:assets/neighborhood_bounds.json

--- a/taui/configurations/staging/settings.yml
+++ b/taui/configurations/staging/settings.yml
@@ -1,7 +1,6 @@
 cloudfront: E3A0YNQDZRFX9J
 entries:
   - src/index.js:assets/index.js
-  - src/img/BHAlogo.png:assets/BHAlogo.png
   - config.json:assets/config.json
   - neighborhoods.json:assets/neighborhoods.json
   - neighborhood_bounds.json:assets/neighborhood_bounds.json

--- a/taui/src/components/custom-sign-in.js
+++ b/taui/src/components/custom-sign-in.js
@@ -61,6 +61,7 @@ export default class CustomSignIn extends SignIn {
             <FormField theme={theme}>
               <InputLabel>{I18n.get('Username')}</InputLabel>
               <Input
+                data-private
                 autoFocus
                 theme={theme}
                 key='username'
@@ -71,6 +72,7 @@ export default class CustomSignIn extends SignIn {
             <FormField theme={theme}>
               <InputLabel>{I18n.get('Password')}</InputLabel>
               <Input
+                data-private
                 theme={theme}
                 key='password'
                 type='password'

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -277,6 +277,7 @@ export default class EditProfile extends PureComponent<Props> {
         className='account-profile__destination'>
         <div className='account-profile__destination_field account-profile__destination_field--wide'>
           <Geocoder
+            data-private
             className='account-profile__input account-profile__input--geocoder'
             geocode={geocode}
             onChange={(e) => setGeocodeLocation(index, editAddress, e)}
@@ -411,6 +412,7 @@ export default class EditProfile extends PureComponent<Props> {
                 {message('Accounts.Name')}
               </label>
               <input
+                data-private
                 className='account-profile__input account-profile__input--text'
                 id='headOfHousehold'
                 type='text'

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -52,53 +52,29 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
       ? neighborhood.score.toLocaleString('en-US', {style: 'percent'})
       : message('UnknownValue')
 
+    const tableData = [
+      {label: 'NeighborhoodInfo.Score', value: overallScore},
+      {label: 'NeighborhoodInfo.Affordability', value: labels.affordability},
+      {label: 'NeighborhoodInfo.ViolentCrime', value: labels.violentCrime},
+      {label: 'NeighborhoodInfo.EducationCategory', value: labels.education},
+      {label: 'NeighborhoodInfo.EducationPercentile', value: labels.educationPercentile},
+      {label: 'NeighborhoodInfo.Population', value: labels.population},
+      {label: 'NeighborhoodInfo.PercentCollegeGraduates', value: labels.percentCollegeGraduates},
+      {label: 'NeighborhoodInfo.HasTransitStop', value: labels.hasTransitStop},
+      {label: 'NeighborhoodInfo.NearTransit', value: labels.nearTransitStop},
+      {label: 'NeighborhoodInfo.NearRailStation', value: labels.nearRailStation},
+      {label: 'NeighborhoodInfo.NearPark', value: labels.nearPark}
+    ]
+
     return (
       <table className='neighborhood-details__facts'>
         <tbody>
-          <tr className='neighborhood-details__row'>
-            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.Score')}:</td>
-            <td className='neighborhood-details__cell'>{overallScore}</td>
-          </tr>
-          <tr className='neighborhood-details__row'>
-            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.Affordability')}:</td>
-            <td className='neighborhood-details__cell'>{labels.affordability}</td>
-          </tr>
-          <tr className='neighborhood-details__row'>
-            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.ViolentCrime')}:</td>
-            <td className='neighborhood-details__cell'>{labels.violentCrime}</td>
-          </tr>
-          <tr className='neighborhood-details__row'>
-            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.EducationCategory')}:</td>
-            <td className='neighborhood-details__cell'>{labels.education}</td>
-          </tr>
-          <tr className='neighborhood-details__row'>
-            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.EducationPercentile')}:</td>
-            <td className='neighborhood-details__cell'>{labels.educationPercentile}</td>
-          </tr>
-          <tr className='neighborhood-details__row'>
-            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.Population')}:</td>
-            <td className='neighborhood-details__cell'>{labels.population}</td>
-          </tr>
-          <tr className='neighborhood-details__row'>
-            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.PercentCollegeGraduates')}:</td>
-            <td className='neighborhood-details__cell'>{labels.percentCollegeGraduates}</td>
-          </tr>
-          <tr className='neighborhood-details__row'>
-            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.HasTransitStop')}:</td>
-            <td className='neighborhood-details__cell'>{labels.hasTransitStop}</td>
-          </tr>
-          <tr className='neighborhood-details__row'>
-            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.NearTransit')}:</td>
-            <td className='neighborhood-details__cell'>{labels.nearTransitStop}</td>
-          </tr>
-          <tr className='neighborhood-details__row'>
-            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.NearRailStation')}:</td>
-            <td className='neighborhood-details__cell'>{labels.nearRailStation}</td>
-          </tr>
-          <tr className='neighborhood-details__row'>
-            <td className='neighborhood-details__cell'>{message('NeighborhoodInfo.NearPark')}:</td>
-            <td className='neighborhood-details__cell'>{labels.nearPark}</td>
-          </tr>
+          {tableData.map(data => (
+            <tr className='neighborhood-details__row' key={data.label}>
+              <td className='neighborhood-details__cell'>{message(data.label)}:</td>
+              <td className='neighborhood-details__cell'>{data.value}</td>
+            </tr>
+          ))}
         </tbody>
       </table>
     )

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -4,9 +4,10 @@ import message from '@conveyal/woonerf/message'
 import uniq from 'lodash/uniq'
 import {PureComponent} from 'react'
 
-import type {AccountProfile, NeighborhoodLabels} from '../types'
+import type {AccountProfile, NeighborhoodImageMetadata, NeighborhoodLabels} from '../types'
 import getGoogleDirectionsLink from '../utils/google-directions-link'
 import getGoogleSearchLink from '../utils/google-search-link'
+import getNeighborhoodImage from '../utils/neighborhood-images'
 import getNeighborhoodPropertyLabels from '../utils/neighborhood-properties'
 
 import RouteSegments from './route-segments'
@@ -104,41 +105,20 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
   }
 
   neighborhoodImage (props) {
-    const nprops = props.nprops
-    const imageField = props.imageField
-
-    if (!imageField || !nprops) {
-      console.error('missing data for neighborhood image')
+    const image: NeighborhoodImageMetadata = getNeighborhoodImage(props.nprops, props.imageField)
+    if (!image) {
       return null
     }
-
-    const description = nprops[imageField + '_description']
-    const license = nprops[imageField + '_license']
-    const licenseUrl = nprops[imageField + '_license_url']
-    const imageLink = nprops[imageField]
-    const thumbnail = nprops[imageField + '_thumbnail']
-    const userName = nprops[imageField + '_username']
-
-    if (!thumbnail) {
-      return null
-    }
-
-    // Build the attribution text to display on hover
-    let attrText = userName + ' [' + license
-    if (licenseUrl) {
-      attrText += ' (' + licenseUrl + ')'
-    }
-    attrText += '], ' + message('NeighborhoodDetails.WikipediaAttribution')
 
     return (
       <a
         className='neighborhood-details__image'
         target='_blank'
-        title={attrText}
-        href={imageLink}>
+        title={image.attribution}
+        href={image.imageLink}>
         <img
-          alt={description}
-          src={thumbnail} />
+          alt={image.description}
+          src={image.thumbnail} />
       </a>
     )
   }

--- a/taui/src/components/route-card.js
+++ b/taui/src/components/route-card.js
@@ -3,6 +3,9 @@ import Icon from '@conveyal/woonerf/components/icon'
 import message from '@conveyal/woonerf/message'
 import React from 'react'
 
+import type {NeighborhoodImageMetadata} from '../types'
+import {getFirstNeighborhoodImage} from '../utils/neighborhood-images'
+
 import NeighborhoodListInfo from './neighborhood-list-info'
 
 type Props = {
@@ -21,50 +24,20 @@ export default class RouteCard extends React.PureComponent<Props> {
 
   summaryImage (props) {
     const nprops = props.nprops
-
-    // Look for an available image to use as the summary
-    let imageField = nprops['town_square_thumbnail'] ? 'town_square' : null
-    if (!imageField) {
-      imageField = nprops['open_space_or_landmark_thumbnail'] ? 'open_space_or_landmark' : null
-    }
-    if (!imageField) {
-      imageField = nprops['school_thumbnail'] ? 'school' : null
-    }
-    if (!imageField) {
-      imageField = 'street'
-    }
-
-    if (!imageField) {
-      return null // Have no summary image available
-    }
-
-    const description = nprops[imageField + '_description']
-    const license = nprops[imageField + '_license']
-    const licenseUrl = nprops[imageField + '_license_url']
-    const imageLink = nprops[imageField]
-    const thumbnail = nprops[imageField + '_thumbnail']
-    const userName = nprops[imageField + '_username']
-
-    if (!thumbnail) {
+    const image: NeighborhoodImageMetadata = getFirstNeighborhoodImage(nprops)
+    if (!image) {
       return null
     }
-
-    // Build the attribution text to display on hover
-    let attrText = userName + ' [' + license
-    if (licenseUrl) {
-      attrText += ' (' + licenseUrl + ')'
-    }
-    attrText += '], ' + message('NeighborhoodDetails.WikipediaAttribution')
 
     return (
       <a
         className='neighborhood-summary__image'
         target='_blank'
-        title={attrText}
-        href={imageLink}>
+        title={image.attribution}
+        href={image.imageLink}>
         <img
-          alt={description}
-          src={thumbnail} />
+          alt={image.description}
+          src={image.thumbnail} />
       </a>
     )
   }

--- a/taui/src/constants.js
+++ b/taui/src/constants.js
@@ -4,6 +4,14 @@ export const ACCESSIBILITY_IS_LOADING = 'accessibility-is-loading'
 
 export const ANONYMOUS_USERNAME = 'ANONYMOUS'
 
+// Neighborhood image fields
+export const IMAGE_FIELDS = [
+  'town_square',
+  'open_space_or_landmark',
+  'school',
+  'street'
+]
+
 // Maximum number of destinations that may be added to a user profile
 export const MAX_ADDRESSES = 3
 

--- a/taui/src/types.js
+++ b/taui/src/types.js
@@ -65,7 +65,7 @@ export type AccountProfile = {
 
 /**
  * Neighborhood GeoJSON properties.
- * Should correspond to the column definitions in generate_neighborhood_json.py.
+ * See the column definitions in generate_neighborhood_json.py.
  */
 
 export type NeighborhoodProperties = {
@@ -78,15 +78,20 @@ export type NeighborhoodProperties = {
   near_t_stop: number,
   overall_affordability_quintile: number, // rental affordability
   percentage_college_graduates: number,
+  routable: boolean, // derived property changed with the origin
   town: string, // the label
+  town_link: string,
+  town_website_description: string,
   violentcrime_quintile: number,
+  wikipedia: string,
+  wikipedia_link: string,
   zipcode: string,
   zipcode_population: number
 }
 
 /**
  * Derived, formatted, user-presentable values for `NeighborhoodProperties`
- * calcualted in `utils/neighborhood-properties.js` (all properties but id, zipcode, and town).
+ * calcualted in `utils/neighborhood-properties.js`.
  */
 export type NeighborhoodLabels = {
   affordability: string,
@@ -99,6 +104,19 @@ export type NeighborhoodLabels = {
   percentCollegeGraduates: string,
   population: string,
   violentCrime: string
+}
+
+/**
+ * Neighborhood image metadata derived from `NeighborhoodProperties`
+ */
+export type NeighborhoodImageMetadata = {
+  attribution: string,
+  description: string,
+  imageLink: string,
+  license: string,
+  licenseUrl: string,
+  thumbnail: string,
+  userName: string
 }
 
 /**

--- a/taui/src/utils/neighborhood-images.js
+++ b/taui/src/utils/neighborhood-images.js
@@ -1,0 +1,55 @@
+// @flow
+import message from '@conveyal/woonerf/message'
+import find from 'lodash/find'
+
+import {IMAGE_FIELDS} from '../constants'
+import type {NeighborhoodImageMetadata, NeighborhoodProperties} from '../types'
+
+// Returns metadata for the first image field found that is available, or null if there are none
+export function getFirstNeighborhoodImage (properties: NeighborhoodProperties): NeighborhoodImageMetadata {
+  if (!properties) {
+    return null
+  }
+  // Look for an available image to use as the summary
+  const imageField = find(IMAGE_FIELDS, field => {
+    return !!properties[field + '_thumbnail']
+  })
+  return getNeighborhoodImage(properties, imageField)
+}
+
+// Returns metadata for a given image field, or null if unavailable
+export default function getNeighborhoodImage (properties: NeighborhoodProperties,
+  imageField: string): NeighborhoodImageMetadata {
+  if (!IMAGE_FIELDS.includes(imageField)) {
+    console.error(imageField + ' is not a neighborhood image field')
+    return null
+  }
+  // All images that have the thumbnail hotlink field set should exist as files in assets
+  if (!properties || !properties[imageField + '_thumbnail']) {
+    return null
+  }
+
+  const description = properties[imageField + '_description']
+  const license = properties[imageField + '_license']
+  const licenseUrl = properties[imageField + '_license_url']
+  const imageLink = properties[imageField]
+  const thumbnail = 'assets/neighborhoods/' + properties['id'] + '_' + imageField + '.jpg'
+  const userName = properties[imageField + '_username']
+
+  let attribution = userName + ' [' + license
+  if (licenseUrl) {
+    attribution += ' (' + licenseUrl + ')'
+  }
+  attribution += '], ' + message('NeighborhoodDetails.WikipediaAttribution')
+
+  const image: NeighborhoodImageMetadata = {
+    attribution,
+    description,
+    imageLink,
+    license,
+    licenseUrl,
+    thumbnail,
+    userName
+  }
+  return image
+}


### PR DESCRIPTION
## Overview

Use and deploy neighborhood image thumbnails downloaded with the image metadata with the `neighborhood_data` data processing scripts, instead of hotlinking to the images. Fixes deploying app images (only affects the logo). Refactor image and image metadata referencing. Also adds `data-private` attribute to text inputs to hide user profile information from LogRocket.


## Demo

Using locally hosted image:
![image](https://user-images.githubusercontent.com/960264/55824689-5fe53680-5ad2-11e9-858f-54f2c44e15f1.png)


### Notes

Since the neighborhood thumbnail images are not under version control and so are not available to the CI environment, deploying those images must be done as a separate step when they are updated. As that data source should only change infrequently, it shouldn't be necessary to do so often. Redeploying via CI should not affect previously deployed neighborhood images.


## Testing Instructions

 * `./scripts/imagepublish staging` should succeed in copying local `neighborhood_data/images` to S3
 * `mkdir -p ../taui/assets/neighborhoods/ && cp images/* ../taui/assets/neighborhoods/` (now part of update script)
 * Neighborhood images should continue to serve locally
 * Neighborhood image sources should point to local `assets`, not remote thumbnail


Closes #118 
Fixes #112 
Closes #114 

