### PR TITLE
Feature/kak/hide school ranks#179

### DIFF
--- a/taui/Dockerfile
+++ b/taui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-slim
+FROM node:10-slim
 
 # Install git for packages on GitHub
 RUN set -ex; \

--- a/taui/README.md
+++ b/taui/README.md
@@ -7,7 +7,7 @@
 
 ## Running
 
-Clone the repository and with [yarn](https://yarnpkg.com/en/) and [node v8](https://nodejs.org/en/) installed run `yarn start`. Changes to JavaScript and CSS will be rebuilt automatically. Refresh your web page to see changes. Changes to configuration files require a full stop and fresh `yarn start`.
+Clone the repository and with [yarn](https://yarnpkg.com/en/) and [node v10](https://nodejs.org/en/) installed run `yarn start`. Changes to JavaScript and CSS will be rebuilt automatically. Refresh your web page to see changes. Changes to configuration files require a full stop and fresh `yarn start`.
 
 ## Configuration
 

--- a/taui/src/components/meter.js
+++ b/taui/src/components/meter.js
@@ -1,15 +1,17 @@
 // @flow
+import {getTier} from '../utils/scaling'
+
 export default function Meter ({
   value,
   max = 100,
-  average,
-  tier,
+  average = 50,
   width = 100,
   height = 12,
   tooltip
 }) {
   const percentage = value / max
   const percentageLabel = Math.round(percentage * 100)
+  const tier = getTier(percentage)
 
   return (
     <div className='meter'>

--- a/taui/src/components/neighborhood-list-info.js
+++ b/taui/src/components/neighborhood-list-info.js
@@ -13,16 +13,17 @@ export default function NeighborhoodListInfo ({neighborhood}) {
   const crimeQuintile = props['violentcrime_quintile']
   const edPercentile = props['education_percentile']
   const houses = props['house_number_symbol']
+  const isSchoolChoice = !!props['school_choice']
 
   return (
     <table className='neighborhood-facts'>
       <tbody>
-        <tr>
+        {!isSchoolChoice && <tr>
           <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.EducationCategory')}</td>
           <td className='neighborhood-facts__cell'>
             <Meter value={edPercentile} />
           </td>
-        </tr>
+        </tr>}
         <tr>
           <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.ViolentCrime')}</td>
           <td className='neighborhood-facts__cell'>

--- a/taui/src/components/neighborhood-list-info.js
+++ b/taui/src/components/neighborhood-list-info.js
@@ -9,25 +9,30 @@ export default function NeighborhoodListInfo ({neighborhood}) {
     return null
   }
 
+  const props = neighborhood.properties
+  const crimeQuintile = props['violentcrime_quintile']
+  const edPercentile = props['education_percentile']
+  const houses = props['house_number_symbol']
+
   return (
     <table className='neighborhood-facts'>
       <tbody>
         <tr>
           <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.EducationCategory')}</td>
           <td className='neighborhood-facts__cell'>
-            <Meter value={86} average={58} tier='high' tooltip='hello' />
+            <Meter value={edPercentile} />
           </td>
         </tr>
         <tr>
           <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.ViolentCrime')}</td>
           <td className='neighborhood-facts__cell'>
-            <Meter value={72} average={66} tier='med' />
+            <Meter value={crimeQuintile} average={3} max={5} />
           </td>
         </tr>
         <tr>
           <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.RentalUnits')}</td>
           <td className='neighborhood-facts__cell'>
-            <RentalUnitsMeter value={400} max={1000} tier='low' />
+            <RentalUnitsMeter value={houses} />
           </td>
         </tr>
       </tbody>

--- a/taui/src/components/neighborhood-list-info.js
+++ b/taui/src/components/neighborhood-list-info.js
@@ -1,6 +1,8 @@
 // @flow
 import message from '@conveyal/woonerf/message'
 
+import scale from '../utils/scaling'
+
 import Meter from './meter'
 import RentalUnitsMeter from './rental-units-meter'
 
@@ -10,7 +12,9 @@ export default function NeighborhoodListInfo ({neighborhood}) {
   }
 
   const props = neighborhood.properties
-  const crimeQuintile = props['violentcrime_quintile']
+  const crime = props['violentcrime_quintile'] > 0 ? props['violentcrime_quintile'] : 1
+  // Invert range for crime quintile
+  const crimeQuintile = scale(crime, 1, 5, 4, 0)
   const edPercentile = props['education_percentile']
   const houses = props['house_number_symbol']
   const isSchoolChoice = !!props['school_choice']
@@ -27,7 +31,7 @@ export default function NeighborhoodListInfo ({neighborhood}) {
         <tr>
           <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.ViolentCrime')}</td>
           <td className='neighborhood-facts__cell'>
-            <Meter value={crimeQuintile} average={3} max={5} />
+            <Meter value={crimeQuintile} average={2} max={4} />
           </td>
         </tr>
         <tr>

--- a/taui/src/components/rental-units-meter.js
+++ b/taui/src/components/rental-units-meter.js
@@ -1,18 +1,28 @@
 // @flow
 import Icon from '@conveyal/woonerf/components/icon'
 
+import {getTier} from '../utils/scaling'
+
 export default function RentalUnitsMeter ({
   value,
-  max,
-  tier,
   tooltip
 }) {
   const NUM_ICONS = 5
-  const filledCount = Math.round(NUM_ICONS * value / max)
-  const unfilledCount = NUM_ICONS - filledCount
+
+  if (value > NUM_ICONS || value < 0) {
+    console.warn('Rental unit meter count out of range')
+    if (value < 0) {
+      value = 0
+    } else {
+      value = NUM_ICONS
+    }
+  }
+
+  const unfilledCount = NUM_ICONS - value
+  const tier = getTier(value / NUM_ICONS)
 
   const filledIcons = []
-  for (let i = 0; i < filledCount; i++) {
+  for (let i = 0; i < value; i++) {
     filledIcons.push(
       <span
         key={i}

--- a/taui/src/selectors/neighborhoods-sorted-with-routes.js
+++ b/taui/src/selectors/neighborhoods-sorted-with-routes.js
@@ -11,6 +11,7 @@ import {
   DEFAULT_SCHOOLS_IMPORTANCE
 } from '../constants'
 import {NeighborhoodProperties} from '../types'
+import scale from '../utils/scaling'
 
 import selectNeighborhoodRoutes from './network-neighborhood-routes'
 import neighborhoodTravelTimes from './neighborhood-travel-times'
@@ -110,9 +111,4 @@ const distanceTime = (origin, neighborhood) => {
   const normalized = distance < MAX_DISTANCE ? distance : MAX_DISTANCE
   // Then map the distance to the travel time range
   return scale(normalized, 0, MAX_DISTANCE, 0, MAX_TRAVEL_TIME)
-}
-
-// Map value from one range to another
-const scale = (num, startMin, startMax, rangeMin, rangeMax) => {
-  return (num - startMin) * (rangeMax - rangeMin) / (startMax - startMin) + rangeMin
 }

--- a/taui/src/utils/scaling.js
+++ b/taui/src/utils/scaling.js
@@ -1,0 +1,15 @@
+// @flow
+
+// Labels for meter shading CSS categories
+const METER_TIERS = ['low', 'med', 'high']
+
+// Map value from one range to another
+export default function scale (num, startMin, startMax, rangeMin, rangeMax) {
+  return (num - startMin) * (rangeMax - rangeMin) / (startMax - startMin) + rangeMin
+}
+
+// Return CSS label for meter shading
+export function getTier (percentage) {
+  // Convert percentange to third to find shading tier
+  return METER_TIERS[Math.round(scale(percentage, 0, 1, 0, 2))]
+}

--- a/taui/yarn.lock
+++ b/taui/yarn.lock
@@ -3581,7 +3581,7 @@ debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@~4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -5669,7 +5669,7 @@ import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -7064,7 +7064,7 @@ libnpm@^2.0.1:
     read-package-json "^2.0.13"
     stringify-package "^1.0.0"
 
-libnpmaccess@*, libnpmaccess@^3.0.1:
+libnpmaccess@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/libnpmaccess/-/libnpmaccess-3.0.1.tgz#5b3a9de621f293d425191aa2e779102f84167fa8"
   integrity sha512-RlZ7PNarCBt+XbnP7R6PoVgOq9t+kou5rvhaInoNibhPO7eMlRfS0B8yjatgn2yaHIwWNyoJDolC/6Lc5L/IQA==
@@ -7093,7 +7093,7 @@ libnpmhook@^5.0.2:
     get-stream "^4.0.0"
     npm-registry-fetch "^3.8.0"
 
-libnpmorg@*, libnpmorg@^1.0.0:
+libnpmorg@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/libnpmorg/-/libnpmorg-1.0.0.tgz#979b868c48ba28c5820e3bb9d9e73c883c16a232"
   integrity sha512-o+4eVJBoDGMgRwh2lJY0a8pRV2c/tQM/SxlqXezjcAg26Qe9jigYVs+Xk0vvlYDWCDhP0g74J8UwWeAgsB7gGw==
@@ -7118,7 +7118,7 @@ libnpmpublish@^1.1.0:
     semver "^5.5.1"
     ssri "^6.0.1"
 
-libnpmsearch@*, libnpmsearch@^2.0.0:
+libnpmsearch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/libnpmsearch/-/libnpmsearch-2.0.0.tgz#de05af47ada81554a5f64276a69599070d4a5685"
   integrity sha512-vd+JWbTGzOSfiOc+72MU6y7WqmBXn49egCCrIXp27iE/88bX8EpG64ST1blWQI1bSMUr9l1AKPMVsqa2tS5KWA==
@@ -7127,7 +7127,7 @@ libnpmsearch@*, libnpmsearch@^2.0.0:
     get-stream "^4.0.0"
     npm-registry-fetch "^3.8.0"
 
-libnpmteam@*, libnpmteam@^1.0.1:
+libnpmteam@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/libnpmteam/-/libnpmteam-1.0.1.tgz#ff704b1b6c06ea674b3b1101ac3e305f5114f213"
   integrity sha512-gDdrflKFCX7TNwOMX1snWojCoDE5LoRWcfOC0C/fqF7mBq8Uz9zWAX4B2RllYETNO7pBupBaSyBDkTAC15cAMg==
@@ -7233,11 +7233,6 @@ lodash-es@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
   integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -7246,32 +7241,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
@@ -7332,11 +7305,6 @@ lodash.merge@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
   integrity sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -8408,7 +8376,7 @@ npm-pick-manifest@^2.2.3:
     npm-package-arg "^6.0.0"
     semver "^5.4.1"
 
-npm-profile@*, npm-profile@^4.0.1:
+npm-profile@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/npm-profile/-/npm-profile-4.0.1.tgz#d350f7a5e6b60691c7168fbb8392c3603583f5aa"
   integrity sha512-NQ1I/1Q7YRtHZXkcuU1/IyHeLy6pd+ScKg4+DQHdfsm769TGq6HPrkbuNJVJS4zwE+0mvvmeULzQdWn2L2EsVA==
@@ -10637,7 +10605,7 @@ readable-stream@~1.1.10:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=


### PR DESCRIPTION
## Overview

Implement the meters for school ranking, crime rate, and housing availability from #199. Hide the school ranking meter for school choice zip codes (#179).


### Demo

![echo_list_school_choice_hidden_meter](https://user-images.githubusercontent.com/960264/59047521-09864100-8852-11e9-8877-64ccd51191fd.png)

![image](https://user-images.githubusercontent.com/960264/59047634-3f2b2a00-8852-11e9-8149-3394461adcbc.png)


### Notes

The data source provides the education percentile, but only the crime rank quintile. The number of houses to display in the five-house icon chart is provided directly by the data source.


## Testing Instructions

 * Meters should display as expected
 * Meter shading (orange-yellow, yellow, or green) should match value range
 * Housing availability shading and count should display as expected
 * School choice zip codes (i.e., Boston-labelled zip codes) should hide school rank meter


Closes #179.
