### PR TITLE
Feature/kak/hide walk leg#186

### DIFF
--- a/taui/src/components/map.js
+++ b/taui/src/components/map.js
@@ -265,18 +265,6 @@ export default class Map extends PureComponent<Props, State> {
             </Popup>
           </Marker>}
 
-        {showDetailNeighborhood &&
-          <Marker
-            icon={endIcon}
-            key={`end-${this._getKey()}`}
-            position={lonlat.toLeaflet(showDetailNeighborhood.geometry.coordinates)}
-            zIndex={getZIndex()}
-          >
-            <Popup>
-              <span>{showDetailNeighborhood.properties.town} {showDetailNeighborhood.properties.id}</span>
-            </Popup>
-          </Marker>}
-
         {otherNeighborhoods && otherNeighborhoods.length &&
           otherNeighborhoods.map((other) =>
             <Marker

--- a/taui/src/components/map.js
+++ b/taui/src/components/map.js
@@ -2,7 +2,6 @@
 import lonlat from '@conveyal/lonlat'
 import Leaflet from 'leaflet'
 import filter from 'lodash/filter'
-import find from 'lodash/find'
 import get from 'lodash/get'
 import React, {PureComponent} from 'react'
 import {
@@ -45,13 +44,6 @@ const iconHTML = '' // <div className="innerMarker"></div>'
 
 const startIcon = Leaflet.divIcon({
   className: 'LeafletIcon Start map__marker map__marker--start',
-  html: iconHTML,
-  iconAnchor,
-  iconSize
-})
-
-const endIcon = Leaflet.divIcon({
-  className: 'LeafletIcon End map__marker map__marker--end',
   html: iconHTML,
   iconAnchor,
   iconSize
@@ -201,9 +193,6 @@ export default class Map extends PureComponent<Props, State> {
     const otherNeighborhoods = (p.displayNeighborhoods && !p.showDetails)
       ? filter(p.displayNeighborhoods, n => !n.active)
       : []
-
-    const showDetailNeighborhood = p.showDetails ? p.detailNeighborhood
-      : find(p.displayNeighborhoods, n => n.properties.id === p.activeNeighborhood)
 
     // Index elements with keys to reset them when elements are added / removed
     this._key = 0

--- a/taui/src/selectors/draw-neighborhood-route.js
+++ b/taui/src/selectors/draw-neighborhood-route.js
@@ -27,6 +27,8 @@ export default createSelector(
     const transitStyle = {...TRANSIT_STYLE, ...applyStyle}
     const stopStyle = {...STOP_STYLE, ...applyStyle}
     const segments = get(transitive, 'journeys[0].segments', [])
+    // Remove final walk leg
+    segments.pop()
     return {
       index,
       id: transitive.id,

--- a/taui/src/selectors/draw-neighborhood-route.js
+++ b/taui/src/selectors/draw-neighborhood-route.js
@@ -26,8 +26,9 @@ export default createSelector(
     const walkStyle = {...WALK_STYLE, ...applyStyle}
     const transitStyle = {...TRANSIT_STYLE, ...applyStyle}
     const stopStyle = {...STOP_STYLE, ...applyStyle}
-    const segments = get(transitive, 'journeys[0].segments', [])
+    const allSegments = get(transitive, 'journeys[0].segments', [])
     // Remove final walk leg
+    const segments = [...allSegments]
     segments.pop()
     return {
       index,


### PR DESCRIPTION
## Overview

Do not draw the final walk leg of transit routes, which goes from the nearest transit stop to the neighborhood centroid. Also do not show marker on neighborhood centroid when displaying route.


### Demo

Start walk displays from user address to boarding stop. End walk from disembarking stop to neighborhood centroid used for routing is not displayed.
![image](https://user-images.githubusercontent.com/960264/58500235-bb858500-814f-11e9-9f74-33c179ea2963.png)


### Notes

The walk legs were not calculated by the routing engine to follow the street network, but are instead a straight line from the first/last stop to the origin/destination.


## Testing Instructions

 * Open a profile in transit mode
 * Go to neighborhood details
 * Should not have walk leg to neighborhood centroid

Closes #186 
