### PR TITLE
Link to Craigslist housing search

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -42,6 +42,7 @@ Dock:
   ShowAllButton: All
   ShowSavedButton: Saved
 NeighborhoodDetails:
+  CraigslistSearchLink: Search Craigslist
   DriveMode: drive
   TransitMode: transit
   FromOrigin: from

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -5,6 +5,7 @@ import uniq from 'lodash/uniq'
 import {PureComponent} from 'react'
 
 import type {AccountProfile, NeighborhoodImageMetadata, NeighborhoodLabels} from '../types'
+import getCraigslistSearchLink from '../utils/craigslist-search-link'
 import getGoogleDirectionsLink from '../utils/google-directions-link'
 import getGoogleSearchLink from '../utils/google-search-link'
 import getNeighborhoodImage from '../utils/neighborhood-images'
@@ -122,7 +123,7 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
   }
 
   neighborhoodLinks (props) {
-    const { hasVehicle, neighborhood, origin } = this.props
+    const { hasVehicle, neighborhood, origin, userProfile } = this.props
     // lat,lon strings for Google Directions link from neighborhood to current destination
     const destinationCoordinateString = origin.position.lat + ',' + origin.position.lon
     const originCoordinateString = neighborhood.geometry.coordinates[1] +
@@ -160,6 +161,15 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
           target='_blank'
         >
           {message('NeighborhoodDetails.GoogleMapsLink')}
+        </a>
+        <a
+          className='neighborhood-details__link'
+          href={getCraigslistSearchLink(
+            neighborhood.properties.id,
+            userProfile.rooms)}
+          target='_blank'
+        >
+          {message('NeighborhoodDetails.CraigslistSearchLink')}
         </a>
       </div>
     )
@@ -216,7 +226,8 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
         <NeighborhoodLinks
           hasVehicle={hasVehicle}
           neighborhood={neighborhood}
-          origin={origin} />
+          origin={origin}
+          userProfile={userProfile} />
         <NeighborhoodDetailsTable neighborhood={neighborhood} />
       </div>
     )

--- a/taui/src/utils/craigslist-search-link.js
+++ b/taui/src/utils/craigslist-search-link.js
@@ -1,0 +1,7 @@
+// @flow
+// Returns a link to Boston area Craigslist housing search for zipcode and number of bedrooms
+const CRAIGSLIST_BASE_URL = 'https://boston.craigslist.org/search/aap?postal='
+export default function getCraigslistSearchLink (zipcode, rooms) {
+  return CRAIGSLIST_BASE_URL + encodeURIComponent(zipcode) + '&min_bedrooms=' +
+    encodeURIComponent(rooms) + '&max_bedrooms=' + encodeURIComponent(rooms)
+}


### PR DESCRIPTION
## Overview

Link out to Craigslist housing search from neighborhood detail page, using neighborhood zip code and the number of bedrooms from the user profile as search parameters. 


### Demo

![image](https://user-images.githubusercontent.com/960264/56513926-ec93e980-6501-11e9-9e7c-1644af0cccaf.png)

Craigslist's map of results from the search is in the same area:
![image](https://user-images.githubusercontent.com/960264/56513977-07fef480-6502-11e9-83c6-eccc543c8d6d.png)


## Testing Instructions

 * Go to details for a neighborhood
 * Link to search Craigslist should open search in a new tab
 * Results should match neighborhood zip code and user profile room count


Closes #131.
