### PR TITLE
Feature/kak/remove fields#138

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -52,16 +52,8 @@ NeighborhoodDetails:
   GoogleMapsLink: Google Maps
   ModeSummary: via
 NeighborhoodInfo:
-  Affordability: Affordability
   EducationCategory: Schools
-  EducationPercentile: Education percentile
-  HasNoTransitStop: Has no transit stop
-  HasTransitStop: Has transit stop
   IsExpandedChoice: Expanded Choice Community
-  NearPark: Near a park
-  NearRailStation: Near a rail station
-  NearTransit: Near transit stops
-  PercentCollegeGraduates: College graduates
   Population: Population
   Score: Overall score
   ViolentCrime: Violent crime

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -69,6 +69,7 @@ Strings:
 Slower: slower
 Title: ECHOLocator
 Units:
+  About: About
   Minutes: minutes
   Mins: min
 Agency: Boston Housing Authority

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -76,7 +76,6 @@ Agency: Boston Housing Authority
 SignIn:
   Anonymous: Continue without an account
   AnonymousExplanation: Don't have an account?
-  Greeting: At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga.
 Header:
   New: New search
   Edit: Edit profile

--- a/taui/src/components/custom-sign-in.js
+++ b/taui/src/components/custom-sign-in.js
@@ -30,7 +30,6 @@ class SignInHeader extends React.Component {
           {message('Agency')}
         </h2>
         <h1 className='auth-header__app-name' >{message('Title')}</h1>
-        <p className='auth-header__greeting'>{message('SignIn.Greeting')}</p>
       </header>
     )
   }

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -54,16 +54,9 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
 
     const tableData = [
       {label: 'NeighborhoodInfo.Score', value: overallScore},
-      {label: 'NeighborhoodInfo.Affordability', value: labels.affordability},
       {label: 'NeighborhoodInfo.ViolentCrime', value: labels.violentCrime},
       {label: 'NeighborhoodInfo.EducationCategory', value: labels.education},
-      {label: 'NeighborhoodInfo.EducationPercentile', value: labels.educationPercentile},
-      {label: 'NeighborhoodInfo.Population', value: labels.population},
-      {label: 'NeighborhoodInfo.PercentCollegeGraduates', value: labels.percentCollegeGraduates},
-      {label: 'NeighborhoodInfo.HasTransitStop', value: labels.hasTransitStop},
-      {label: 'NeighborhoodInfo.NearTransit', value: labels.nearTransitStop},
-      {label: 'NeighborhoodInfo.NearRailStation', value: labels.nearRailStation},
-      {label: 'NeighborhoodInfo.NearPark', value: labels.nearPark}
+      {label: 'NeighborhoodInfo.Population', value: labels.population}
     ]
 
     return (

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -194,6 +194,7 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
           <Icon className='neighborhood-details__marker' type='map-marker' />
         </header>
         {!hasVehicle && <div className='neighborhood-details__trip'>
+          {message('Units.About')}&nbsp;
           {Math.round(neighborhood.time)}&nbsp;
           {message('Units.Mins')}&nbsp;
           <ModesList segments={bestJourney} />&nbsp;

--- a/taui/src/components/neighborhood-list-info.js
+++ b/taui/src/components/neighborhood-list-info.js
@@ -8,9 +8,7 @@ export default function NeighborhoodListInfo ({neighborhood}) {
   if (!neighborhood || !neighborhood.properties) {
     return null
   }
-
   const labels: NeighborhoodLabels = getNeighborhoodPropertyLabels(neighborhood.properties)
-
   // Overall score is a derived value and not a neighborhood property (so not in `labels`).
   const overallScore = neighborhood.score
     ? neighborhood.score.toLocaleString('en-US', {style: 'percent'})
@@ -22,10 +20,6 @@ export default function NeighborhoodListInfo ({neighborhood}) {
         <tr>
           <td className='neighborhood-summary__cell'>{message('NeighborhoodInfo.Score')}:</td>
           <td className='neighborhood-summary__cell'>{overallScore}</td>
-        </tr>
-        <tr>
-          <td className='neighborhood-summary__cell'>{message('NeighborhoodInfo.Affordability')}:</td>
-          <td className='neighborhood-summary__cell'>{labels.affordability}</td>
         </tr>
         <tr>
           <td className='neighborhood-summary__cell'>{message('NeighborhoodInfo.ViolentCrime')}:</td>

--- a/taui/src/components/route-card.js
+++ b/taui/src/components/route-card.js
@@ -89,7 +89,7 @@ export default class RouteCard extends React.PureComponent<Props> {
             <SummaryImage nprops={neighborhood.properties} />
             <div className='neighborhood-summary__trip'>
               {!userProfile.hasVehicle && <div className='neighborhood-summary__duration'>
-                {Math.round(time)} {message('Units.Mins')}
+                {message('Units.About')} {Math.round(time)} {message('Units.Mins')}
               </div>}
               <div className='neighborhood-summary__trajectory'>
                 <span className='neighborhood-summary__mode'>

--- a/taui/src/types.js
+++ b/taui/src/types.js
@@ -72,15 +72,9 @@ export type AccountProfile = {
  */
 
 export type NeighborhoodProperties = {
-  education_percentile: number,
   education_percentile_quintile: number,
   has_t_stop: boolean,
   id: string, // same as zipcode; unique
-  near_park: number,
-  near_railstation: number,
-  near_t_stop: number,
-  overall_affordability_quintile: number, // rental affordability
-  percentage_college_graduates: number,
   routable: boolean, // derived property changed with the origin
   town: string, // the label
   town_link: string,
@@ -97,14 +91,7 @@ export type NeighborhoodProperties = {
  * calcualted in `utils/neighborhood-properties.js`.
  */
 export type NeighborhoodLabels = {
-  affordability: string,
   education: string,
-  educationPercentile: string,
-  hasTransitStop: string,
-  nearPark: string,
-  nearRailStation: string,
-  nearTransitStop: string,
-  percentCollegeGraduates: string,
   population: string,
   violentCrime: string
 }

--- a/taui/src/utils/neighborhood-properties.js
+++ b/taui/src/utils/neighborhood-properties.js
@@ -12,37 +12,14 @@ function lookupLabel (quintileType: string, value: number): NeighborhoodLabels {
 
 // Returns a set of user-presentable formatted strings for a given neighborhood's properties.
 export default function getNeighborhoodPropertyLabels (properties: NeighborhoodProperties) {
-  const affordability = lookupLabel('Affordability', properties.overall_affordability_quintile)
   const education = lookupLabel('Education', properties.education_percentile_quintile)
   const violentCrime = lookupLabel('ViolentCrime', properties.violentcrime_quintile)
-
-  const educationPercentile = properties.education_percentile
-    ? (properties.education_percentile / 100).toLocaleString('en-US', {style: 'percent'})
-    : message('UnknownValue')
   const population = properties.zipcode_population
     ? properties.zipcode_population.toLocaleString('en-US', {style: 'decimal', useGrouping: true})
     : message('UnknownValue')
-  const hasTransitStop = properties.has_t_stop ? message('NeighborhoodInfo.HasTransitStop')
-    : message('NeighborhoodInfo.HasNoTransitStop')
-  const percentCollegeGraduates = properties.percentage_college_graduates
-    ? (properties.percentage_college_graduates / 100).toLocaleString('en-US', {style: 'percent'})
-    : message('UnknownValue')
-  const nearTransitStop = properties.near_t_stop ? properties.near_t_stop.toLocaleString(
-    'en-US', {style: 'percent'}) : message('UnknownValue')
-  const nearPark = properties.near_park ? properties.near_park.toLocaleString(
-    'en-US', {style: 'percent'}) : message('UnknownValue')
-  const nearRailStation = properties.near_railstation ? properties.near_railstation.toLocaleString(
-    'en-US', {style: 'percent'}) : message('UnknownValue')
 
   const labels: NeighborhoodLabels = {
-    affordability,
     education,
-    educationPercentile,
-    hasTransitStop,
-    nearPark,
-    nearRailStation,
-    nearTransitStop,
-    percentCollegeGraduates,
     population,
     violentCrime
   }


### PR DESCRIPTION
## Overview

Remove some detail fields from display that will no longer be used. Add "approximately/about" text before travel times, to indicate they are estimated.


### Demo

"About" in the list card, as there isn't enough space for "approximately":
![image](https://user-images.githubusercontent.com/960264/56380248-ad9f2480-61df-11e9-82f5-3a0a3a880ebf.png)

"Approximately" before travel time in details:
![image](https://user-images.githubusercontent.com/960264/56380293-cf98a700-61df-11e9-8e39-cf71646b8c6a.png)

Fewer detail fields:
![image](https://user-images.githubusercontent.com/960264/56380319-e0e1b380-61df-11e9-95ed-9aeb58e7a495.png)

Removed greeting text:
![image](https://user-images.githubusercontent.com/960264/56380752-ff947a00-61e0-11e9-936c-c01458a13f4b.png)


## Testing Instructions

 * List card and detail card text should look as expected


Closes #138 
Connects #144 
Closes #103 
