### PR TITLE
Feature/kak/toggle commuter rail#140

### DIFF
--- a/taui/config.json
+++ b/taui/config.json
@@ -3,20 +3,26 @@
     {
       "name": "home locations",
       "icon": "home",
-      "url": "https://d2z7d5345ccuw9.cloudfront.net/5b4667b532b98e1992ca79a9/Workers_with_earnings_1250_per_month_or_less.grid",
+      "url": "https://d2z7d5345ccuw9.cloudfront.net/5c9bdffa37ed813dbe27f8f1/Workers_with_earnings_1250_per_month_or_less.grid",
       "showOnMap": true
     }
   ],
   "networks": [
     {
-      "name": "Late Night",
-      "url": "https://d2z7d5345ccuw9.cloudfront.net/5b46678232b98e1992ca79a5",
-      "showOnMap": true
+      "name": "Peak",
+      "url": "https://d2z7d5345ccuw9.cloudfront.net/5c9bdffa37ed813dbe27f8f1"
     },
     {
-      "name": "Late Afternoon",
-      "url": "https://d2z7d5345ccuw9.cloudfront.net/5b4667b532b98e1992ca79a9",
-      "showOnMap": true
+      "name": "Off Peak",
+      "url": "https://d2z7d5345ccuw9.cloudfront.net/5c9be04737ed813dbe27f8f3"
+    },
+    {
+      "name": "Peak No Express",
+      "url": "https://d2z7d5345ccuw9.cloudfront.net/5cb8ebc037ed813dbe29182e"
+    },
+    {
+      "name": "Off Peak No Express",
+      "url": "https://d2z7d5345ccuw9.cloudfront.net/5cb8ebe437ed813dbe291830"
     }
   ]
 }

--- a/taui/config.json
+++ b/taui/config.json
@@ -10,19 +10,23 @@
   "networks": [
     {
       "name": "Peak",
-      "url": "https://d2z7d5345ccuw9.cloudfront.net/5c9bdffa37ed813dbe27f8f1"
+      "url": "https://d2z7d5345ccuw9.cloudfront.net/5c9bdffa37ed813dbe27f8f1",
+      "commuter": true
     },
     {
       "name": "Off Peak",
-      "url": "https://d2z7d5345ccuw9.cloudfront.net/5c9be04737ed813dbe27f8f3"
+      "url": "https://d2z7d5345ccuw9.cloudfront.net/5c9be04737ed813dbe27f8f3",
+      "commuter": true
     },
     {
       "name": "Peak No Express",
-      "url": "https://d2z7d5345ccuw9.cloudfront.net/5cb8ebc037ed813dbe29182e"
+      "url": "https://d2z7d5345ccuw9.cloudfront.net/5cb8ebc037ed813dbe29182e",
+      "commuter": false
     },
     {
       "name": "Off Peak No Express",
-      "url": "https://d2z7d5345ccuw9.cloudfront.net/5cb8ebe437ed813dbe291830"
+      "url": "https://d2z7d5345ccuw9.cloudfront.net/5cb8ebe437ed813dbe291830",
+      "commuter": false
     }
   ]
 }

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -116,6 +116,7 @@ Profile:
   SaveError: Failed to save profile. Please try again.
   Title: Profile
   ExpandedChoiceCommunitiesOnly: Expanded Choice Communities only
+  UseCommuterRail: Can take commuter rail
 ImportanceLabels:
   1: Not important
   2: Somewhat important

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -116,7 +116,7 @@ Profile:
   SaveError: Failed to save profile. Please try again.
   Title: Profile
   ExpandedChoiceCommunitiesOnly: Expanded Choice Communities only
-  UseCommuterRail: Can take commuter rail
+  UseCommuterRail: Can take commuter rail or express bus
 ImportanceLabels:
   1: Not important
   2: Somewhat important

--- a/taui/configurations/default/store.yml
+++ b/taui/configurations/default/store.yml
@@ -7,12 +7,16 @@ data:
   networks:
     - name: Peak
       url: https://d2z7d5345ccuw9.cloudfront.net/5c9bdffa37ed813dbe27f8f1
