### PR TITLE
Round trip times and show drive times

### DIFF
--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -4,6 +4,7 @@ import message from '@conveyal/woonerf/message'
 import uniq from 'lodash/uniq'
 import {PureComponent} from 'react'
 
+import {ROUND_TRIP_MINUTES} from '../constants'
 import type {AccountProfile, NeighborhoodImageMetadata, NeighborhoodLabels} from '../types'
 import getCraigslistSearchLink from '../utils/craigslist-search-link'
 import getGoogleDirectionsLink from '../utils/google-directions-link'
@@ -193,6 +194,8 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
     const bestJourney = neighborhood.segments && neighborhood.segments.length
       ? neighborhood.segments[0] : null
 
+    const roundedTripTime = Math.round(neighborhood.time / ROUND_TRIP_MINUTES) * ROUND_TRIP_MINUTES
+
     return (
       <div className='neighborhood-details'>
         <header className='neighborhood-details__header'>
@@ -204,14 +207,14 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
           {town} &ndash; {id}
           <Icon className='neighborhood-details__marker' type='map-marker' />
         </header>
-        {!hasVehicle && <div className='neighborhood-details__trip'>
+        <div className='neighborhood-details__trip'>
           {message('Units.About')}&nbsp;
-          {Math.round(neighborhood.time)}&nbsp;
+          {roundedTripTime}&nbsp;
           {message('Units.Mins')}&nbsp;
           <ModesList segments={bestJourney} />&nbsp;
           {message('NeighborhoodDetails.FromOrigin')}&nbsp;
           {currentDestination && currentDestination.purpose.toLowerCase()}
-        </div>}
+        </div>
         {!hasVehicle && <RouteSegments
           hasVehicle={hasVehicle}
           routeSegments={neighborhood.segments}

--- a/taui/src/components/route-card.js
+++ b/taui/src/components/route-card.js
@@ -3,6 +3,7 @@ import Icon from '@conveyal/woonerf/components/icon'
 import message from '@conveyal/woonerf/message'
 import React from 'react'
 
+import {ROUND_TRIP_MINUTES} from '../constants'
 import type {NeighborhoodImageMetadata} from '../types'
 import {getFirstNeighborhoodImage} from '../utils/neighborhood-images'
 
@@ -61,6 +62,8 @@ export default class RouteCard extends React.PureComponent<Props> {
 
     const SummaryImage = this.summaryImage
 
+    const roundedTripTime = Math.round(time / ROUND_TRIP_MINUTES) * ROUND_TRIP_MINUTES
+
     return (
       <div
         className='neighborhood-summary'
@@ -84,9 +87,9 @@ export default class RouteCard extends React.PureComponent<Props> {
           <div className='neighborhood-summary__descriptive'>
             <SummaryImage nprops={neighborhood.properties} />
             <div className='neighborhood-summary__trip'>
-              {!userProfile.hasVehicle && <div className='neighborhood-summary__duration'>
-                {message('Units.About')} {Math.round(time)} {message('Units.Mins')}
-              </div>}
+              <div className='neighborhood-summary__duration'>
+                {message('Units.About')} {roundedTripTime} {message('Units.Mins')}
+              </div>
               <div className='neighborhood-summary__trajectory'>
                 <span className='neighborhood-summary__mode'>
                   {message(modeKey)}

--- a/taui/src/constants.js
+++ b/taui/src/constants.js
@@ -15,6 +15,9 @@ export const IMAGE_FIELDS = [
 // Maximum number of destinations that may be added to a user profile
 export const MAX_ADDRESSES = 3
 
+// Round travel times to nearest five minutes
+export const ROUND_TRIP_MINUTES = 5
+
 // Maximum number of rooms for user profile
 export const MAX_ROOMS = 6
 


### PR DESCRIPTION
## Overview

Round travel times to nearest five minutes, and show estimated drive times.


### Demo

82 minutes transit time, rounded to 80:
![image](https://user-images.githubusercontent.com/960264/58589886-ed224d00-8230-11e9-813b-2e393840e78b.png)

also in details:
![image](https://user-images.githubusercontent.com/960264/58589913-fca19600-8230-11e9-9e76-9ce1f396c68d.png)

rounded drive times display:
![image](https://user-images.githubusercontent.com/960264/58589971-14791a00-8231-11e9-9ffe-15d117291463.png)


### Notes

The 'About' term indicating the travel time is an estimate is the same for transit and driving. There's nothing to indicate to the user that the drive time estimates are far less accurate.


## Testing Instructions

 * Travel times should be rounded to nearest five minutes
 * Travel times should display in drive mode
 * Travel times should display as expected in both summary cards and details


Closes #181.
Closes #144.
