### PR TITLE
Pass maximum subsidy to housing search

### DIFF
--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -126,6 +126,7 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
     const destinationCoordinateString = origin.position.lat + ',' + origin.position.lon
     const originCoordinateString = neighborhood.geometry.coordinates[1] +
       ',' + neighborhood.geometry.coordinates[0]
+    const maxSubsidy = neighborhood.properties['max_rent_' + userProfile.rooms + 'br']
 
     return (
       <>
@@ -167,7 +168,8 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
             className='neighborhood-details__link'
             href={getCraigslistSearchLink(
               neighborhood.properties.id,
-              userProfile.rooms)}
+              userProfile.rooms,
+              maxSubsidy)}
             target='_blank'
           >
             {message('NeighborhoodDetails.CraigslistSearchLink')}
@@ -176,7 +178,8 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
             className='neighborhood-details__link'
             href={getZillowSearchLink(
               neighborhood.properties.id,
-              userProfile.rooms)}
+              userProfile.rooms,
+              maxSubsidy)}
             target='_blank'
           >
             {message('NeighborhoodDetails.ZillowSearchLink')}

--- a/taui/src/utils/craigslist-search-link.js
+++ b/taui/src/utils/craigslist-search-link.js
@@ -1,7 +1,8 @@
 // @flow
 // Returns a link to Boston area Craigslist housing search for zipcode and number of bedrooms
 const CRAIGSLIST_BASE_URL = 'https://boston.craigslist.org/search/aap?postal='
-export default function getCraigslistSearchLink (zipcode, rooms) {
+export default function getCraigslistSearchLink (zipcode, rooms, maxSubsidy) {
   return CRAIGSLIST_BASE_URL + encodeURIComponent(zipcode) + '&min_bedrooms=' +
-    encodeURIComponent(rooms) + '&max_bedrooms=' + encodeURIComponent(rooms)
+    encodeURIComponent(rooms) + '&max_bedrooms=' + encodeURIComponent(rooms) +
+    '&max_price=' + encodeURIComponent(maxSubsidy)
 }

--- a/taui/src/utils/zillow-search-link.js
+++ b/taui/src/utils/zillow-search-link.js
@@ -1,8 +1,11 @@
 // @flow
 // Returns a link to Zillow rental search for zipcode and number of bedrooms
 const ZILLOW_BASE_URL = 'https://www.zillow.com/homes/for_rent/'
-export default function getZillowSearchLink (zipcode, rooms) {
-  const zipcodeSearch = ZILLOW_BASE_URL + encodeURIComponent(zipcode) + '_rb/'
-  return parseInt(rooms) > 0
-    ? zipcodeSearch + encodeURIComponent(rooms) + '-_beds' : zipcodeSearch
+export default function getZillowSearchLink (zipcode, rooms, maxSubsidy) {
+  let zipcodeSearch = ZILLOW_BASE_URL + encodeURIComponent(zipcode) + '_rb/' +
+    '0-' + encodeURIComponent(maxSubsidy) + '_mp/'
+  if (parseInt(rooms) > 0) {
+    zipcodeSearch += encodeURIComponent(rooms) + '-_beds'
+  }
+  return zipcodeSearch
 }


### PR DESCRIPTION
## Overview

Add parameters for max price to Craigslist and Zillow searches.


### Demo

Searches are for zip code 02467 (Chestnut Hill).

Studio Craigslist:
![image](https://user-images.githubusercontent.com/960264/58646216-ef3ce800-82d2-11e9-85d2-426eb2086275.png)

Studio Zillow:
![image](https://user-images.githubusercontent.com/960264/58646288-17c4e200-82d3-11e9-9c3a-409046af3e01.png)

6 bedroom Cragslist:
![image](https://user-images.githubusercontent.com/960264/58646395-45aa2680-82d3-11e9-8b18-d7e0822ae252.png)

6 bedroom Zillow:
![image](https://user-images.githubusercontent.com/960264/58646528-96218400-82d3-11e9-8f0a-0837c2e71e9f.png)


## Testing Instructions

 * Craigslist and Zillow links from neighborhood details should search with max price
 * Max price should vary by neighborhood and number of bedrooms on user profile


Closes #171.
