### PR TITLE
Polygon fills instead of strokes

### DIFF
--- a/taui/src/components/draw-neighborhood-bounds.js
+++ b/taui/src/components/draw-neighborhood-bounds.js
@@ -24,12 +24,12 @@ export default class DrawNeighborhoodBounds extends React.PureComponent {
         tooltip='town'
         onClick={p.clickNeighborhood}
         zIndex={p.zIndex}
-        activeStyle={NEIGHBORHOOD_BOUNDS_STYLE}
-        style={NEIGHBORHOOD_BOUNDS_HOVER_STYLE}
+        style={NEIGHBORHOOD_BOUNDS_STYLE}
+        hoverStyle={NEIGHBORHOOD_BOUNDS_HOVER_STYLE}
         vectorTileLayerStyles={
           {'sliced': (properties) => {
             return Object.assign({}, NEIGHBORHOOD_BOUNDS_STYLE, {
-              color: properties.routable
+              fillColor: properties.routable
                 ? NEIGHBORHOOD_ROUTABLE_COLOR
                 : NEIGHBORHOOD_NONROUTABLE_COLOR
             })

--- a/taui/src/constants.js
+++ b/taui/src/constants.js
@@ -73,18 +73,22 @@ export const NEIGHBORHOOD_ROUTABLE_COLOR = '#15369d'
 
 export const NEIGHBORHOOD_BOUNDS_STYLE = {
   stroke: true,
-  weight: 2,
-  color: '#85929E',
+  weight: 1,
+  color: '#fff',
   opacity: 0.5,
-  fill: false
+  fill: true,
+  fillColor: '#85929E',
+  fillOpacity: 0.4
 }
 
 export const NEIGHBORHOOD_BOUNDS_HOVER_STYLE = {
   stroke: true,
-  weight: 4,
-  color: '#159d37',
-  opacity: 1,
-  fill: false
+  weight: 1,
+  color: '#fff',
+  opacity: 0.5,
+  fill: true,
+  fillColor: '#159d37',
+  fillOpacity: 0.6
 }
 
 export const NEIGHBORHOOD_STYLE = {


### PR DESCRIPTION
## Overview

Use polygon fills instead of strokes.

Note this PR doesn't alter or add the polygon semantics (eg, see #161). It merely makes `fill` the distinguishing visual characteristic instead of `stroke`.

### Demo

![image](https://user-images.githubusercontent.com/128699/56690549-babe8680-66ab-11e9-85da-9c4c4b29d965.png)
