### PR TITLE
UI enhancements

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -59,6 +59,7 @@ NeighborhoodDetails:
 NeighborhoodInfo:
   EducationCategory: Schools
   Population: Population
+  RentalUnits: Rental units
   Score: Overall score
   ViolentCrime: Public safety
 PageNotFound: Oops! There is no page at

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -99,6 +99,9 @@ Profile:
   AddAddress: Add another destination
   Address: Address
   AddressMissing: All destinations should have an address. Please set or remove any empty destinations.
+  ByCar: Car
+  ByTransit: Transit
+  ChooseTravelMode: Will travel by
   DeleteAddress: Delete this address
   DeletePrimaryAddressError: Cannot delete primary destination. Set another as the primary first.
   Cancel: Cancel
@@ -113,12 +116,11 @@ Profile:
   Primary: Primary
   Purpose: Purpose
   Rooms: Number of rooms in voucher
-  HasVehicle: Will have a car
   Go: Save profile
   NameRequired: Please enter a name for the head of household.
   SaveError: Failed to save profile. Please try again.
   Title: Profile
-  UseCommuterRail: Can take commuter rail or express bus
+  UseCommuterRail: Include commuter rail and express bus
 ImportanceLabels:
   1: Not important
   2: Somewhat important

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -44,17 +44,23 @@ Dock:
   ShowAllButton: All
   ShowSavedButton: Saved
 NeighborhoodDetails:
+  AboutNeighborhoodLinksHeading: Learn about this neighborhood
+  ChildCareSearchLink: Child Care Search
   CraigslistSearchLink: Craigslist
-  DriveMode: drive
-  TransitMode: transit
-  FromOrigin: from
   DirectionsLink: Directions
+  DriveMode: drive
+  FromOrigin: from
+  GoogleSearchLink: Google
+  GoogleMapsLink: Google Maps
+  MassHousingLink: Mass Housing
+  MaxRent: Est. max rent
+  ModeSummary: via
+  MoreSearchToolsLinksHeading: More search tools
+  Section8Link: Section 8
+  TransitMode: transit
   WebsiteLink: Website
   WikipediaAttribution: via Wikimedia Commons
   WikipediaLink: Wikipedia
-  GoogleSearchLink: Google
-  GoogleMapsLink: Google Maps
-  ModeSummary: via
   ZillowSearchLink: Zillow
 NeighborhoodInfo:
   EducationCategory: Schools

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -46,6 +46,7 @@ NeighborhoodDetails:
   DriveMode: drive
   TransitMode: transit
   FromOrigin: from
+  DirectionsLink: Directions
   WebsiteLink: Website
   WikipediaAttribution: via Wikimedia Commons
   WikipediaLink: Wikipedia

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -32,6 +32,8 @@ Map:
     SetEnd: Set end
     ClearMarkers: Clear markers
 Dock:
+  LocationLabel: From
+  NetworkLabel: When
   Favorites: Saved recommendations
   GoBackToRecommendations: Back to recommendations
   GoBackToFavorites: Back to saved recommendations

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -107,14 +107,14 @@ Profile:
   DeleteProfileError: Failed to delete profile. Please try again.
   Destinations: Frequent destinations
   ImportanceAccessibility: Travel time
-  ImportanceHeading: How important are the following?
+  ImportanceHeading: How important are these factors when choosing a home?
   ImportanceSchools: School quality
   ImportanceViolentCrime: Public safety
   Primary: Primary
   Purpose: Purpose
   Rooms: Number of rooms in voucher
   HasVehicle: Will have a car
-  Go: Go
+  Go: Save profile
   NameRequired: Please enter a name for the head of household.
   SaveError: Failed to save profile. Please try again.
   Title: Profile

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -57,7 +57,7 @@ NeighborhoodInfo:
   EducationCategory: Schools
   Population: Population
   Score: Overall score
-  ViolentCrime: Violent crime
+  ViolentCrime: Public safety
 PageNotFound: Oops! There is no page at
 RouteCard:
   MarkerLink: Show neighborhood on map
@@ -106,7 +106,7 @@ Profile:
   ImportanceAccessibility: Travel time
   ImportanceHeading: How important are the following?
   ImportanceSchools: School quality
