### PR TITLE
Fix png image references

### DIFF
--- a/neighborhood_data/requirements.txt
+++ b/neighborhood_data/requirements.txt
@@ -1,5 +1,6 @@
 fiona
 ipdb
+optimize-images
+pillow
 shapely
 requests
-

--- a/neighborhood_data/update_data.sh
+++ b/neighborhood_data/update_data.sh
@@ -7,6 +7,9 @@ python3 add_zcta_centroids.py
 python3 fetch_images.py
 python3 generate_neighborhood_json.py
 
+# optimize downloaded images
+optimize-images ./images/
+
 cp neighborhoods.json neighborhood_bounds.json ../taui/
 
 mkdir -p ../taui/assets/neighborhoods/

--- a/taui/src/utils/neighborhood-images.js
+++ b/taui/src/utils/neighborhood-images.js
@@ -36,7 +36,9 @@ export default function getNeighborhoodImage (properties: NeighborhoodProperties
   const license = properties[imageField + '_license']
   const licenseUrl = properties[imageField + '_license_url']
   const imageLink = properties[imageField]
-  const thumbnail = 'assets/neighborhoods/' + properties['id'] + '_' + imageField + '.jpg'
+  // Get the extension for the image from the link
+  const ext = imageLink.toLowerCase().split('.').pop()
+  const thumbnail = 'assets/neighborhoods/' + properties['id'] + '_' + imageField + '.' + ext
   const userName = properties[imageField + '_username']
 
   let attribution = userName + ' [' + license


### PR DESCRIPTION
## Overview

Fix neighborhood images with `.png` extensions not appearing properly in the UI by reading the extension from the source URL used to download the cached thumbnail, instead of expecting all to be `.jpg` files.

Also adds calling a small Python image compression library to the data processing script pipeline, to make a pass at lossless compression of the cached thumbnail images for web presentation, to speed site responsiveness a bit.


### Demo

Before (on staging):
![image](https://user-images.githubusercontent.com/960264/59128395-eb930c00-8937-11e9-8d5a-ab3d0464180e.png)

After:
![image](https://user-images.githubusercontent.com/960264/59128409-f64da100-8937-11e9-95b3-6f9e1699ca2b.png)

Some output from the image compression library (most didn't need any optimization):
![image](https://user-images.githubusercontent.com/960264/59128632-9f949700-8938-11e9-9134-01b37b9846eb.png)


## Testing Instructions

 * `cd taui && yarn start`
 * View neighborhood card for `Harvard  - 01451` 
 * Picture on list view should show as expected
 * Both pictures should show as expected in detail page


Fixes #209