+      commuter: true
     - name: Off Peak
       url: https://d2z7d5345ccuw9.cloudfront.net/5c9be04737ed813dbe27f8f3
+      commuter: true
     - name: Peak No Express
       url: https://d2z7d5345ccuw9.cloudfront.net/5cb8ebc037ed813dbe29182e
+      commuter: false
     - name: Off Peak No Express
       url: https://d2z7d5345ccuw9.cloudfront.net/5cb8ebe437ed813dbe291830
+      commuter: false
 geocoder:
   proximity: -71.057929,42.360612 # longitude,latitude
   types: country,region,postcode,district,place,locality,neighborhood,address,poi # https://www.mapbox.com/api-documentation/?language=cURL#request-format

--- a/taui/configurations/default/store.yml
+++ b/taui/configurations/default/store.yml
@@ -5,12 +5,14 @@ data:
       url: https://d2z7d5345ccuw9.cloudfront.net/5c9bdffa37ed813dbe27f8f1/Workers_with_earnings_1250_per_month_or_less.grid
       showOnMap: true
   networks:
-    - name: Late Afternoon
+    - name: Peak
       url: https://d2z7d5345ccuw9.cloudfront.net/5c9bdffa37ed813dbe27f8f1
-      showOnMap: true
-    - name: Late Night
+    - name: Off Peak
       url: https://d2z7d5345ccuw9.cloudfront.net/5c9be04737ed813dbe27f8f3
-      showOnMap: true
+    - name: Peak No Express
+      url: https://d2z7d5345ccuw9.cloudfront.net/5cb8ebc037ed813dbe29182e
+    - name: Off Peak No Express
+      url: https://d2z7d5345ccuw9.cloudfront.net/5cb8ebe437ed813dbe291830
 geocoder:
   proximity: -71.057929,42.360612 # longitude,latitude
   types: country,region,postcode,district,place,locality,neighborhood,address,poi # https://www.mapbox.com/api-documentation/?language=cURL#request-format