-  ImportanceViolentCrime: Violent crime
+  ImportanceViolentCrime: Public safety
   Primary: Primary
   Purpose: Purpose
   Rooms: Number of rooms in voucher

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -496,34 +496,57 @@ export default class EditProfile extends PureComponent<Props> {
                 rooms={rooms}
                 changeField={changeField} />
             </div>
-            <div className='account-profile__field account-profile__field--inline'>
-              <input
-                className='account-profile__input account-profile__input--checkbox'
-                id='hasVehicle'
-                type='checkbox'
-                onChange={(e) => changeField('hasVehicle', e.currentTarget.checked)}
-                defaultChecked={hasVehicle}
-              />
-              <label
+            <div className='account-profile__field'>
+              <div
                 className='account-profile__label'
-                htmlFor='hasVehicle'>
-                {message('Profile.HasVehicle')}
-              </label>
+                htmlFor='rooms'>{message('Profile.ChooseTravelMode')}</div>
+              <div className='account-profile__field-row'>
+                <div className='account-profile__field account-profile__field--inline'>
+                  <input
+                    className='account-profile__input account-profile__input--checkbox'
+                    id='byCar'
+                    name='travelMode'
+                    type='radio'
+                    onChange={(e) => changeField('hasVehicle', e.currentTarget.checked)}
+                    defaultChecked={hasVehicle}
+                  />
+                  <label
+                    className='account-profile__label account-profile__label--secondary'
+                    htmlFor='byCar'>
+                    {message('Profile.ByCar')}
+                  </label>
+                </div>
+                <div className='account-profile__field account-profile__field--inline'>
+                  <input
+                    className='account-profile__input account-profile__input--checkbox'
+                    id='byTransit'
+                    name='travelMode'
+                    type='radio'
+                    onChange={(e) => changeField('hasVehicle', !e.currentTarget.checked)}
+                    defaultChecked={!hasVehicle}
+                  />
+                  <label
+                    className='account-profile__label account-profile__label--secondary'
+                    htmlFor='byTransit'>
+                    {message('Profile.ByTransit')}
+                  </label>
+                </div>
+                {!hasVehicle && <div className='account-profile__field account-profile__field--inline'>
+                  <input
+                    className='account-profile__input account-profile__input--checkbox'
+                    id='useCommuterRail'
+                    type='checkbox'
+                    onChange={(e) => changeField('useCommuterRail', e.currentTarget.checked)}
+                    defaultChecked={useCommuterRail}
+                  />
+                  <label
+                    className='account-profile__label account-profile__label--secondary'
+                    htmlFor='useCommuterRail'>
+                    {message('Profile.UseCommuterRail')}
+                  </label>
+                </div>}
+              </div>
             </div>
-            {!hasVehicle && <div className='account-profile__field account-profile__field--inline'>
-              <input
-                className='account-profile__input account-profile__input--checkbox'
-                id='useCommuterRail'
-                type='checkbox'
-                onChange={(e) => changeField('useCommuterRail', e.currentTarget.checked)}
-                defaultChecked={useCommuterRail}
-              />
-              <label
-                className='account-profile__label'
-                htmlFor='useCommuterRail'>
-                {message('Profile.UseCommuterRail')}
-              </label>
-            </div>}
             <DestinationsList
               addAddress={addAddress}
               deleteAddress={deleteAddress}

--- a/taui/src/components/form.js
+++ b/taui/src/components/form.js
@@ -148,27 +148,35 @@ export default class Form extends React.PureComponent<Props> {
 
     return (
       <div className='map-sidebar__travel-form'>
-        <Select
-          clearable={false}
-          filterOptions={destinationFilterOptions}
-          options={locations}
-          optionHeight={38}
-          onChange={this.selectDestination}
-          placeholder={message('Geocoding.StartPlaceholder')}
-          style={SELECT_STYLE}
-          wrapperStyle={SELECT_WRAPPER_STYLE}
-          value={destination}
-        />
-        {!userProfile.hasVehicle && <Select
-          clearable={false}
-          filterOptions={networkFilterOptions}
-          options={networks}
-          onChange={(e) => setNetwork(e)}
-          placeholder={message('Map.SelectNetwork')}
-          style={SELECT_STYLE}
-          wrapperStyle={SELECT_WRAPPER_STYLE}
-          value={network}
-        />}
+        <div className='map-sidebar__field'>
+          <label className='map-sidebar__label'>{message('Dock.LocationLabel')}:</label>
+          <Select
+            className='map-sidebar__select'
+            clearable={false}
+            filterOptions={destinationFilterOptions}
+            options={locations}
+            optionHeight={38}
+            onChange={this.selectDestination}
+            placeholder={message('Geocoding.StartPlaceholder')}
+            style={SELECT_STYLE}
+            wrapperStyle={SELECT_WRAPPER_STYLE}
+            value={destination}
+          />
+        </div>
+        {!userProfile.hasVehicle && <div className='map-sidebar__field'>
+          <label className='map-sidebar__label'>{message('Dock.NetworkLabel')}:</label>
+          <Select
+            className='map-sidebar__select'
+            clearable={false}
+            filterOptions={networkFilterOptions}
+            options={networks}
+            onChange={(e) => setNetwork(e)}
+            placeholder={message('Map.SelectNetwork')}
+            style={SELECT_STYLE}
+            wrapperStyle={SELECT_WRAPPER_STYLE}
+            value={network}
+          />
+        </div>}
       </div>
     )
   }

--- a/taui/src/components/form.js
+++ b/taui/src/components/form.js
@@ -149,7 +149,7 @@ export default class Form extends React.PureComponent<Props> {
     return (
       <div className='map-sidebar__travel-form'>
         <div className='map-sidebar__field'>
-          <label className='map-sidebar__label'>{message('Dock.LocationLabel')}:</label>
+          <label className='map-sidebar__label'>{message('Dock.LocationLabel')}</label>
           <Select
             className='map-sidebar__select'
             clearable={false}
@@ -164,7 +164,7 @@ export default class Form extends React.PureComponent<Props> {
           />
         </div>
         {!userProfile.hasVehicle && <div className='map-sidebar__field'>
-          <label className='map-sidebar__label'>{message('Dock.NetworkLabel')}:</label>
+          <label className='map-sidebar__label'>{message('Dock.NetworkLabel')}</label>
           <Select
             className='map-sidebar__select'
             clearable={false}

--- a/taui/src/components/form.js
+++ b/taui/src/components/form.js
@@ -8,7 +8,7 @@ import React from 'react'
 import Select from 'react-virtualized-select'
 import createFilterOptions from 'react-select-fast-filter-options'
 
-import {SELECT_STYLE, SELECT_WRAPPER_STYLE} from '../constants'
+import {SELECT_STYLE, SELECT_WRAPPER_STYLE, SELECT_OPTION_HEIGHT} from '../constants'
 import type {
   AccountAddress,
   AccountProfile,
@@ -155,7 +155,7 @@ export default class Form extends React.PureComponent<Props> {
             clearable={false}
             filterOptions={destinationFilterOptions}
             options={locations}
-            optionHeight={38}
+            optionHeight={SELECT_OPTION_HEIGHT}
             onChange={this.selectDestination}
             placeholder={message('Geocoding.StartPlaceholder')}
             style={SELECT_STYLE}
@@ -170,6 +170,7 @@ export default class Form extends React.PureComponent<Props> {
             clearable={false}
             filterOptions={networkFilterOptions}
             options={networks}
+            optionHeight={SELECT_OPTION_HEIGHT}
             onChange={(e) => setNetwork(e)}
             placeholder={message('Map.SelectNetwork')}
             style={SELECT_STYLE}

--- a/taui/src/components/meter.js
+++ b/taui/src/components/meter.js
@@ -1,0 +1,42 @@
+// @flow
+export default function Meter ({
+  value,
+  max = 100,
+  average,
+  tier,
+  width = 100,
+  height = 12,
+  tooltip
+}) {
+  return (
+    <svg
+      className='meter'
+      viewBox={`0 0 ${width} ${height}`}
+      width={width}
+      height={height}
+      title={tooltip}
+    >
+      <rect
+        className='meter__track'
+        x='0'
+        y='0'
+        width={width}
+        height={height}
+      />
+      <rect
+        className={`meter__fill meter__fill--${tier}`}
+        x='0'
+        y='0'
+        width={(value / max) * width}
+        height={height}
+      />
+      <rect
+        className='meter__average'
+        x={(average / max) * width}
+        y='0'
+        width='1'
+        height={height}
+      />
+    </svg>
+  )
+}

--- a/taui/src/components/meter.js
+++ b/taui/src/components/meter.js
@@ -8,35 +8,43 @@ export default function Meter ({
   height = 12,
   tooltip
 }) {
+  const percentage = value / max
+  const percentageLabel = Math.round(percentage * 100)
+
   return (
-    <svg
-      className='meter'
-      viewBox={`0 0 ${width} ${height}`}
-      width={width}
-      height={height}
-      title={tooltip}
-    >
-      <rect
-        className='meter__track'
-        x='0'
-        y='0'
+    <div className='meter'>
+      <svg
+        className='meter__chart'
+        viewBox={`0 0 ${width} ${height}`}
         width={width}
         height={height}
-      />
-      <rect
-        className={`meter__fill meter__fill--${tier}`}
-        x='0'
-        y='0'
-        width={(value / max) * width}
-        height={height}
-      />
-      <rect
-        className='meter__average'
-        x={(average / max) * width}
-        y='0'
-        width='1'
-        height={height}
-      />
-    </svg>
+        title={tooltip}
+      >
+        <rect
+          className='meter__track'
+          x='0'
+          y='0'
+          width={width}
+          height={height}
+        />
+        <rect
+          className={`meter__fill meter__fill--${tier}`}
+          x='0'
+          y='0'
+          width={percentage * width}
+          height={height}
+        />
+        <rect
+          className='meter__average'
+          x={(average / max) * width}
+          y='0'
+          width='1'
+          height={height}
+        />
+      </svg>
+      <span className='meter__percentage'>
+        {percentageLabel}%
+      </span>
+    </div>
   )
 }

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -48,13 +48,16 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
   }
 
   neighborhoodStats (props) {
-    const { neighborhood } = props
+    const { neighborhood, userProfile } = props
+    const { rooms } = userProfile
+    const maxSubsidy = neighborhood.properties['max_rent_' + rooms + 'br'] || '–––'
+
     return (
       <div className='neighborhood-details__stats'>
         <div className='neighborhood-details__rent'>
           <div className='neighborhood-details__rent-label'>{message('NeighborhoodDetails.MaxRent')}</div>
-          <div className='neighborhood-details__rent-value'>$2500</div>
-          <div className='neighborhood-details__rent-rooms'>3br</div>
+          <div className='neighborhood-details__rent-value'>${maxSubsidy}</div>
+          <div className='neighborhood-details__rent-rooms'>{rooms}br</div>
         </div>
         <NeighborhoodListInfo neighborhood={neighborhood} />
       </div>
@@ -108,12 +111,13 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
 
   neighborhoodLinks (props) {
     const { neighborhood, userProfile } = props
-    const maxSubsidy = neighborhood.properties['max_rent_' + userProfile.rooms + 'br']
+    const { rooms } = userProfile
+    const maxSubsidy = neighborhood.properties['max_rent_' + rooms + 'br']
 
     return (
       <>
         <h6 className='neighborhood-details__link-heading'>
-          Search for 3br with max rent $2500
+          Search for {rooms}br with max rent ${maxSubsidy}
         </h6>
         <div className='neighborhood-details__links'>
           <a
@@ -267,7 +271,9 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
           />}
         </div>
         <div className='neighborhood-details__section'>
-          <NeighborhoodStats neighborhood={neighborhood} />
+          <NeighborhoodStats
+            neighborhood={neighborhood}
+            userProfile={userProfile} />
         </div>
         <div className='neighborhood-details__section'>
           <NeighborhoodLinks

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -9,6 +9,7 @@ import type {AccountProfile, NeighborhoodImageMetadata, NeighborhoodLabels} from
 import getCraigslistSearchLink from '../utils/craigslist-search-link'
 import getGoogleDirectionsLink from '../utils/google-directions-link'
 import getGoogleSearchLink from '../utils/google-search-link'
+import getGoogleMapsLink from '../utils/google-maps-link'
 import getNeighborhoodImage from '../utils/neighborhood-images'
 import getNeighborhoodPropertyLabels from '../utils/neighborhood-properties'
 import getZillowSearchLink from '../utils/zillow-search-link'
@@ -122,11 +123,7 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
   }
 
   neighborhoodLinks (props) {
-    const { hasVehicle, neighborhood, origin, userProfile } = props
-    // lat,lon strings for Google Directions link from neighborhood to current destination
-    const destinationCoordinateString = origin.position.lat + ',' + origin.position.lon
-    const originCoordinateString = neighborhood.geometry.coordinates[1] +
-      ',' + neighborhood.geometry.coordinates[0]
+    const { neighborhood, userProfile } = props
     const maxSubsidy = neighborhood.properties['max_rent_' + userProfile.rooms + 'br']
 
     return (
@@ -155,10 +152,7 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
           </a>
           <a
             className='neighborhood-details__link'
-            href={getGoogleDirectionsLink(
-              originCoordinateString,
-              destinationCoordinateString,
-              hasVehicle)}
+            href={getGoogleMapsLink(neighborhood.properties.id)}
             target='_blank'
           >
             {message('NeighborhoodDetails.GoogleMapsLink')}
@@ -204,7 +198,7 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
 
     // Look up the currently selected user profile destination from the origin
     const originLabel = origin ? origin.label || '' : ''
-    const currentDestination = userProfile.destinations.find(d => d.location.label === originLabel)
+    const currentDestination = userProfile.destinations.find(d => originLabel.endsWith(d.location.label))
     const { id, town } = neighborhood.properties
     const description = neighborhood.properties['town_website_description']
 
@@ -212,6 +206,11 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
       ? neighborhood.segments[0] : null
 
     const roundedTripTime = Math.round(neighborhood.time / ROUND_TRIP_MINUTES) * ROUND_TRIP_MINUTES
+
+    // lat,lon strings for Google Directions link from neighborhood to current destination
+    const destinationCoordinateString = origin.position.lat + ',' + origin.position.lon
+    const originCoordinateString = neighborhood.geometry.coordinates[1] +
+      ',' + neighborhood.geometry.coordinates[0]
 
     return (
       <div className='neighborhood-details'>
@@ -231,6 +230,16 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
           <ModesList segments={bestJourney} />&nbsp;
           {message('NeighborhoodDetails.FromOrigin')}&nbsp;
           {currentDestination && currentDestination.purpose.toLowerCase()}
+          {hasVehicle && <a
+            className='neighborhood-details__directions'
+            href={getGoogleDirectionsLink(
+              originCoordinateString,
+              destinationCoordinateString,
+              hasVehicle)}
+            target='_blank'
+          >
+            {message('NeighborhoodDetails.DirectionsLink')}
+          </a>}
         </div>
         {!hasVehicle && <RouteSegments
           hasVehicle={hasVehicle}

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -5,15 +5,15 @@ import uniq from 'lodash/uniq'
 import {PureComponent} from 'react'
 
 import {ROUND_TRIP_MINUTES} from '../constants'
-import type {AccountProfile, NeighborhoodImageMetadata, NeighborhoodLabels} from '../types'
+import type {AccountProfile, NeighborhoodImageMetadata} from '../types'
 import getCraigslistSearchLink from '../utils/craigslist-search-link'
 import getGoogleDirectionsLink from '../utils/google-directions-link'
 import getGoogleSearchLink from '../utils/google-search-link'
 import getGoogleMapsLink from '../utils/google-maps-link'
 import getNeighborhoodImage from '../utils/neighborhood-images'
-import getNeighborhoodPropertyLabels from '../utils/neighborhood-properties'
 import getZillowSearchLink from '../utils/zillow-search-link'
 
+import NeighborhoodListInfo from './neighborhood-list-info'
 import RouteSegments from './route-segments'
 
 type Props = {
@@ -33,7 +33,7 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
       : false
     }
 
-    this.neighborhoodDetailsTable = this.neighborhoodDetailsTable.bind(this)
+    this.neighborhoodStats = this.neighborhoodStats.bind(this)
     this.neighborhoodImage = this.neighborhoodImage.bind(this)
     this.neighborhoodImages = this.neighborhoodImages.bind(this)
     this.neighborhoodLinks = this.neighborhoodLinks.bind(this)
@@ -47,33 +47,17 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
     }
   }
 
-  neighborhoodDetailsTable (props) {
+  neighborhoodStats (props) {
     const { neighborhood } = props
-    const labels: NeighborhoodLabels = getNeighborhoodPropertyLabels(neighborhood.properties)
-
-    // Overall score is a derived value and not a neighborhood property (so not in `labels`).
-    const overallScore = neighborhood.score
-      ? neighborhood.score.toLocaleString('en-US', {style: 'percent'})
-      : message('UnknownValue')
-
-    const tableData = [
-      {label: 'NeighborhoodInfo.Score', value: overallScore},
-      {label: 'NeighborhoodInfo.ViolentCrime', value: labels.violentCrime},
-      {label: 'NeighborhoodInfo.EducationCategory', value: labels.education},
-      {label: 'NeighborhoodInfo.Population', value: labels.population}
-    ]
-
     return (
-      <table className='neighborhood-details__facts'>
-        <tbody>
-          {tableData.map(data => (
-            <tr className='neighborhood-details__row' key={data.label}>
-              <td className='neighborhood-details__cell'>{message(data.label)}:</td>
-              <td className='neighborhood-details__cell'>{data.value}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <div className='neighborhood-details__stats'>
+        <div className='neighborhood-details__rent'>
+          <div className='neighborhood-details__rent-label'>{message('NeighborhoodDetails.MaxRent')}</div>
+          <div className='neighborhood-details__rent-value'>$2500</div>
+          <div className='neighborhood-details__rent-rooms'>3br</div>
+        </div>
+        <NeighborhoodListInfo neighborhood={neighborhood} />
+      </div>
     )
   }
 
@@ -128,6 +112,60 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
 
     return (
       <>
+        <h6 className='neighborhood-details__link-heading'>
+          Search for 3br with max rent $2500
+        </h6>
+        <div className='neighborhood-details__links'>
+          <a
+            className='neighborhood-details__link'
+            href='/'
+            target='_blank'
+          >
+            {message('NeighborhoodDetails.Section8Link')}
+          </a>
+          <a
+            className='neighborhood-details__link'
+            href={getZillowSearchLink(
+              neighborhood.properties.id,
+              userProfile.rooms,
+              maxSubsidy)}
+            target='_blank'
+          >
+            {message('NeighborhoodDetails.ZillowSearchLink')}
+          </a>
+          <a
+            className='neighborhood-details__link'
+            href={getCraigslistSearchLink(
+              neighborhood.properties.id,
+              userProfile.rooms,
+              maxSubsidy)}
+            target='_blank'
+          >
+            {message('NeighborhoodDetails.CraigslistSearchLink')}
+          </a>
+        </div>
+        <h6 className='neighborhood-details__link-heading'>
+          {message('NeighborhoodDetails.MoreSearchToolsLinksHeading')}
+        </h6>
+        <div className='neighborhood-details__links'>
+          <a
+            className='neighborhood-details__link'
+            href='https://www.masshousing.com/portal/server.pt/community/rental_housing/240/looking_for_an_affordable_apartment_'
+            target='_blank'
+          >
+            {message('NeighborhoodDetails.MassHousingLink')}
+          </a>
+          <a
+            className='neighborhood-details__link'
+            href='https://eeclead.force.com/EEC_ChildCareSearch'
+            target='_blank'
+          >
+            {message('NeighborhoodDetails.ChildCareSearchLink')}
+          </a>
+        </div>
+        <h6 className='neighborhood-details__link-heading'>
+          {message('NeighborhoodDetails.AboutNeighborhoodLinksHeading')}
+        </h6>
         <div className='neighborhood-details__links'>
           {neighborhood.properties.town_link && <a
             className='neighborhood-details__link'
@@ -158,28 +196,6 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
             {message('NeighborhoodDetails.GoogleMapsLink')}
           </a>
         </div>
-        <div className='neighborhood-details__links'>
-          <a
-            className='neighborhood-details__link'
-            href={getCraigslistSearchLink(
-              neighborhood.properties.id,
-              userProfile.rooms,
-              maxSubsidy)}
-            target='_blank'
-          >
-            {message('NeighborhoodDetails.CraigslistSearchLink')}
-          </a>
-          <a
-            className='neighborhood-details__link'
-            href={getZillowSearchLink(
-              neighborhood.properties.id,
-              userProfile.rooms,
-              maxSubsidy)}
-            target='_blank'
-          >
-            {message('NeighborhoodDetails.ZillowSearchLink')}
-          </a>
-        </div>
       </>
     )
   }
@@ -188,7 +204,7 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
     const { changeUserProfile, neighborhood, origin, setFavorite, userProfile } = this.props
     const isFavorite = this.state.isFavorite
     const hasVehicle = userProfile ? userProfile.hasVehicle : false
-    const NeighborhoodDetailsTable = this.neighborhoodDetailsTable
+    const NeighborhoodStats = this.neighborhoodStats
     const NeighborhoodImages = this.neighborhoodImages
     const NeighborhoodLinks = this.neighborhoodLinks
 
@@ -214,48 +230,58 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
 
     return (
       <div className='neighborhood-details'>
-        <header className='neighborhood-details__header'>
-          <Icon
-            className='neighborhood-details__star'
-            type={isFavorite ? 'star' : 'star-o'}
-            onClick={(e) => setFavorite(id, userProfile, changeUserProfile)}
-          />
-          {town} &ndash; {id}
-          <Icon className='neighborhood-details__marker' type='map-marker' />
-        </header>
-        <div className='neighborhood-details__trip'>
-          {message('Units.About')}&nbsp;
-          {roundedTripTime}&nbsp;
-          {message('Units.Mins')}&nbsp;
-          <ModesList segments={bestJourney} />&nbsp;
-          {message('NeighborhoodDetails.FromOrigin')}&nbsp;
-          {currentDestination && currentDestination.purpose.toLowerCase()}
-          {hasVehicle && <a
-            className='neighborhood-details__directions'
-            href={getGoogleDirectionsLink(
-              originCoordinateString,
-              destinationCoordinateString,
-              hasVehicle)}
-            target='_blank'
-          >
-            {message('NeighborhoodDetails.DirectionsLink')}
-          </a>}
+        <div className='neighborhood-details__section'>
+          <header className='neighborhood-details__header'>
+            <Icon
+              className='neighborhood-details__star'
+              type={isFavorite ? 'star' : 'star-o'}
+              onClick={(e) => setFavorite(id, userProfile, changeUserProfile)}
+            />
+            <div className='neighborhood-details__name'>{town} &ndash; {id}</div>
+            <Icon className='neighborhood-details__marker' type='map-marker' />
+          </header>
         </div>
-        {!hasVehicle && <RouteSegments
-          hasVehicle={hasVehicle}
-          routeSegments={neighborhood.segments}
-          travelTime={neighborhood.time}
-        />}
-        <NeighborhoodImages neighborhood={neighborhood} />
-        <div className='neighborhood-details__desc'>
-          {description}
+        <div className='neighborhood-details__section'>
+          <div className='neighborhood-details__trip'>
+            {message('Units.About')}&nbsp;
+            {roundedTripTime}&nbsp;
+            {message('Units.Mins')}&nbsp;
+            <ModesList segments={bestJourney} />&nbsp;
+            {message('NeighborhoodDetails.FromOrigin')}&nbsp;
+            {currentDestination && currentDestination.purpose.toLowerCase()}
+            {hasVehicle && <a
+              className='neighborhood-details__directions'
+              href={getGoogleDirectionsLink(
+                originCoordinateString,
+                destinationCoordinateString,
+                hasVehicle)}
+              target='_blank'
+            >
+              {message('NeighborhoodDetails.DirectionsLink')}
+            </a>}
+          </div>
+          {!hasVehicle && <RouteSegments
+            hasVehicle={hasVehicle}
+            routeSegments={neighborhood.segments}
+            travelTime={neighborhood.time}
+          />}
         </div>
-        <NeighborhoodLinks
-          hasVehicle={hasVehicle}
-          neighborhood={neighborhood}
-          origin={origin}
-          userProfile={userProfile} />
-        <NeighborhoodDetailsTable neighborhood={neighborhood} />
+        <div className='neighborhood-details__section'>
+          <NeighborhoodStats neighborhood={neighborhood} />
+        </div>
+        <div className='neighborhood-details__section'>
+          <NeighborhoodLinks
+            hasVehicle={hasVehicle}
+            neighborhood={neighborhood}
+            origin={origin}
+            userProfile={userProfile} />
+        </div>
+        <div className='neighborhood-details__section'>
+          <NeighborhoodImages neighborhood={neighborhood} />
+          <div className='neighborhood-details__desc'>
+            {description}
+          </div>
+        </div>
       </div>
     )
   }

--- a/taui/src/components/neighborhood-list-info.js
+++ b/taui/src/components/neighborhood-list-info.js
@@ -2,6 +2,7 @@
 import message from '@conveyal/woonerf/message'
 
 import Meter from './meter'
+import RentalUnitsMeter from './rental-units-meter'
 
 export default function NeighborhoodListInfo ({neighborhood}) {
   if (!neighborhood || !neighborhood.properties) {
@@ -14,31 +15,19 @@ export default function NeighborhoodListInfo ({neighborhood}) {
         <tr>
           <td className='neighborhood-summary__cell'>{message('NeighborhoodInfo.EducationCategory')}:</td>
           <td className='neighborhood-summary__cell'>
-            <div className='neighborhood-summary__value'>
-              <Meter value={86} average={58} tier='high' tooltip='hello' />
-              <span className='neighborhood-summary__percentage'>
-                86%
-              </span>
-            </div>
+            <Meter value={86} average={58} tier='high' tooltip='hello' />
           </td>
         </tr>
         <tr>
           <td className='neighborhood-summary__cell'>{message('NeighborhoodInfo.ViolentCrime')}:</td>
           <td className='neighborhood-summary__cell'>
-            <div className='neighborhood-summary__value'>
-              <Meter value={72} average={66} tier='med' />
-              <span className='neighborhood-summary__percentage'>
-                72%
-              </span>
-            </div>
+            <Meter value={72} average={66} tier='med' />
           </td>
         </tr>
         <tr>
           <td className='neighborhood-summary__cell'>{message('NeighborhoodInfo.RentalUnits')}:</td>
           <td className='neighborhood-summary__cell'>
-            <div className='neighborhood-summary__value'>
-              TK
-            </div>
+            <RentalUnitsMeter value={400} max={1000} tier='low' />
           </td>
         </tr>
       </tbody>

--- a/taui/src/components/neighborhood-list-info.js
+++ b/taui/src/components/neighborhood-list-info.js
@@ -10,23 +10,23 @@ export default function NeighborhoodListInfo ({neighborhood}) {
   }
 
   return (
-    <table className='neighborhood-summary__facts'>
+    <table className='neighborhood-facts'>
       <tbody>
         <tr>
-          <td className='neighborhood-summary__cell'>{message('NeighborhoodInfo.EducationCategory')}:</td>
-          <td className='neighborhood-summary__cell'>
+          <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.EducationCategory')}</td>
+          <td className='neighborhood-facts__cell'>
             <Meter value={86} average={58} tier='high' tooltip='hello' />
           </td>
         </tr>
         <tr>
-          <td className='neighborhood-summary__cell'>{message('NeighborhoodInfo.ViolentCrime')}:</td>
-          <td className='neighborhood-summary__cell'>
+          <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.ViolentCrime')}</td>
+          <td className='neighborhood-facts__cell'>
             <Meter value={72} average={66} tier='med' />
           </td>
         </tr>
         <tr>
-          <td className='neighborhood-summary__cell'>{message('NeighborhoodInfo.RentalUnits')}:</td>
-          <td className='neighborhood-summary__cell'>
+          <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.RentalUnits')}</td>
+          <td className='neighborhood-facts__cell'>
             <RentalUnitsMeter value={400} max={1000} tier='low' />
           </td>
         </tr>

--- a/taui/src/components/neighborhood-list-info.js
+++ b/taui/src/components/neighborhood-list-info.js
@@ -1,33 +1,45 @@
 // @flow
 import message from '@conveyal/woonerf/message'
 
-import {NeighborhoodLabels} from '../types'
-import getNeighborhoodPropertyLabels from '../utils/neighborhood-properties'
+import Meter from './meter'
 
 export default function NeighborhoodListInfo ({neighborhood}) {
   if (!neighborhood || !neighborhood.properties) {
     return null
   }
-  const labels: NeighborhoodLabels = getNeighborhoodPropertyLabels(neighborhood.properties)
-  // Overall score is a derived value and not a neighborhood property (so not in `labels`).
-  const overallScore = neighborhood.score
-    ? neighborhood.score.toLocaleString('en-US', {style: 'percent'})
-    : message('UnknownValue')
 
   return (
     <table className='neighborhood-summary__facts'>
       <tbody>
         <tr>
-          <td className='neighborhood-summary__cell'>{message('NeighborhoodInfo.Score')}:</td>
-          <td className='neighborhood-summary__cell'>{overallScore}</td>
+          <td className='neighborhood-summary__cell'>{message('NeighborhoodInfo.EducationCategory')}:</td>
+          <td className='neighborhood-summary__cell'>
+            <div className='neighborhood-summary__value'>
+              <Meter value={86} average={58} tier='high' tooltip='hello' />
+              <span className='neighborhood-summary__percentage'>
+                86%
+              </span>
+            </div>
+          </td>
         </tr>
         <tr>
           <td className='neighborhood-summary__cell'>{message('NeighborhoodInfo.ViolentCrime')}:</td>
-          <td className='neighborhood-summary__cell'>{labels.violentCrime}</td>
+          <td className='neighborhood-summary__cell'>
+            <div className='neighborhood-summary__value'>
+              <Meter value={72} average={66} tier='med' />
+              <span className='neighborhood-summary__percentage'>
+                72%
+              </span>
+            </div>
+          </td>
         </tr>
         <tr>
-          <td className='neighborhood-summary__cell'>{message('NeighborhoodInfo.EducationCategory')}:</td>
-          <td className='neighborhood-summary__cell'>{labels.education}</td>
+          <td className='neighborhood-summary__cell'>{message('NeighborhoodInfo.RentalUnits')}:</td>
+          <td className='neighborhood-summary__cell'>
+            <div className='neighborhood-summary__value'>
+              TK
+            </div>
+          </td>
         </tr>
       </tbody>
     </table>

--- a/taui/src/components/rental-units-meter.js
+++ b/taui/src/components/rental-units-meter.js
@@ -1,0 +1,44 @@
+// @flow
+import Icon from '@conveyal/woonerf/components/icon'
+
+export default function RentalUnitsMeter ({
+  value,
+  max,
+  tier,
+  tooltip
+}) {
+  const NUM_ICONS = 5
+  const filledCount = Math.round(NUM_ICONS * value / max)
+  const unfilledCount = NUM_ICONS - filledCount
+
+  const filledIcons = []
+  for (let i = 0; i < filledCount; i++) {
+    filledIcons.push(
+      <span
+        key={i}
+        className={`rental-units-meter__icon rental-units-meter__icon--${tier}`}
+      >
+        <Icon type='home' />
+      </span>
+    )
+  }
+
+  const unfilledIcons = []
+  for (let i = 0; i < unfilledCount; i++) {
+    unfilledIcons.push(
+      <span
+        key={i}
+        className='rental-units-meter__icon'
+      >
+        <Icon type='home' />
+      </span>
+    )
+  }
+
+  return (
+    <div className='rental-units-meter'>
+      {filledIcons}
+      {unfilledIcons}
+    </div>
+  )
+}

--- a/taui/src/components/route-card.js
+++ b/taui/src/components/route-card.js
@@ -54,7 +54,7 @@ export default class RouteCard extends React.PureComponent<Props> {
     const markerClass = `neighborhood-summary__marker ${neighborhood.active ? 'neighborhood-summary__marker--on' : ''}`
     const { time } = neighborhood
     const originLabel = origin ? origin.label || '' : ''
-    const currentDestination = userProfile.destinations.find(d => d.location.label === originLabel)
+    const currentDestination = userProfile.destinations.find(d => originLabel.endsWith(d.location.label))
 
     const modeKey = userProfile.hasVehicle
       ? 'NeighborhoodDetails.DriveMode'

--- a/taui/src/constants.js
+++ b/taui/src/constants.js
@@ -123,7 +123,6 @@ export const SELECT_STYLE = {
 
 export const SELECT_WRAPPER_STYLE = {
   'height': '4rem',
-  'marginBottom': '0.8rem',
   'boxShadow': 'none',
   'border': '1px solid #bdbdbd'
 }

--- a/taui/src/constants.js
+++ b/taui/src/constants.js
@@ -121,6 +121,8 @@ export const SELECT_STYLE = {
   'height': '3.8rem'
 }
 
+export const SELECT_OPTION_HEIGHT = 38
+
 export const SELECT_WRAPPER_STYLE = {
   'height': '4rem',
   'boxShadow': 'none',

--- a/taui/src/sass/01_settings/_color.scss
+++ b/taui/src/sass/01_settings/_color.scss
@@ -23,3 +23,9 @@ $font-colors: (
     normal: $gray-800,
     dark: $black,
 );
+
+$meter-track: #e0e0e0;
+$meter-fill-high: #7cd193;
+$meter-fill-med: #ffee92;
+$meter-fill-low: #fedca0;
+$meter-average: rgba(#000, 0.8);

--- a/taui/src/sass/06_components/_account-profile.scss
+++ b/taui/src/sass/06_components/_account-profile.scss
@@ -13,9 +13,10 @@
     &--inline {
       flex-direction: row;
       align-items: center;
+      margin-bottom: 0;
 
       > *:not(:last-child) {
-        margin-right: 1.6rem;
+        margin-right: 0.8rem;
         margin-bottom: 0;
       }
     }
@@ -24,6 +25,17 @@
       justify-content: space-between;
       max-width: 40rem;
       margin: 2.4rem 0;
+    }
+  }
+
+  &__field-row {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: flex-start;
+    align-items: center;
+
+    > *:not(:last-child) {
+      margin-right: 2.4rem;
     }
   }
 

--- a/taui/src/sass/06_components/_map-sidebar.scss
+++ b/taui/src/sass/06_components/_map-sidebar.scss
@@ -1,5 +1,8 @@
 .map-sidebar {
   position: relative;
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: stretch;
   padding: 0 2.4rem 2.4rem;
 
   &__error {
@@ -109,7 +112,8 @@
 
   &__attribution {
     @include text(200);
-    margin-top: 2.4rem;
+    margin-top: auto;
+    padding-top: 3.2rem;
     color: $gray-600;
     text-align: center;
   }

--- a/taui/src/sass/06_components/_map-sidebar.scss
+++ b/taui/src/sass/06_components/_map-sidebar.scss
@@ -19,15 +19,24 @@
     border-bottom: 1px solid $gray-400;
   }
 
-  &__checkbox {
-    width: 1.6rem;
-    height: 1.6rem;
-    margin-right: 0.8rem;
+  &__field {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: flex-start;
+    align-items: center;
+    margin-bottom: 0.8rem;
   }
 
   &__label {
     @include text(300);
     @include font-weight(bold);
+    flex: none;
+    min-width: 3.6em;
+    padding-right: 0.4rem;
+  }
+
+  &__select {
+    flex: auto;
   }
 
   &__details-navigation {

--- a/taui/src/sass/06_components/_meter.scss
+++ b/taui/src/sass/06_components/_meter.scss
@@ -1,6 +1,7 @@
 .meter {
   display: flex;
   flex-flow: row nowrap;
+  justify-content: flex-start;
   align-items: center;
 
   &__track {

--- a/taui/src/sass/06_components/_meter.scss
+++ b/taui/src/sass/06_components/_meter.scss
@@ -1,4 +1,8 @@
 .meter {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+
   &__track {
     fill: $meter-track;
   }
@@ -19,5 +23,9 @@
 
   &__average {
     fill: $meter-average;
+  }
+
+  &__percentage {
+    margin-left: 0.8rem;
   }
 }

--- a/taui/src/sass/06_components/_meter.scss
+++ b/taui/src/sass/06_components/_meter.scss
@@ -1,0 +1,23 @@
+.meter {
+  &__track {
+    fill: $meter-track;
+  }
+
+  &__fill {
+    &--high {
+      fill: $meter-fill-high;
+    }
+
+    &--med {
+      fill: $meter-fill-med;
+    }
+
+    &--low {
+      fill: $meter-fill-low;
+    }
+  }
+
+  &__average {
+    fill: $meter-average;
+  }
+}

--- a/taui/src/sass/06_components/_neighborhood-details.scss
+++ b/taui/src/sass/06_components/_neighborhood-details.scss
@@ -26,8 +26,20 @@
   }
 
   &__trip {
+    @include text(200);
     @include font-weight(bold);
     margin-bottom: 1.6rem;
+  }
+
+  &__directions {
+    @include font-weight(normal);
+    @include link-states() {
+      color: $brand-blue;
+    }
+
+    &::before {
+      content: ' – ';
+    }
   }
 
   &__desc {
@@ -89,8 +101,6 @@
     @include text(200);
     margin-top: -0.8rem;
     margin-bottom: 1.6rem;
-    padding: 0.8rem;
     line-height: 2.4;
-    background-color: $gray-100;
   }
 }

--- a/taui/src/sass/06_components/_neighborhood-details.scss
+++ b/taui/src/sass/06_components/_neighborhood-details.scss
@@ -1,24 +1,35 @@
 .neighborhood-details {
   margin-bottom: 1.6rem;
-  padding: 0 0.8rem 0.8rem;
-  background-color: $white;
+
+  &__section {
+    margin-bottom: 0.8rem;
+    padding: 1.6rem 1.6rem;
+    background-color: $white;
+  }
 
   &__header {
-    @include heading(500);
+    @include heading(400);
     @include font-weight(bold);
     display: flex;
     flex-flow: row nowrap;
     justify-content: flex-start;
     align-items: center;
-    padding: 0.6rem 0 0.8rem;
   }
 
   &__star {
+    flex: none;
     margin-right: 0.8rem;
     font-size: 1.8rem !important;
   }
 
+  &__name {
+    flex: auto;
+    margin-right: 0.8rem;
+    line-height: 1.5;
+  }
+
   &__marker {
+    flex: none;
     width: auto !important;
     margin-left: auto;
     color: $green;
@@ -26,42 +37,58 @@
   }
 
   &__trip {
-    @include text(200);
+    @include text(300);
     @include font-weight(bold);
-    margin-bottom: 1.6rem;
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: flex-start;
+    align-items: center;
   }
 
   &__directions {
-    @include font-weight(normal);
     @include link-states() {
       color: $brand-blue;
     }
-
-    &::before {
-      content: ' – ';
-    }
+    margin-left: auto;
   }
 
-  &__desc {
+  .route-segments {
     @include text(200);
-    margin-bottom: 1.6rem;
-    color: $gray-800;
+    margin-top: 0.6rem;
+    line-height: 2.4;
   }
 
-  &__links {
-    @include text(300);
+  &__stats {
     display: flex;
-    flex-flow: row wrap;
+    flex-flow: row nowrap;
     justify-content: space-between;
-    align-items: center;
-    margin-bottom: 2.4rem;
+    align-items: stretch;
+    width: 100%;
   }
 
-  &__link {
-    @include link-states() {
-      color: $brand-blue;
-    }
-    margin-right: auto;
+  &__rent {
+    flex: none;
+    margin-right: 0.8rem;
+    padding-top: 0.4rem;
+    padding-right: 1.6rem;
+    text-align: center;
+    border-right: 4px solid $bg-gray;
+  }
+
+  &__rent-label {
+    @include text(300);
+    margin-bottom: 0.8rem;
+  }
+
+  &__rent-value {
+    @include text(500);
+    @include font-weight(bold);
+    margin-bottom: 0.8rem;
+  }
+
+  &__rent-rooms {
+    @include text(300);
+    @include font-weight(bold);
   }
 
   &__images {
@@ -69,7 +96,7 @@
     flex-flow: row nowrap;
     justify-content: flex-start;
     align-items: flex-start;
-    margin-bottom: 1.6rem;
+    margin-bottom: 0.8rem;
   }
 
   &__image {
@@ -83,24 +110,35 @@
     margin-right: 1.6rem;
   }
 
-  &__facts {
-    @include text(200);
-    @include font-weight(bold);
-    width: 100%;
+  &__desc {
+    @include text(300);
+    color: $gray-800;
   }
 
-  &__row:nth-child(odd) {
-    background-color: $gray-100;
+  &__link-heading {
+    @include heading(300);
+    margin-bottom: 0.8rem;
+
+    &:not(:first-of-type) {
+      margin-top: 2.4rem;
+    }
   }
 
-  &__cell {
-    padding: 0.8rem 0.4rem;
+  &__links {
+    @include text(300);
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: flex-start;
+    align-items: center;
   }
 
-  > .route-segments {
-    @include text(200);
-    margin-top: -0.8rem;
-    margin-bottom: 1.6rem;
-    line-height: 2.4;
+  &__link {
+    @include link-states() {
+      color: $brand-blue;
+    }
+
+    &:not(:last-child) {
+      margin-right: 2.4rem;
+    }
   }
 }

--- a/taui/src/sass/06_components/_neighborhood-details.scss
+++ b/taui/src/sass/06_components/_neighborhood-details.scss
@@ -3,7 +3,7 @@
 
   &__section {
     margin-bottom: 0.8rem;
-    padding: 1.6rem 1.6rem;
+    padding: 1.6rem;
     background-color: $white;
   }
 

--- a/taui/src/sass/06_components/_neighborhood-facts.scss
+++ b/taui/src/sass/06_components/_neighborhood-facts.scss
@@ -1,0 +1,20 @@
+.neighborhood-facts {
+  @include text(300);
+  flex: none;
+  table-layout: fixed;
+
+  &__cell {
+    white-space: nowrap;
+    vertical-align: middle;
+
+    &:first-child {
+      padding-right: 1.6rem;
+      text-align: right;
+    }
+  }
+
+  tr:not(:last-of-type) &__cell {
+    padding-top: 0.4rem;
+    padding-bottom: 0.8rem;
+  }
+}

--- a/taui/src/sass/06_components/_neighborhood-summary.scss
+++ b/taui/src/sass/06_components/_neighborhood-summary.scss
@@ -1,7 +1,7 @@
 .neighborhood-summary {
   @include elevation(1);
   margin-bottom: 1.6rem;
-  padding: 0 0.8rem 0.8rem;
+  padding: 0 0.8rem 1.2rem;
   background-color: $white;
   cursor: pointer;
 
@@ -33,7 +33,7 @@
   &__contents {
     display: flex;
     flex-flow: row nowrap;
-    justify-content: flex-start;
+    justify-content: space-between;
     align-items: flex-start;
     padding: 0 0.8rem;
   }
@@ -72,23 +72,5 @@
 
   &__location {
     @include font-weight(bold);
-  }
-
-  &__facts {
-    @include text(200);
-    flex: auto;
-    table-layout: fixed;
-  }
-
-  &__cell {
-    padding-top: 0.4rem;
-    padding-bottom: 1.2rem;
-    white-space: nowrap;
-    vertical-align: middle;
-
-    &:first-child {
-      padding-right: 0.8rem;
-      text-align: right;
-    }
   }
 }

--- a/taui/src/sass/06_components/_neighborhood-summary.scss
+++ b/taui/src/sass/06_components/_neighborhood-summary.scss
@@ -39,7 +39,7 @@
 
   &__descriptive {
     flex: none;
-    margin-right: 1.6rem;
+    margin-right: 1.2rem;
     margin-left: 0.8rem;
   }
 
@@ -67,7 +67,7 @@
 
   &__trajectory {
     @include text(200);
-    color: $gray-500;
+    color: $gray-600;
   }
 
   &__location {
@@ -75,13 +75,30 @@
   }
 
   &__facts {
-    @include text(300);
+    @include text(200);
     flex: auto;
     table-layout: fixed;
   }
 
   &__cell {
-    padding-bottom: 0.8rem;
+    padding-top: 0.4rem;
+    padding-bottom: 1.2rem;
     white-space: nowrap;
+    vertical-align: middle;
+
+    &:first-child {
+      padding-right: 0.8rem;
+      text-align: right;
+    }
+  }
+
+  &__value {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+  }
+
+  &__percentage {
+    margin-left: 0.8rem;
   }
 }

--- a/taui/src/sass/06_components/_neighborhood-summary.scss
+++ b/taui/src/sass/06_components/_neighborhood-summary.scss
@@ -35,12 +35,12 @@
     flex-flow: row nowrap;
     justify-content: flex-start;
     align-items: flex-start;
+    padding: 0 0.8rem;
   }
 
   &__descriptive {
     flex: none;
     margin-right: 1.2rem;
-    margin-left: 0.8rem;
   }
 
   &__image {
@@ -90,15 +90,5 @@
       padding-right: 0.8rem;
       text-align: right;
     }
-  }
-
-  &__value {
-    display: flex;
-    flex-flow: row nowrap;
-    align-items: center;
-  }
-
-  &__percentage {
-    margin-left: 0.8rem;
   }
 }

--- a/taui/src/sass/06_components/_rental-units-meter.scss
+++ b/taui/src/sass/06_components/_rental-units-meter.scss
@@ -1,0 +1,22 @@
+.rental-units-meter {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+
+  &__icon {
+    color: $meter-track;
+    font-size: 2rem;
+
+    &--high {
+      color: $meter-fill-high;
+    }
+
+    &--med {
+      color: $meter-fill-med;
+    }
+
+    &--low {
+      color: $meter-fill-low;
+    }
+  }
+}

--- a/taui/src/sass/main.scss
+++ b/taui/src/sass/main.scss
@@ -17,6 +17,7 @@
 '06_components/account-list.scss',
 '06_components/map.scss',
 '06_components/map-sidebar.scss',
+'06_components/meter.scss',
 '06_components/neighborhood-summary.scss',
 '06_components/neighborhood-details.scss',
 '07_layouts/app-root.scss',

--- a/taui/src/sass/main.scss
+++ b/taui/src/sass/main.scss
@@ -18,6 +18,7 @@
 '06_components/map.scss',
 '06_components/map-sidebar.scss',
 '06_components/meter.scss',
+'06_components/neighborhood-facts.scss',
 '06_components/neighborhood-summary.scss',
 '06_components/neighborhood-details.scss',
 '06_components/rental-units-meter.scss',

--- a/taui/src/sass/main.scss
+++ b/taui/src/sass/main.scss
@@ -20,6 +20,7 @@
 '06_components/meter.scss',
 '06_components/neighborhood-summary.scss',
 '06_components/neighborhood-details.scss',
+'06_components/rental-units-meter.scss',
 '07_layouts/app-root.scss',
 '07_layouts/auth-screen.scss',
 '07_layouts/form-screen.scss',

--- a/taui/src/utils/google-maps-link.js
+++ b/taui/src/utils/google-maps-link.js
@@ -1,0 +1,6 @@
+// @flow
+// Returns a link to Google Maps with the given search term
+const GOOGLE_BASE_URL = 'https://www.google.com/maps/place/'
+export default function getGoogleSearchLink (query) {
+  return GOOGLE_BASE_URL + encodeURIComponent(query)
+}


### PR DESCRIPTION
## Overview

- Replace quintile labels with bar charts and "housing" chart
- Redesign neighborhood detail page
- Add labels to sidebar form fields
- Rename "Violent crime" to "Public safety"
- Drive-by: Profile copy tweaks
- Drive-by: Keep sidebar attribution on bottom

### Demo

![image](https://user-images.githubusercontent.com/128699/58907883-264d3800-86dd-11e9-9cc4-2189f2594abb.png)

![image](https://user-images.githubusercontent.com/128699/58907892-2cdbaf80-86dd-11e9-934a-5507d359bbc3.png)

![image](https://user-images.githubusercontent.com/128699/58907823-0a499680-86dd-11e9-91a8-a779d3042902.png)

![image](https://user-images.githubusercontent.com/128699/58907833-10d80e00-86dd-11e9-85a3-954139794ab8.png)


![image](https://user-images.githubusercontent.com/128699/58907860-1cc3d000-86dd-11e9-94d1-e5d951734028.png)

![image](https://user-images.githubusercontent.com/128699/58907790-ff8f0180-86dc-11e9-944f-9586aa36fabe.png)


### Notes

Fixed bug where destination purpose wasn't rendering in detail and search views.

A number of new features are using placeholder values and need to be wired up:
- Schools meter (`neighborhood-list-info.js`)
- Public safety meter (`neighborhood-list-info.js`)
- Rental units meter (`neighborhood-list-info.js`)
- ~Max rent (_twice_ in `neighborhood-details.js`)~
- ~Number of rooms (_twice_ in `neighborhood-details.js`)~

Some of the links in the detail view need to be wired up or adjusted:
- Section 8 link needs a util function
- Zillow link should be replaced with Apartments.com?
- Remove Craigslist link?

New charts can get tooltips after #134 

Public safety has only been renamed. The scale itself needs to be adjusted (flipped?) to match the semantics.

Did not design "School choice" links for Boston and Cambridge. Can style those once they're implemented.

{Green, Yellow, Orange} colors from client don't meet a11y color contrast standards. Will likely be changed.


Resolves #180 
