### PR TITLE
Feature/kak/add tooltip library#134

### DIFF
--- a/taui/package.json
+++ b/taui/package.json
@@ -62,6 +62,7 @@
     "react-router-dom": "~5.0.1",
     "react-select": "~1.2.1",
     "react-select-fast-filter-options": "~0.2.3",
+    "react-tooltip": "~3.10.0",
     "react-virtualized-select": "~3.1.3",
     "redux": "~4.0.1",
     "redux-actions": "~2.6.5",

--- a/taui/src/components/meter.js
+++ b/taui/src/components/meter.js
@@ -1,4 +1,6 @@
 // @flow
+import ReactTooltip from 'react-tooltip'
+
 import {getTier} from '../utils/scaling'
 
 export default function Meter ({
@@ -14,13 +16,13 @@ export default function Meter ({
   const tier = getTier(percentage)
 
   return (
-    <div className='meter'>
+    <div className='meter' data-tip={tooltip}>
+      <ReactTooltip />
       <svg
         className='meter__chart'
         viewBox={`0 0 ${width} ${height}`}
         width={width}
         height={height}
-        title={tooltip}
       >
         <rect
           className='meter__track'

--- a/taui/src/components/neighborhood-list-info.js
+++ b/taui/src/components/neighborhood-list-info.js
@@ -25,19 +25,22 @@ export default function NeighborhoodListInfo ({neighborhood}) {
         {!isSchoolChoice && <tr>
           <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.EducationCategory')}</td>
           <td className='neighborhood-facts__cell'>
-            <Meter value={edPercentile} />
+            <Meter value={edPercentile} tooltip={message('NeighborhoodInfo.EducationCategory')} />
           </td>
         </tr>}
         <tr>
           <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.ViolentCrime')}</td>
           <td className='neighborhood-facts__cell'>
-            <Meter value={crimeQuintile} average={2} max={4} />
+            <Meter value={crimeQuintile}
+              average={2}
+              max={4}
+              tooltip={message('NeighborhoodInfo.ViolentCrime')} />
           </td>
         </tr>
         <tr>
           <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.RentalUnits')}</td>
           <td className='neighborhood-facts__cell'>
-            <RentalUnitsMeter value={houses} />
+            <RentalUnitsMeter value={houses} tooltip={message('NeighborhoodInfo.RentalUnits')} />
           </td>
         </tr>
       </tbody>

--- a/taui/src/components/rental-units-meter.js
+++ b/taui/src/components/rental-units-meter.js
@@ -1,5 +1,6 @@
 // @flow
 import Icon from '@conveyal/woonerf/components/icon'
+import ReactTooltip from 'react-tooltip'
 
 import {getTier} from '../utils/scaling'
 
@@ -46,7 +47,9 @@ export default function RentalUnitsMeter ({
   }
 
   return (
-    <div className='rental-units-meter'>
+    <div className='rental-units-meter'
+      data-tip={tooltip}>
+      <ReactTooltip />
       {filledIcons}
       {unfilledIcons}
     </div>

--- a/taui/yarn.lock
+++ b/taui/yarn.lock
@@ -2636,7 +2636,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.4:
+classnames@^2.2.4, classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -10411,6 +10411,14 @@ react-select@~1.2.1:
     classnames "^2.2.4"
     prop-types "^15.5.8"
     react-input-autosize "^2.1.2"
+
+react-tooltip@~3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-3.10.0.tgz#268b5ef519fd8a1369288d1f086f42c90d5da7ef"
+  integrity sha512-GGdxJvM1zSFztkTP7gCQbLTstWr1OOoMpJ5WZUGhimj0nhRY+MPz+92MpEnKmj0cftJ9Pd/M6FfSl0sfzmZWkg==
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.6.0"
 
 react-virtualized-select@~3.1.3:
   version "3.1.3"


### PR DESCRIPTION
## Overview

Adds the [react-tooltip](https://github.com/wwayne/react-tooltip) library and uses it to display tooltips on hover over each of the three neighborhood charts.


### Demo

![echo_public_safety_tooltip](https://user-images.githubusercontent.com/960264/59126621-7de4e100-8933-11e9-8a2d-19d008971884.png)

![echo_rental_units_toolitp](https://user-images.githubusercontent.com/960264/59126695-b2589d00-8933-11e9-81c7-bfff9b668b30.png)


### Notes

This should make it easier for us to add specific tooltips later (we don't have text yet for what to display, or for which elements).


## Testing Instructions

 * `cd taui && yarn install && yarn start`
 * Go to map page
 * Neighborhood chars in both list view and details should have hover interactivity now


Closes #134 
