### PR TITLE
Go directly to map after setting profile

### DIFF
--- a/taui/src/components/select-account.js
+++ b/taui/src/components/select-account.js
@@ -98,7 +98,10 @@ export default class SelectAccount extends PureComponent<Props> {
       const text = result.Body.toString('utf-8')
       const profile: AccountProfile = JSON.parse(text)
       this.props.changeUserProfile(profile)
-      this.props.history.push({pathname: '/profile', state: {fromApp: true}})
+      // Skip profile page and go to map if profile exists and has destinations set
+      const destination = profile && profile.destinations &&
+        profile.destinations.length ? '/map' : '/profile'
+      this.props.history.push({pathname: destination, state: {fromApp: true}})
     }).catch(err => {
       // If file not found, error message returned has `code` / `name`: NoSuchKey
       // and `message`: The specified key does not exist `statusCode`: 404


### PR DESCRIPTION
## Overview

Skip profile edit page after search if profile already exists and has destinations.


### Notes

Checks for destinations on profile to guard against pulling up a profile that exists but is incomplete, which would result in staying on the search page, as the `/map` route guards against routing to it without a profile with destinations.


## Testing Instructions

 * Log out/back in
 * Search for a profile that exists
 * Should go direct to map page
 * Edit profile button on map page should still function as expected
 * Log out/back in
 * Search for a profile that does *not* exist
 * Should still get prompt to create profile
 * Click to complete the profile, but do not complete it (do not add any destinations)
 * Log out/back in
 * Search for the created, incomplete profile
 * Should be directed to profile page


Closes #184.
