### PR TITLE
ECC checkbox semantics, style. External links.

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -115,7 +115,7 @@ Profile:
   NameRequired: Please enter a name for the head of household.
   SaveError: Failed to save profile. Please try again.
   Title: Profile
-  IncludeNonExpandedChoiceCommunities: Include non-expanded choice communities
+  ExpandedChoiceCommunitiesOnly: Expanded Choice Communities only
 ImportanceLabels:
   1: Not important
   2: Somewhat important

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -42,11 +42,11 @@ Dock:
   ShowAllButton: All
   ShowSavedButton: Saved
 NeighborhoodDetails:
-  CraigslistSearchLink: Search Craigslist
+  CraigslistSearchLink: Craigslist
   DriveMode: drive
   TransitMode: transit
   FromOrigin: from
-  WebsiteLink: Official site
+  WebsiteLink: Website
   WikipediaAttribution: via Wikimedia Commons
   WikipediaLink: Wikipedia
   GoogleSearchLink: Google

--- a/taui/src/components/form.js
+++ b/taui/src/components/form.js
@@ -161,16 +161,16 @@ export default class Form extends React.PureComponent<Props> {
           wrapperStyle={SELECT_WRAPPER_STYLE}
           value={network}
         />
-        <div className='account-profile__field account-profile__field--inline'>
+        <div className='map-sidebar__ecc-checkbox'>
           <input
-            className='account-profile__input account-profile__input--checkbox'
+            className='map-sidebar__checkbox'
             id='useNonECC'
             type='checkbox'
             onClick={(e) => setStateUseNonECC(e.currentTarget.checked)}
             defaultChecked={useNonECC}
           />
           <label
-            className='account-profile__label'
+            className='map-sidebar__label'
             htmlFor='useNonECC'>
             {message('Profile.IncludeNonExpandedChoiceCommunities')}
           </label>

--- a/taui/src/components/form.js
+++ b/taui/src/components/form.js
@@ -166,13 +166,13 @@ export default class Form extends React.PureComponent<Props> {
             className='map-sidebar__checkbox'
             id='useNonECC'
             type='checkbox'
-            onClick={(e) => setStateUseNonECC(e.currentTarget.checked)}
-            defaultChecked={useNonECC}
+            onClick={(e) => setStateUseNonECC(!e.currentTarget.checked)}
+            defaultChecked={!useNonECC}
           />
           <label
             className='map-sidebar__label'
             htmlFor='useNonECC'>
-            {message('Profile.IncludeNonExpandedChoiceCommunities')}
+            {message('Profile.ExpandedChoiceCommunitiesOnly')}
           </label>
         </div>
       </div>

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -138,6 +138,15 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
         >
           {message('NeighborhoodDetails.WebsiteLink')}
         </a>}
+        <a
+          className='neighborhood-details__link'
+          href={getCraigslistSearchLink(
+            neighborhood.properties.id,
+            userProfile.rooms)}
+          target='_blank'
+        >
+          {message('NeighborhoodDetails.CraigslistSearchLink')}
+        </a>
         {neighborhood.properties.wikipedia_link && <a
           className='neighborhood-details__link'
           href={neighborhood.properties.wikipedia_link}
@@ -161,15 +170,6 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
           target='_blank'
         >
           {message('NeighborhoodDetails.GoogleMapsLink')}
-        </a>
-        <a
-          className='neighborhood-details__link'
-          href={getCraigslistSearchLink(
-            neighborhood.properties.id,
-            userProfile.rooms)}
-          target='_blank'
-        >
-          {message('NeighborhoodDetails.CraigslistSearchLink')}
         </a>
       </div>
     )

--- a/taui/src/sass/06_components/_map-sidebar.scss
+++ b/taui/src/sass/06_components/_map-sidebar.scss
@@ -15,8 +15,27 @@
   }
 
   &__travel-form {
-    padding-bottom: 0.8rem;
+    padding-bottom: 1.6rem;
     border-bottom: 1px solid $gray-400;
+  }
+
+  &__ecc-checkbox {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: flex-start;
+    align-items: center;
+    margin-top: 1.6rem;
+  }
+
+  &__checkbox {
+    width: 1.6rem;
+    height: 1.6rem;
+    margin-right: 0.8rem;
+  }
+
+  &__label {
+    @include text(300);
+    @include font-weight(bold);
   }
 
   &__details-navigation {

--- a/taui/src/sass/06_components/_neighborhood-details.scss
+++ b/taui/src/sass/06_components/_neighborhood-details.scss
@@ -90,8 +90,8 @@
     @include text(200);
     margin-top: -0.8rem;
     margin-bottom: 1.6rem;
-    padding: 0.4rem 0.8rem;
-    line-height: 2;
+    padding: 0.8rem;
+    line-height: 2.4;
     background-color: $gray-100;
   }
 }

--- a/taui/src/sass/06_components/_neighborhood-details.scss
+++ b/taui/src/sass/06_components/_neighborhood-details.scss
@@ -37,19 +37,18 @@
   }
 
   &__links {
-    @include text(200);
+    @include text(300);
     display: flex;
-    flex-flow: row nowrap;
-    justify-content: flex-start;
+    flex-flow: row wrap;
+    justify-content: space-between;
     align-items: center;
-    margin-bottom: 1.6rem;
+    margin-bottom: 2.4rem;
   }
 
   &__link {
     @include link-states() {
       color: $brand-blue;
     }
-    @include font-weight(bold);
     margin-right: auto;
   }
 

--- a/taui/src/taui.css
+++ b/taui/src/taui.css
@@ -192,10 +192,11 @@ table.CardContent td:first-of-type {
 }
 
 .CardSegment {
-  font-size: 0.75rem;
-  padding: 0 0.25rem;
+  font-size: 1rem;
+  line-height: 2;
+  padding: 0 0.5rem;
   border-radius: var(--rad);
-  margin-right: 0.25rem;
+  margin-right: 0.4rem;
   white-space: nowrap;
   display: inline-block;
 }


### PR DESCRIPTION
## Overview

- Style ECC checkbox
- Rename ECC checkbox to "Expanded Choice Communities only" and enable by default.
- Adjust copy and order of detail page external links.
- Tweak transit chip size.

### Demo

![Screen Shot 2019-04-24 at 2 06 02 PM](https://user-images.githubusercontent.com/128699/56682846-6bbc2580-669a-11e9-9920-74d74280b1fa.png)

![Screen Shot 2019-04-24 at 2 06 14 PM](https://user-images.githubusercontent.com/128699/56682847-6bbc2580-669a-11e9-9fed-002920fd128b.png)
