### PR TITLE
Display destination type label in drop-down

### DIFF
--- a/taui/src/components/form.js
+++ b/taui/src/components/form.js
@@ -100,7 +100,7 @@ export default class Form extends React.PureComponent<Props> {
     }
     const position = destination.location.position
     return (position.lat !== 0 && position.lon !== 0) ? {
-      label: destination.location.label,
+      label: destination.purpose + ': ' + destination.location.label,
       position: position
     } : null
   }
@@ -133,7 +133,12 @@ export default class Form extends React.PureComponent<Props> {
     const {userProfile} = this.props
     const {destination, network} = this.state
     const destinations: Array<AccountAddress> = userProfile ? userProfile.destinations : []
-    const locations = destinations.map(d => d.location)
+    const locations = destinations.map(d => {
+      return {
+        label: d.purpose + ': ' + d.location.label,
+        position: d.location.position
+      }
+    })
     const destinationFilterOptions = createDestinationsFilter(locations)
     const useNetworks = this.getProfileNetworks(this.props.networks, userProfile)
     const networks = useNetworks.map(n => ({label: n.name, value: n.url}))


### PR DESCRIPTION
## Overview

Display destination purpose type before the address in the map page destination drop-down.


### Demo

![echo_labeled_addresses_dropdown](https://user-images.githubusercontent.com/960264/58649069-3037fb00-82d9-11e9-83a2-41c7ea294270.png)


## Testing Instructions

 * Map page should load with [destination type]: [address] in the destination drop-down text field
 * Drop-down options should match above format
 * Toggling destination should still behave as expected


Closes #183.
