### PR TITLE
Feature/kak/link zillow#132

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -52,6 +52,7 @@ NeighborhoodDetails:
   GoogleSearchLink: Google
   GoogleMapsLink: Google Maps
   ModeSummary: via
+  ZillowSearchLink: Zillow
 NeighborhoodInfo:
   EducationCategory: Schools
   ExpandedChoice: Expanded Choice

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -131,57 +131,61 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
       ',' + neighborhood.geometry.coordinates[0]
 
     return (
-      <div className='neighborhood-details__links'>
-        {neighborhood.properties.town_link && <a
-          className='neighborhood-details__link'
-          href={neighborhood.properties.town_link}
-          target='_blank'
-        >
-          {message('NeighborhoodDetails.WebsiteLink')}
-        </a>}
-        <a
-          className='neighborhood-details__link'
-          href={getCraigslistSearchLink(
-            neighborhood.properties.id,
-            userProfile.rooms)}
-          target='_blank'
-        >
-          {message('NeighborhoodDetails.CraigslistSearchLink')}
-        </a>
-        <a
-          className='neighborhood-details__link'
-          href={getZillowSearchLink(
-            neighborhood.properties.id,
-            userProfile.rooms)}
-          target='_blank'
-        >
-          {message('NeighborhoodDetails.ZillowSearchLink')}
-        </a>
-        {neighborhood.properties.wikipedia_link && <a
-          className='neighborhood-details__link'
-          href={neighborhood.properties.wikipedia_link}
-          target='_blank'
-        >
-          {message('NeighborhoodDetails.WikipediaLink')}
-        </a>}
-        <a
-          className='neighborhood-details__link'
-          href={getGoogleSearchLink(neighborhood.properties.id)}
-          target='_blank'
-        >
-          {message('NeighborhoodDetails.GoogleSearchLink')}
-        </a>
-        <a
-          className='neighborhood-details__link'
-          href={getGoogleDirectionsLink(
-            originCoordinateString,
-            destinationCoordinateString,
-            hasVehicle)}
-          target='_blank'
-        >
-          {message('NeighborhoodDetails.GoogleMapsLink')}
-        </a>
-      </div>
+      <>
+        <div className='neighborhood-details__links'>
+          {neighborhood.properties.town_link && <a
+            className='neighborhood-details__link'
+            href={neighborhood.properties.town_link}
+            target='_blank'
+          >
+            {message('NeighborhoodDetails.WebsiteLink')}
+          </a>}
+          {neighborhood.properties.wikipedia_link && <a
+            className='neighborhood-details__link'
+            href={neighborhood.properties.wikipedia_link}
+            target='_blank'
+          >
+            {message('NeighborhoodDetails.WikipediaLink')}
+          </a>}
+          <a
+            className='neighborhood-details__link'
+            href={getGoogleSearchLink(neighborhood.properties.id)}
+            target='_blank'
+          >
+            {message('NeighborhoodDetails.GoogleSearchLink')}
+          </a>
+          <a
+            className='neighborhood-details__link'
+            href={getGoogleDirectionsLink(
+              originCoordinateString,
+              destinationCoordinateString,
+              hasVehicle)}
+            target='_blank'
+          >
+            {message('NeighborhoodDetails.GoogleMapsLink')}
+          </a>
+        </div>
+        <div className='neighborhood-details__links'>
+          <a
+            className='neighborhood-details__link'
+            href={getCraigslistSearchLink(
+              neighborhood.properties.id,
+              userProfile.rooms)}
+            target='_blank'
+          >
+            {message('NeighborhoodDetails.CraigslistSearchLink')}
+          </a>
+          <a
+            className='neighborhood-details__link'
+            href={getZillowSearchLink(
+              neighborhood.properties.id,
+              userProfile.rooms)}
+            target='_blank'
+          >
+            {message('NeighborhoodDetails.ZillowSearchLink')}
+          </a>
+        </div>
+      </>
     )
   }
 

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -10,6 +10,7 @@ import getGoogleDirectionsLink from '../utils/google-directions-link'
 import getGoogleSearchLink from '../utils/google-search-link'
 import getNeighborhoodImage from '../utils/neighborhood-images'
 import getNeighborhoodPropertyLabels from '../utils/neighborhood-properties'
+import getZillowSearchLink from '../utils/zillow-search-link'
 
 import RouteSegments from './route-segments'
 
@@ -146,6 +147,15 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
           target='_blank'
         >
           {message('NeighborhoodDetails.CraigslistSearchLink')}
+        </a>
+        <a
+          className='neighborhood-details__link'
+          href={getZillowSearchLink(
+            neighborhood.properties.id,
+            userProfile.rooms)}
+          target='_blank'
+        >
+          {message('NeighborhoodDetails.ZillowSearchLink')}
         </a>
         {neighborhood.properties.wikipedia_link && <a
           className='neighborhood-details__link'

--- a/taui/src/utils/zillow-search-link.js
+++ b/taui/src/utils/zillow-search-link.js
@@ -1,0 +1,8 @@
+// @flow
+// Returns a link to Zillow rental search for zipcode and number of bedrooms
+const ZILLOW_BASE_URL = 'https://www.zillow.com/homes/for_rent/'
+export default function getZillowSearchLink (zipcode, rooms) {
+  const zipcodeSearch = ZILLOW_BASE_URL + encodeURIComponent(zipcode) + '_rb/'
+  return parseInt(rooms) > 0
+    ? zipcodeSearch + encodeURIComponent(rooms) + '-_beds' : zipcodeSearch
+}


### PR DESCRIPTION
## Overview

Adds a dynamic search link to Zillow rentals in the neighborhood details card.


### Demo

Details links now are on two lines:
![image](https://user-images.githubusercontent.com/960264/56988375-e0d9a000-6b5d-11e9-9615-ae8698a72663.png)

Search opens in new tab:
![image](https://user-images.githubusercontent.com/960264/56988416-f949ba80-6b5d-11e9-90b1-0577c9f6fc96.png)


### Notes

The links line was getting a little crowded, so I moved the search links to a second line in the details card.


## Testing Instructions

 * Go to details for a neighborhood
 * Click 'Zillow' button
 * Search should open in new tab for neighborhood's zip code and user profile's rooms number

Closes #132 