--- a/taui/src/actions/network.js
+++ b/taui/src/actions/network.js
@@ -115,7 +115,7 @@ export function loadDatasetFromJSON (jsonConfig: any) {
 }
 
 export const loadDataset = (
-  networks: {name: string, showOnMap: boolean, url: string},
+  networks: {commuter: boolean, name: string, url: string},
   grids: {icon: string, name: string, showOnMap: boolean, url: string},
   pointsOfInterestUrl?: string,
   startCoordinate?: LonLat

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -79,7 +79,9 @@ export default class EditProfile extends PureComponent<Props> {
           ? profile.destinations : [Object.assign({}, firstAddress)],
         favorites: profile.favorites,
         hasVehicle: profile.hasVehicle,
-        useCommuterRail: !profile.hasVehicle && profile.useCommuterRail,
+        useCommuterRail: !profile.hasVehicle &&
+        // Default to true for profiles that do not have the useCommuterRail property set yet
+        (profile.useCommuterRail || profile.useCommuterRail === undefined),
         headOfHousehold: profile.headOfHousehold,
         importanceAccessibility: profile.importanceAccessibility ? profile.importanceAccessibility
           : DEFAULT_ACCESSIBILITY_IMPORTANCE,

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -79,6 +79,7 @@ export default class EditProfile extends PureComponent<Props> {
           ? profile.destinations : [Object.assign({}, firstAddress)],
         favorites: profile.favorites,
         hasVehicle: profile.hasVehicle,
+        useCommuterRail: profile.useCommuterRail,
         headOfHousehold: profile.headOfHousehold,
         importanceAccessibility: profile.importanceAccessibility ? profile.importanceAccessibility
           : DEFAULT_ACCESSIBILITY_IMPORTANCE,
@@ -99,6 +100,7 @@ export default class EditProfile extends PureComponent<Props> {
         destinations: [Object.assign({}, firstAddress)],
         favorites: [],
         hasVehicle: false,
+        useCommuterRail: true,
         headOfHousehold: '',
         importanceAccessibility: DEFAULT_ACCESSIBILITY_IMPORTANCE,
         importanceSchools: DEFAULT_SCHOOLS_IMPORTANCE,
@@ -139,6 +141,7 @@ export default class EditProfile extends PureComponent<Props> {
       importanceViolentCrime,
       key,
       rooms,
+      useCommuterRail,
       voucherNumber
     } = this.state
     const favorites = this.state.favorites || []
@@ -153,6 +156,7 @@ export default class EditProfile extends PureComponent<Props> {
       importanceViolentCrime,
       key,
       rooms,
+      useCommuterRail,
       voucherNumber
     }
   }
@@ -453,7 +457,8 @@ export default class EditProfile extends PureComponent<Props> {
       errorMessage,
       isAnonymous,
       key,
-      rooms
+      rooms,
+      useCommuterRail
     } = this.state
 
     const DestinationsList = this.destinationsList
@@ -501,6 +506,20 @@ export default class EditProfile extends PureComponent<Props> {
                 className='account-profile__label'
                 htmlFor='hasVehicle'>
                 {message('Profile.HasVehicle')}
+              </label>
+            </div>
+	    <div className='account-profile__field account-profile__field--inline'>
+              <input
+                className='account-profile__input account-profile__input--checkbox'
+                id='useCommuterRail'
+                type='checkbox'
+                onChange={(e) => changeField('useCommuterRail', e.currentTarget.checked)}
+                defaultChecked={useCommuterRail}
+              />
+              <label
+                className='account-profile__label'
+                htmlFor='useCommuterRail'>
+                {message('Profile.UseCommuterRail')}
               </label>
             </div>
             <DestinationsList

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -79,7 +79,7 @@ export default class EditProfile extends PureComponent<Props> {
           ? profile.destinations : [Object.assign({}, firstAddress)],
         favorites: profile.favorites,
         hasVehicle: profile.hasVehicle,
-        useCommuterRail: profile.useCommuterRail,
+        useCommuterRail: !profile.hasVehicle && profile.useCommuterRail,
         headOfHousehold: profile.headOfHousehold,
         importanceAccessibility: profile.importanceAccessibility ? profile.importanceAccessibility
           : DEFAULT_ACCESSIBILITY_IMPORTANCE,
@@ -141,10 +141,10 @@ export default class EditProfile extends PureComponent<Props> {
       importanceViolentCrime,
       key,
       rooms,
-      useCommuterRail,
       voucherNumber
     } = this.state
     const favorites = this.state.favorites || []
+    const useCommuterRail = !this.state.hasVehicle && this.state.useCommuterRail
 
     return {
       destinations,
@@ -508,7 +508,7 @@ export default class EditProfile extends PureComponent<Props> {
                 {message('Profile.HasVehicle')}
               </label>
             </div>
-	    <div className='account-profile__field account-profile__field--inline'>
+            {!hasVehicle && <div className='account-profile__field account-profile__field--inline'>
               <input
                 className='account-profile__input account-profile__input--checkbox'
                 id='useCommuterRail'
@@ -521,7 +521,7 @@ export default class EditProfile extends PureComponent<Props> {
                 htmlFor='useCommuterRail'>
                 {message('Profile.UseCommuterRail')}
               </label>
-            </div>
+            </div>}
             <DestinationsList
               addAddress={addAddress}
               deleteAddress={deleteAddress}

--- a/taui/src/components/form.js
+++ b/taui/src/components/form.js
@@ -2,6 +2,7 @@
 import lonlat from '@conveyal/lonlat'
 import message from '@conveyal/woonerf/message'
 import find from 'lodash/find'
+import filter from 'lodash/filter'
 import memoize from 'lodash/memoize'
 import React from 'react'
 import Select from 'react-virtualized-select'
@@ -132,7 +133,9 @@ export default class Form extends React.PureComponent<Props> {
     const destinations: Array<AccountAddress> = userProfile ? userProfile.destinations : []
     const locations = destinations.map(d => d.location)
     const destinationFilterOptions = createDestinationsFilter(locations)
-    const networks = this.props.networks.map(n => ({label: n.name, value: n.url}))
+    const useNetworks = filter(this.props.networks,
+      n => !!n.commuter === !!userProfile.useCommuterRail)
+    const networks = useNetworks.map(n => ({label: n.name, value: n.url}))
     const networkFilterOptions = createNetworksFilter(networks)
 
     const setNetwork = this.setNetwork

--- a/taui/src/components/form.js
+++ b/taui/src/components/form.js
@@ -39,6 +39,7 @@ export default class Form extends React.PureComponent<Props> {
   constructor (props) {
     super(props)
 
+    this.getProfileNetworks = this.getProfileNetworks.bind(this)
     this.setNetwork = this.setNetwork.bind(this)
 
     const {networks, userProfile} = props
@@ -46,10 +47,12 @@ export default class Form extends React.PureComponent<Props> {
     const destination = userProfile && userProfile.destinations
       ? this.getPrimaryDestination(userProfile.destinations) : null
 
+    const useNetworks = this.getProfileNetworks(networks, userProfile)
+
     this.state = {
       destination,
-      network: networks && networks.length ? {
-        label: networks[0].name, value: networks[0].url
+      network: useNetworks ? {
+        label: useNetworks[0].name, value: useNetworks[0].url
       } : null,
       useNonECC: false
     }
@@ -63,8 +66,9 @@ export default class Form extends React.PureComponent<Props> {
     if (!nextProps) {
       return
     }
-    if (!this.state.network && nextProps.networks && nextProps.networks.length) {
-      this.setStateNetwork(nextProps.networks)
+    if (!this.state.network && nextProps.networks && nextProps.networks.length &&
+      nextProps.userProfile) {
+      this.setStateNetwork(nextProps.networks, nextProps.userProfile)
     }
 
     if (this.state.useNonECC !== nextProps.useNonECC) {
@@ -86,6 +90,14 @@ export default class Form extends React.PureComponent<Props> {
     }
   }
 
+  // Filter networks to list/use based on user profile setting
+  // to use commuter rail/express bus or not.
+  getProfileNetworks (networks, userProfile): any[] {
+    const useCommuter = !userProfile || userProfile.useCommuterRail === undefined ||
+      !!userProfile.useCommuterRail
+    return networks ? filter(networks, n => !!n.commuter === useCommuter) : null
+  }
+
   getPrimaryDestination = (destinations) => {
     const destination = find(destinations, d => !!d.primary)
     if (!destination) {
@@ -99,8 +111,9 @@ export default class Form extends React.PureComponent<Props> {
     } : null
   }
 
-  setStateNetwork = (networks) => {
-    const first = networks[0]
+  setStateNetwork = (networks, userProfile) => {
+    const useNetworks = this.getProfileNetworks(networks, userProfile)
+    const first = useNetworks[0]
     const network = {label: first.name, value: first.url}
     this.setState({network})
     this.props.setActiveNetwork(network.label)
@@ -133,8 +146,7 @@ export default class Form extends React.PureComponent<Props> {
     const destinations: Array<AccountAddress> = userProfile ? userProfile.destinations : []
     const locations = destinations.map(d => d.location)
     const destinationFilterOptions = createDestinationsFilter(locations)
-    const useNetworks = filter(this.props.networks,
-      n => !!n.commuter === !!userProfile.useCommuterRail)
+    const useNetworks = this.getProfileNetworks(this.props.networks, userProfile)
     const networks = useNetworks.map(n => ({label: n.name, value: n.url}))
     const networkFilterOptions = createNetworksFilter(networks)
 

--- a/taui/src/components/form.js
+++ b/taui/src/components/form.js
@@ -166,7 +166,7 @@ export default class Form extends React.PureComponent<Props> {
           wrapperStyle={SELECT_WRAPPER_STYLE}
           value={destination}
         />
-        <Select
+        {!userProfile.hasVehicle && <Select
           clearable={false}
           filterOptions={networkFilterOptions}
           options={networks}
@@ -175,7 +175,7 @@ export default class Form extends React.PureComponent<Props> {
           style={SELECT_STYLE}
           wrapperStyle={SELECT_WRAPPER_STYLE}
           value={network}
-        />
+        />}
         <div className='map-sidebar__ecc-checkbox'>
           <input
             className='map-sidebar__checkbox'

--- a/taui/src/components/main-page.js
+++ b/taui/src/components/main-page.js
@@ -81,17 +81,6 @@ export default class MainPage extends React.PureComponent<Props> {
     this.props.setSelectedTimeCutoff(parseInt(event.currentTarget.value, 10))
   }
 
-  _setShowOnMap = memoize(index => () => {
-    const p = this.props
-    const network = p.data.networks[index]
-    const showOnMap = !network.showOnMap
-    p.setNetwork({
-      ...network,
-      showOnMap
-    })
-    if (showOnMap) p.setActiveNetwork(network.name)
-  })
-
   _downloadIsochrone = memoize(index => () => {
     const p = this.props
     const isochrone = p.isochrones[index]

--- a/taui/src/components/route-card.js
+++ b/taui/src/components/route-card.js
@@ -11,8 +11,6 @@ import NeighborhoodListInfo from './neighborhood-list-info'
 type Props = {
   children?: any,
   downloadIsochrone?: Function,
-  setShowOnMap: Function,
-  showOnMap: boolean,
   title: string
 }
 

--- a/taui/src/components/select-account.js
+++ b/taui/src/components/select-account.js
@@ -3,6 +3,11 @@ import Storage from '@aws-amplify/storage'
 import message from '@conveyal/woonerf/message'
 import {PureComponent} from 'react'
 
+import {
+  DEFAULT_ACCESSIBILITY_IMPORTANCE,
+  DEFAULT_CRIME_IMPORTANCE,
+  DEFAULT_SCHOOLS_IMPORTANCE
+} from '../constants'
 import type {AccountProfile} from '../types'
 import validateVoucherNumber from '../utils/validate-voucher-number'
 
@@ -46,12 +51,19 @@ export default class SelectAccount extends PureComponent<Props> {
     }
 
     const key = voucher.toUpperCase()
+
+    // Default profile
     const profile: AccountProfile = {
       destinations: [],
+      favorites: [],
       hasVehicle: false,
       headOfHousehold: name,
+      importanceAccessibility: DEFAULT_ACCESSIBILITY_IMPORTANCE,
+      importanceSchools: DEFAULT_SCHOOLS_IMPORTANCE,
+      importanceViolentCrime: DEFAULT_CRIME_IMPORTANCE,
       key: key,
       rooms: 0,
+      useCommuterRail: true,
       voucherNumber: voucher
     }
 

--- a/taui/src/selectors/active-network-index.js
+++ b/taui/src/selectors/active-network-index.js
@@ -4,8 +4,16 @@ import {createSelector} from 'reselect'
 
 export default createSelector(
   state => get(state, 'data.networks'),
-  networks => {
-    const index = networks.findIndex(n => !!n.active)
+  state => get(state, 'data.userProfile'),
+  (networks, userProfile) => {
+    // Default to use commuter rail if property not set
+    const useCommuter = !userProfile ||
+      userProfile.useCommuterRail === undefined || !!userProfile.useCommuterRail
+    var index = networks.findIndex(n => !!n.active)
+    // Filter to first network that matches user profile setting to use commuter rail or not
+    if (index === -1) {
+      index = networks.findIndex(n => !!n.commuter === useCommuter)
+    }
     return index >= 0 ? index : 0
   }
 )

--- a/taui/src/selectors/draw-isochrones.js
+++ b/taui/src/selectors/draw-isochrones.js
@@ -22,7 +22,7 @@ export default createSelector(
   state => get(state, 'data.networks', []),
   (networks = []) =>
     networks.map((n, i) => {
-      if (n.showOnMap && n.travelTimeSurface && n.travelTimeSurface.data) {
+      if (n.travelTimeSurface && n.travelTimeSurface.data) {
         return gdlz.createDrawTile({
           colorizer: colorizer(i),
           grid: n.travelTimeSurface,

--- a/taui/src/selectors/isochrones.js
+++ b/taui/src/selectors/isochrones.js
@@ -19,7 +19,7 @@ export default createSelector(
   state => get(state, 'timeCutoff.selected'),
   (networks = [], timeCutoff) =>
     networks.map((n, i) => {
-      if (n.showOnMap && n.travelTimeSurface && n.travelTimeSurface.data) {
+      if (n.travelTimeSurface && n.travelTimeSurface.data) {
         return getIsochrone(n, i, timeCutoff)
       }
     })

--- a/taui/src/types.js
+++ b/taui/src/types.js
@@ -63,6 +63,7 @@ export type AccountProfile = {
   importanceViolentCrime: number,
   key: string,
   rooms: number,
+  useCommuterRail: boolean,
   voucherNumber: string
 }
 
@@ -72,6 +73,7 @@ export type AccountProfile = {
  */
 
 export type NeighborhoodProperties = {
+  ecc: boolean,
   education_percentile_quintile: number,
   has_t_stop: boolean,
   id: string, // same as zipcode; unique


### PR DESCRIPTION
## Overview

Add checkbox to user profile to set whether to include commuter rail and express bus in the transit results. Add configuration for two more results buckets that exclude commuter rail and express bus. Based on user profile setting, filter out networks (results buckets) that do not match the new setting, or hide the network selector if in car mode (not using transit results). Also changes the labels for the networks.


### Demo

With commuter rail/express bus option set, this result for Whitman shows as accessible via the Kingston commuter rail line:
![image](https://user-images.githubusercontent.com/960264/56983391-833f5680-6b51-11e9-990a-c8c688d264f4.png)

With the commuter rail/express bus option unset, Whitman is greyed out as unaccessible and the drop-down label changes:
![image](https://user-images.githubusercontent.com/960264/56983515-d31e1d80-6b51-11e9-877a-265a2d0a86c8.png)


Network drop-down hidden in car mode:
![image](https://user-images.githubusercontent.com/960264/56982425-4eca9b00-6b4f-11e9-802b-980bb241dd46.png)


### Notes

The two new buckets appear to not have CORS headers set to allow access from `localhost` in the app, so it will be necessary to use something like `ngrok` to test.

The `networks` configuration for the results buckets goes in both `config.json` and `store.yml`. This is an artifact of `taui`, likely to support the feature for in-browser editing of the configuration. Although not ideal, I don't think it would be worthwhile at this point to strip out the use of one or the other. If we do more network configuration changes, we might want to go ahead with refactoring the configuration file use.


## Testing Instructions

 * Create a new user profile without car (transit) on staging or using current `develop` (not this branch)
 * Check out this branch
 * `./ngrok http 9966` and visit ngrok's URL
 * Open the newly created profile; the use commuter checkbox should default to checked
 * Do not click 'Go' from the profile page, but instead navigate directly to `/map` (do not save profile)
 * The two commuter networks should show in drop-down ("Peak" and "Off peak")
 * Default network selected should be "Peak" in drop-down
 * Map/sidebar results should be for "Peak" (setting via drop-down to "Peak" should not change results)
 * On page refresh, network and network results should be set as above
 * Toggling network should update map and results as expected
 * Edit profile and uncheck commuter rail/express bus box; click 'Go'
 * Network labels should now be for peak and off-peak "No Express"
 * Map and sidebar results should exclude neighborhoods accessed by commuter rail or express bus
 * Edit profile and check 'has vehicle' box
 * Commuter rail/express bus checkbox should be hidden when 'has vehicle' box is checked
 * Click 'Go'
 * Drop-down for network should be hidden and driving estimate results should still display


Closes #140 
Closes #135
