### PR TITLE
Feature/kak/submit login on enter#185

### DIFF
--- a/taui/src/components/custom-sign-in.js
+++ b/taui/src/components/custom-sign-in.js
@@ -36,6 +36,11 @@ class SignInHeader extends React.Component {
 }
 
 export default class CustomSignIn extends SignIn {
+  submitOnEnter = (e) => {
+    if (e.key === 'Enter') {
+      this.signIn(e)
+    }
+  }
   // Have to copy showComponent here, because `hide` non-mutable property
   // results in null being returned from call to super.
   // Based on source:
@@ -64,6 +69,7 @@ export default class CustomSignIn extends SignIn {
                 autoFocus
                 theme={theme}
                 key='username'
+                onKeyPress={(e) => this.submitOnEnter(e)}
                 name='username'
                 onChange={this.handleInputChange}
               />
@@ -74,6 +80,7 @@ export default class CustomSignIn extends SignIn {
                 data-private
                 theme={theme}
                 key='password'
+                onKeyPress={(e) => this.submitOnEnter(e)}
                 type='password'
                 name='password'
                 onChange={this.handleInputChange}

--- a/taui/src/components/with-authenticator.js
+++ b/taui/src/components/with-authenticator.js
@@ -77,7 +77,7 @@ export default function withAuthenticator (Comp, includeGreetings = false,
         // Clear all local storage after logout
         clearLocalStorage()
       } else {
-        if (data.username) {
+        if (data && data.username) {
           LogRocket.identify(data.username)
         }
         this.setState({authState: state, authData: data})

--- a/taui/src/selectors/neighborhoods-sorted-with-routes.js
+++ b/taui/src/selectors/neighborhoods-sorted-with-routes.js
@@ -32,7 +32,7 @@ export default createSelector(
   state => get(state, 'data.origin'),
   state => get(state, 'data.userProfile'),
   (neighborhoodRoutes, travelTimes, neighborhoods, origin, profile) => {
-    if (!neighborhoods || !neighborhoods.features || !neighborhoods.features.length ||
+    if (!neighborhoods || !profile || !neighborhoods.features || !neighborhoods.features.length ||
       !neighborhoodRoutes || !neighborhoodRoutes.length) {
       return []
     }


### PR DESCRIPTION
## Overview

Log in on keypress in either username or password sign-in field.

Also fixes a couple of null reference errors that might occur on logout.


### Notes

The AWS Amplify [React components](https://github.com/aws-amplify/amplify-js/blob/master/packages/aws-amplify-react/src/Amplify-UI/Amplify-UI-Components-React.jsx) for the form do not create an HTML form, and so do not [implicitly submit](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission).


## Testing Instructions

 * Hit enter in either username or password sign-in field
 * Site should attempt to sign in and redirect to profile search if successful


Closes #185 
