### PR TITLE
Feature/kak/indicate ecc#128

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Website to explore Choice Neighborhoods in the Boston area.
 
-[![Build Status](https://travis-ci.org/azavea/echo-locator.svg?branch=develop)](https://travis-ci.com/azavea/echo-locator)
+[![Build Status](https://travis-ci.org/azavea/echo-locator.svg?branch=develop)](https://travis-ci.org/azavea/echo-locator)
 
 ## Requirements
 

--- a/taui/.eslintrc.json
+++ b/taui/.eslintrc.json
@@ -17,7 +17,7 @@
     "jest"
   ],
   "rules": {
-    "complexity": ["warn", 12],
+    "complexity": ["warn", 15],
     "import/order": ["warn", {
       "newlines-between": "always"
     }],

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -57,6 +57,7 @@ NeighborhoodInfo:
   EducationPercentile: Education percentile
   HasNoTransitStop: Has no transit stop
   HasTransitStop: Has transit stop
+  IsExpandedChoice: Expanded Choice Community
   NearPark: Near a park
   NearRailStation: Near a rail station
   NearTransit: Near transit stops

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -184,7 +184,7 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
     // Look up the currently selected user profile destination from the origin
     const originLabel = origin ? origin.label || '' : ''
     const currentDestination = userProfile.destinations.find(d => d.location.label === originLabel)
-    const { id, town, wikipedia } = neighborhood.properties
+    const { ecc, id, town, wikipedia } = neighborhood.properties
 
     const bestJourney = neighborhood.segments && neighborhood.segments.length
       ? neighborhood.segments[0] : null
@@ -213,6 +213,7 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
           travelTime={neighborhood.time}
         />}
         <NeighborhoodImages neighborhood={neighborhood} />
+        {!!ecc && <span>{message('NeighborhoodInfo.IsExpandedChoice')}</span>}
         <div className='neighborhood-details__desc'>
           {wikipedia}
         </div>


### PR DESCRIPTION
## Overview

Show ECC text in neighborhood details for expanded choice zip codes.


### Demo

![image](https://user-images.githubusercontent.com/960264/56378251-77ab7180-61da-11e9-8162-645dddb4d5dc.png)


## Testing Instructions

 * Text should show for ECC neighborhoods (generally, those with images)
 * Text should not show for non-ECC neighborhoods


Closes #128
