### PR TITLE
Style search weights and ECC field

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -102,8 +102,9 @@ Profile:
   DeleteProfile: Delete profile
   DeleteProfileError: Failed to delete profile. Please try again.
   Destinations: Frequent destinations
-  ImportanceAccessibility: Accessibility
-  ImportanceSchools: Schools
+  ImportanceAccessibility: Travel time
+  ImportanceHeading: How important are the following?
+  ImportanceSchools: School quality
   ImportanceViolentCrime: Violent crime
   Primary: Primary
   Purpose: Purpose

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -53,7 +53,7 @@ NeighborhoodDetails:
   ModeSummary: via
 NeighborhoodInfo:
   EducationCategory: Schools
-  IsExpandedChoice: Expanded Choice Community
+  ExpandedChoice: Expanded Choice
   Population: Population
   Score: Overall score
   ViolentCrime: Violent crime
@@ -142,4 +142,7 @@ TripPurpose:
   Daycare: Day care
   Other: Other
   Work: Work
+Booleans:
+  Yes: Yes
+  No: No
 UnknownValue: Unknown

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -359,7 +359,7 @@ export default class EditProfile extends PureComponent<Props> {
 
     return (
       <div className='account-profile__destinations'>
-        <h2 className='account-profile__label'>{message('Profile.Destinations')}</h2>
+        <h3 className='account-profile__label'>{message('Profile.Destinations')}</h3>
         <div className='account-profile__destination-list-header'>
           <div className='account-profile__destination_field account-profile__destination_field--wide'>
             <span className='account-profile__destination-list-heading'>
@@ -489,44 +489,6 @@ export default class EditProfile extends PureComponent<Props> {
                 rooms={rooms}
                 changeField={changeField} />
             </div>
-            <DestinationsList
-              addAddress={addAddress}
-              deleteAddress={deleteAddress}
-              destinations={destinations}
-              editAddress={editAddress}
-              geocode={geocode}
-              reverseGeocode={reverseGeocode}
-              setGeocodeLocation={setGeocodeLocation}
-              setPrimaryAddress={setPrimaryAddress}
-              TripPurposeOptions={TripPurposeOptions}
-            />
-            <div className='account-profile__field'>
-              <label
-                className='account-profile__label'
-                htmlFor='importanceAccessibility'>{message('Profile.ImportanceAccessibility')}</label>
-              <ImportanceOptions
-                fieldName='importanceAccessibility'
-                importance={importanceAccessibility}
-                changeField={changeField} />
-            </div>
-            <div className='account-profile__field'>
-              <label
-                className='account-profile__label'
-                htmlFor='importanceSchools'>{message('Profile.ImportanceSchools')}</label>
-              <ImportanceOptions
-                fieldName='importanceSchools'
-                importance={importanceSchools}
-                changeField={changeField} />
-            </div>
-            <div className='account-profile__field'>
-              <label
-                className='account-profile__label'
-                htmlFor='importanceViolentCrime'>{message('Profile.ImportanceViolentCrime')}</label>
-              <ImportanceOptions
-                fieldName='importanceViolentCrime'
-                importance={importanceViolentCrime}
-                changeField={changeField} />
-            </div>
             <div className='account-profile__field account-profile__field--inline'>
               <input
                 className='account-profile__input account-profile__input--checkbox'
@@ -540,6 +502,49 @@ export default class EditProfile extends PureComponent<Props> {
                 htmlFor='hasVehicle'>
                 {message('Profile.HasVehicle')}
               </label>
+            </div>
+            <DestinationsList
+              addAddress={addAddress}
+              deleteAddress={deleteAddress}
+              destinations={destinations}
+              editAddress={editAddress}
+              geocode={geocode}
+              reverseGeocode={reverseGeocode}
+              setGeocodeLocation={setGeocodeLocation}
+              setPrimaryAddress={setPrimaryAddress}
+              TripPurposeOptions={TripPurposeOptions}
+            />
+            <div className='account-profile__importance-options'>
+              <h3 className='account-profile__label'>
+                {message('Profile.ImportanceHeading')}
+              </h3>
+              <div className='account-profile__field account-profile__field--inline account-profile__field--stack'>
+                <label
+                  className='account-profile__label account-profile__label--secondary'
+                  htmlFor='importanceAccessibility'>{message('Profile.ImportanceAccessibility')}</label>
+                <ImportanceOptions
+                  fieldName='importanceAccessibility'
+                  importance={importanceAccessibility}
+                  changeField={changeField} />
+              </div>
+              <div className='account-profile__field account-profile__field--inline account-profile__field--stack'>
+                <label
+                  className='account-profile__label account-profile__label--secondary'
+                  htmlFor='importanceSchools'>{message('Profile.ImportanceSchools')}</label>
+                <ImportanceOptions
+                  fieldName='importanceSchools'
+                  importance={importanceSchools}
+                  changeField={changeField} />
+              </div>
+              <div className='account-profile__field account-profile__field--inline account-profile__field--stack'>
+                <label
+                  className='account-profile__label account-profile__label--secondary'
+                  htmlFor='importanceViolentCrime'>{message('Profile.ImportanceViolentCrime')}</label>
+                <ImportanceOptions
+                  fieldName='importanceViolentCrime'
+                  importance={importanceViolentCrime}
+                  changeField={changeField} />
+              </div>
             </div>
             {errorMessage &&
               <p className='account-profile__error'>{errorMessage}</p>

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -52,11 +52,14 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
       ? neighborhood.score.toLocaleString('en-US', {style: 'percent'})
       : message('UnknownValue')
 
+    const ecc = neighborhood.properties.ecc ? message('Booleans.Yes') : message('Booleans.No')
+
     const tableData = [
       {label: 'NeighborhoodInfo.Score', value: overallScore},
       {label: 'NeighborhoodInfo.ViolentCrime', value: labels.violentCrime},
       {label: 'NeighborhoodInfo.EducationCategory', value: labels.education},
-      {label: 'NeighborhoodInfo.Population', value: labels.population}
+      {label: 'NeighborhoodInfo.Population', value: labels.population},
+      {label: 'NeighborhoodInfo.ExpandedChoice', value: ecc}
     ]
 
     return (
@@ -177,7 +180,7 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
     // Look up the currently selected user profile destination from the origin
     const originLabel = origin ? origin.label || '' : ''
     const currentDestination = userProfile.destinations.find(d => d.location.label === originLabel)
-    const { ecc, id, town, wikipedia } = neighborhood.properties
+    const { id, town, wikipedia } = neighborhood.properties
 
     const bestJourney = neighborhood.segments && neighborhood.segments.length
       ? neighborhood.segments[0] : null
@@ -207,7 +210,6 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
           travelTime={neighborhood.time}
         />}
         <NeighborhoodImages neighborhood={neighborhood} />
-        {!!ecc && <span>{message('NeighborhoodInfo.IsExpandedChoice')}</span>}
         <div className='neighborhood-details__desc'>
           {wikipedia}
         </div>

--- a/taui/src/components/neighborhood-list-info.js
+++ b/taui/src/components/neighborhood-list-info.js
@@ -14,6 +14,8 @@ export default function NeighborhoodListInfo ({neighborhood}) {
     ? neighborhood.score.toLocaleString('en-US', {style: 'percent'})
     : message('UnknownValue')
 
+  const ecc = neighborhood.properties.ecc ? message('Booleans.Yes') : message('Booleans.No')
+
   return (
     <table className='neighborhood-summary__facts'>
       <tbody>
@@ -28,6 +30,10 @@ export default function NeighborhoodListInfo ({neighborhood}) {
         <tr>
           <td className='neighborhood-summary__cell'>{message('NeighborhoodInfo.EducationCategory')}:</td>
           <td className='neighborhood-summary__cell'>{labels.education}</td>
+        </tr>
+        <tr>
+          <td className='neighborhood-summary__cell'>{message('NeighborhoodInfo.ExpandedChoice')}:</td>
+          <td className='neighborhood-summary__cell'>{ecc}</td>
         </tr>
       </tbody>
     </table>

--- a/taui/src/components/route-card.js
+++ b/taui/src/components/route-card.js
@@ -30,15 +30,13 @@ export default class RouteCard extends React.PureComponent<Props> {
     }
 
     return (
-      <a
+      <div
         className='neighborhood-summary__image'
-        target='_blank'
-        title={image.attribution}
-        href={image.imageLink}>
+        title={image.attribution}>
         <img
           alt={image.description}
           src={image.thumbnail} />
-      </a>
+      </div>
     )
   }
 

--- a/taui/src/sass/06_components/_account-profile.scss
+++ b/taui/src/sass/06_components/_account-profile.scss
@@ -15,15 +15,26 @@
       align-items: center;
 
       > *:not(:last-child) {
-        margin-right: 0.8rem;
+        margin-right: 1.6rem;
         margin-bottom: 0;
       }
+    }
+
+    &--stack {
+      justify-content: space-between;
+      max-width: 40rem;
+      margin: 2.4rem 0;
     }
   }
 
   &__label {
     @include text(400);
     @include font-weight(bold);
+
+    &--secondary {
+      @include text(300);
+      @include font-weight(bold);
+    }
   }
 
   &__input {
@@ -126,6 +137,10 @@
     }
   }
 
+  &__importance-options {
+    margin-bottom: 4rem;
+  }
+
   &__error {
     @include text(400);
     margin-top: 1.6rem;
@@ -157,7 +172,7 @@
 
     &--secondary {
       @include button($color: $black, $background: $gray-300);
-      min-width: 12rem;
+      min-width: 14rem;
     }
 
     &--tertiary {

--- a/taui/src/sass/06_components/_neighborhood-details.scss
+++ b/taui/src/sass/06_components/_neighborhood-details.scss
@@ -14,7 +14,7 @@
   }
 
   &__star {
-    margin-right: 0.4rem;
+    margin-right: 0.8rem;
     font-size: 1.8rem !important;
   }
 

--- a/taui/src/sass/06_components/_neighborhood-summary.scss
+++ b/taui/src/sass/06_components/_neighborhood-summary.scss
@@ -45,6 +45,8 @@
 
   &__image {
     width: 12rem;
+    height: 9rem;
+    margin-bottom: 0.8rem;
 
     img {
       width: 120px;

--- a/taui/src/sass/06_components/_neighborhood-summary.scss
+++ b/taui/src/sass/06_components/_neighborhood-summary.scss
@@ -39,7 +39,7 @@
 
   &__descriptive {
     flex: none;
-    margin-right: 2.4rem;
+    margin-right: 1.6rem;
     margin-left: 0.8rem;
   }
 
@@ -79,7 +79,7 @@
   }
 
   &__cell {
-    width: 50%;
-    padding-bottom: 0.6rem;
+    padding-bottom: 0.8rem;
+    white-space: nowrap;
   }
 }


### PR DESCRIPTION
## Overview

- Style search weight fields on Profile page. Moved car checkbox higher up so it doesn't get lost.
- Render ECC boolean field as another table row in neighborhood summary and detail
- [EDIT:] Unlink thumbnails in search result cards

### Demo

![Screen Shot 2019-04-19 at 2 42 00 PM](https://user-images.githubusercontent.com/128699/56438742-f6271280-62b1-11e9-8844-d91b1f783b1a.png)

![Screen Shot 2019-04-19 at 2 42 14 PM](https://user-images.githubusercontent.com/128699/56438744-f9220300-62b1-11e9-91da-f6314a1e0a2f.png)

![Screen Shot 2019-04-19 at 2 42 22 PM](https://user-images.githubusercontent.com/128699/56438751-fb845d00-62b1-11e9-8bb7-0e78a04349ec.png)


### Notes

I first experimented with rendering the ECC field as a sort of tag/badge, but it was too prominent, and looked too similar to the treatment of transit lines on the neighborhood detail page. 

