### PR TITLE
Fix chart overflow in FF, Edge

### DIFF
--- a/taui/src/sass/06_components/_neighborhood-facts.scss
+++ b/taui/src/sass/06_components/_neighborhood-facts.scss
@@ -1,5 +1,5 @@
 .neighborhood-facts {
-  @include text(300);
+  @include text(200);
   flex: none;
   table-layout: fixed;
 
@@ -8,13 +8,13 @@
     vertical-align: middle;
 
     &:first-child {
-      padding-right: 1.6rem;
+      padding-right: 0.8rem;
       text-align: right;
     }
   }
 
   tr:not(:last-of-type) &__cell {
-    padding-top: 0.4rem;
+    padding-top: 0.6rem;
     padding-bottom: 0.8rem;
   }
 }

--- a/taui/src/sass/06_components/_neighborhood-summary.scss
+++ b/taui/src/sass/06_components/_neighborhood-summary.scss
@@ -40,7 +40,7 @@
 
   &__descriptive {
     flex: none;
-    margin-right: 1.2rem;
+    margin-right: 0.8rem;
   }
 
   &__image {


### PR DESCRIPTION
## Overview

Was able to recreate #204 in FF/Win and Edge.

Fixed by decreasing font size and tightening up padding. Tested across browsers.

### Demo

![image](https://user-images.githubusercontent.com/128699/59055364-a6050f00-8863-11e9-82b9-c5912d8c57ca.png)



Resolves #204 
