### PR TITLE
Feature/kak/hover interactivity#161

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -31,6 +31,7 @@ Map:
     SetStart: Set start
     SetEnd: Set end
     ClearMarkers: Clear markers
+  Unreachable: cannot be reached by transit
 Dock:
   LocationLabel: From
   NetworkLabel: When

--- a/taui/src/components/application.js
+++ b/taui/src/components/application.js
@@ -32,6 +32,7 @@ type MapState = {
 type Props = {
   accessibility: number[][],
   actionLog: LogItems,
+  activeNeighborhoodBounds: any,
   data: {
     grids: string[],
     neighborhoodBounds: any,

--- a/taui/src/components/dock.js
+++ b/taui/src/components/dock.js
@@ -12,6 +12,7 @@ import NeighborhoodDetails from './neighborhood-details'
 import RouteCard from './route-card'
 
 type Props = {
+  activeNeighborhood: string,
   activeNetworkIndex: number,
   detailNeighborhood: any,
   endingOffset: number,
@@ -154,6 +155,7 @@ export default class Dock extends PureComponent<Props> {
   // Render list of neighborhoods
   neighborhoodsList (props) {
     const {
+      activeNeighborhood,
       changeUserProfile,
       neighborhoods,
       setActiveNeighborhood,
@@ -170,6 +172,7 @@ export default class Dock extends PureComponent<Props> {
     return (
       neighborhoods.map((neighborhood, index) =>
         <RouteCard
+          activeNeighborhood={activeNeighborhood}
           goToDetails={(e) => goToDetails(e, neighborhood)}
           index={index}
           isFavorite={userProfile.favorites &&

--- a/taui/src/components/draw-neighborhood-bounds.js
+++ b/taui/src/components/draw-neighborhood-bounds.js
@@ -5,7 +5,7 @@ import {LayerGroup} from 'react-leaflet'
 
 import {
   NEIGHBORHOOD_BOUNDS_STYLE,
-  NEIGHBORHOOD_HOVER_COLOR,
+  NEIGHBORHOOD_ROUTABLE_COLOR,
   NEIGHBORHOOD_NONROUTABLE_COLOR
 } from '../constants'
 
@@ -15,14 +15,6 @@ export default class DrawNeighborhoodBounds extends React.PureComponent {
   _key = 0
   _getKey () { return this._key++ }
 
-  hoverStyle = (feature) => {
-    return Object.assign({}, NEIGHBORHOOD_BOUNDS_STYLE, {
-      fillColor: feature.routable
-        ? NEIGHBORHOOD_HOVER_COLOR
-        : NEIGHBORHOOD_NONROUTABLE_COLOR
-    })
-  }
-
   getTooltip = (feature) => {
     if (!feature || !feature.properties) return ''
     const {routable, town} = feature.properties
@@ -31,20 +23,24 @@ export default class DrawNeighborhoodBounds extends React.PureComponent {
 
   render () {
     const p = this.props
-    const hoverStyle = this.hoverStyle
     const getTooltip = this.getTooltip
     return <LayerGroup key={`neighborhood-boundary-${this._getKey()}`}>
       {p.neighborhoods && <VGrid
         data={p.neighborhoods}
         idField='id'
         tooltip={(feature) => getTooltip(feature)}
-        hoverStyle={(feature) => hoverStyle(feature)}
         onClick={p.clickNeighborhood}
         onMouseover={p.hoverNeighborhood}
         zIndex={p.zIndex}
         style={NEIGHBORHOOD_BOUNDS_STYLE}
         vectorTileLayerStyles={
-          {'sliced': p.styleNeighborhood}
+          {'sliced': (properties) => {
+            return Object.assign({}, NEIGHBORHOOD_BOUNDS_STYLE, {
+              fillColor: properties.routable
+                ? NEIGHBORHOOD_ROUTABLE_COLOR
+                : NEIGHBORHOOD_NONROUTABLE_COLOR
+            })
+          }}
         }
       />}
     </LayerGroup>

--- a/taui/src/components/draw-neighborhood-bounds.js
+++ b/taui/src/components/draw-neighborhood-bounds.js
@@ -16,9 +16,9 @@ export default class DrawNeighborhoodBounds extends React.PureComponent {
   _key = 0
   _getKey () { return this._key++ }
 
-  hoverStyle = (feature) => {
+  hoverStyle = (feature, activeNeighborhood) => {
     return Object.assign({}, NEIGHBORHOOD_BOUNDS_STYLE, {
-      fillColor: feature.active || feature.routable
+      fillColor: feature.id === activeNeighborhood || feature.routable
         ? NEIGHBORHOOD_HOVER_COLOR
         : NEIGHBORHOOD_NONROUTABLE_COLOR
     })
@@ -32,6 +32,7 @@ export default class DrawNeighborhoodBounds extends React.PureComponent {
 
   render () {
     const p = this.props
+    const activeNeighborhood = p.activeNeighborhood
     const hoverStyle = this.hoverStyle
     const getTooltip = this.getTooltip
     return <LayerGroup key={`neighborhood-boundary-${this._getKey()}`}>
@@ -39,7 +40,7 @@ export default class DrawNeighborhoodBounds extends React.PureComponent {
         data={p.neighborhoods}
         idField='id'
         tooltip={(feature) => getTooltip(feature)}
-        hoverStyle={(feature) => hoverStyle(feature)}
+        hoverStyle={(feature, activeNeighborhood) => hoverStyle(feature, activeNeighborhood)}
         onClick={p.clickNeighborhood}
         onMouseover={p.hoverNeighborhood}
         zIndex={p.zIndex}
@@ -47,7 +48,7 @@ export default class DrawNeighborhoodBounds extends React.PureComponent {
         vectorTileLayerStyles={
           {'sliced': (properties) => {
             return Object.assign({}, NEIGHBORHOOD_BOUNDS_STYLE, {
-              fillColor: properties.active
+              fillColor: properties.id === activeNeighborhood
                 ? NEIGHBORHOOD_HOVER_COLOR
                 : (properties.routable
                   ? NEIGHBORHOOD_ROUTABLE_COLOR

--- a/taui/src/components/draw-neighborhood-bounds.js
+++ b/taui/src/components/draw-neighborhood-bounds.js
@@ -15,13 +15,23 @@ export default class DrawNeighborhoodBounds extends React.PureComponent {
   _key = 0
   _getKey () { return this._key++ }
 
+  hoverStyle = (feature) => {
+    return Object.assign({}, NEIGHBORHOOD_BOUNDS_STYLE, {
+      fillColor: feature.active || feature.routable
+        ? NEIGHBORHOOD_HOVER_COLOR
+        : NEIGHBORHOOD_NONROUTABLE_COLOR
+    })
+  }
+
   render () {
     const p = this.props
+    const hoverStyle = this.hoverStyle
     return <LayerGroup key={`neighborhood-boundary-${this._getKey()}`}>
       {p.neighborhoods && <VGrid
         data={p.neighborhoods}
         idField='id'
         tooltip='town'
+        hoverStyle={(feature) => hoverStyle(feature)}
         onClick={p.clickNeighborhood}
         onMouseover={p.hoverNeighborhood}
         zIndex={p.zIndex}

--- a/taui/src/components/draw-neighborhood-bounds.js
+++ b/taui/src/components/draw-neighborhood-bounds.js
@@ -1,4 +1,5 @@
 // @flow
+import message from '@conveyal/woonerf/message'
 import React from 'react'
 import {LayerGroup} from 'react-leaflet'
 
@@ -23,14 +24,21 @@ export default class DrawNeighborhoodBounds extends React.PureComponent {
     })
   }
 
+  getTooltip = (feature) => {
+    if (!feature || !feature.properties) return ''
+    const {routable, town} = feature.properties
+    return routable ? town : town + ' ' + message('Map.Unreachable')
+  }
+
   render () {
     const p = this.props
     const hoverStyle = this.hoverStyle
+    const getTooltip = this.getTooltip
     return <LayerGroup key={`neighborhood-boundary-${this._getKey()}`}>
       {p.neighborhoods && <VGrid
         data={p.neighborhoods}
         idField='id'
-        tooltip='town'
+        tooltip={(feature) => getTooltip(feature)}
         hoverStyle={(feature) => hoverStyle(feature)}
         onClick={p.clickNeighborhood}
         onMouseover={p.hoverNeighborhood}

--- a/taui/src/components/draw-neighborhood-bounds.js
+++ b/taui/src/components/draw-neighborhood-bounds.js
@@ -6,8 +6,7 @@ import {LayerGroup} from 'react-leaflet'
 import {
   NEIGHBORHOOD_BOUNDS_STYLE,
   NEIGHBORHOOD_HOVER_COLOR,
-  NEIGHBORHOOD_NONROUTABLE_COLOR,
-  NEIGHBORHOOD_ROUTABLE_COLOR
+  NEIGHBORHOOD_NONROUTABLE_COLOR
 } from '../constants'
 
 import VGrid from './vector-grid'
@@ -16,9 +15,9 @@ export default class DrawNeighborhoodBounds extends React.PureComponent {
   _key = 0
   _getKey () { return this._key++ }
 
-  hoverStyle = (feature, activeNeighborhood) => {
+  hoverStyle = (feature) => {
     return Object.assign({}, NEIGHBORHOOD_BOUNDS_STYLE, {
-      fillColor: feature.id === activeNeighborhood || feature.routable
+      fillColor: feature.routable
         ? NEIGHBORHOOD_HOVER_COLOR
         : NEIGHBORHOOD_NONROUTABLE_COLOR
     })
@@ -32,7 +31,6 @@ export default class DrawNeighborhoodBounds extends React.PureComponent {
 
   render () {
     const p = this.props
-    const activeNeighborhood = p.activeNeighborhood
     const hoverStyle = this.hoverStyle
     const getTooltip = this.getTooltip
     return <LayerGroup key={`neighborhood-boundary-${this._getKey()}`}>
@@ -40,21 +38,13 @@ export default class DrawNeighborhoodBounds extends React.PureComponent {
         data={p.neighborhoods}
         idField='id'
         tooltip={(feature) => getTooltip(feature)}
-        hoverStyle={(feature, activeNeighborhood) => hoverStyle(feature, activeNeighborhood)}
+        hoverStyle={(feature) => hoverStyle(feature)}
         onClick={p.clickNeighborhood}
         onMouseover={p.hoverNeighborhood}
         zIndex={p.zIndex}
         style={NEIGHBORHOOD_BOUNDS_STYLE}
         vectorTileLayerStyles={
-          {'sliced': (properties) => {
-            return Object.assign({}, NEIGHBORHOOD_BOUNDS_STYLE, {
-              fillColor: properties.id === activeNeighborhood
-                ? NEIGHBORHOOD_HOVER_COLOR
-                : (properties.routable
-                  ? NEIGHBORHOOD_ROUTABLE_COLOR
-                  : NEIGHBORHOOD_NONROUTABLE_COLOR)
-            })
-          }}
+          {'sliced': p.styleNeighborhood}
         }
       />}
     </LayerGroup>

--- a/taui/src/components/draw-neighborhood-bounds.js
+++ b/taui/src/components/draw-neighborhood-bounds.js
@@ -4,7 +4,7 @@ import {LayerGroup} from 'react-leaflet'
 
 import {
   NEIGHBORHOOD_BOUNDS_STYLE,
-  NEIGHBORHOOD_BOUNDS_HOVER_STYLE,
+  NEIGHBORHOOD_HOVER_COLOR,
   NEIGHBORHOOD_NONROUTABLE_COLOR,
   NEIGHBORHOOD_ROUTABLE_COLOR
 } from '../constants'
@@ -23,15 +23,17 @@ export default class DrawNeighborhoodBounds extends React.PureComponent {
         idField='id'
         tooltip='town'
         onClick={p.clickNeighborhood}
+        onMouseover={p.hoverNeighborhood}
         zIndex={p.zIndex}
         style={NEIGHBORHOOD_BOUNDS_STYLE}
-        hoverStyle={NEIGHBORHOOD_BOUNDS_HOVER_STYLE}
         vectorTileLayerStyles={
           {'sliced': (properties) => {
             return Object.assign({}, NEIGHBORHOOD_BOUNDS_STYLE, {
-              fillColor: properties.routable
-                ? NEIGHBORHOOD_ROUTABLE_COLOR
-                : NEIGHBORHOOD_NONROUTABLE_COLOR
+              fillColor: properties.active
+                ? NEIGHBORHOOD_HOVER_COLOR
+                : (properties.routable
+                  ? NEIGHBORHOOD_ROUTABLE_COLOR
+                  : NEIGHBORHOOD_NONROUTABLE_COLOR)
             })
           }}
         }

--- a/taui/src/components/draw-route.js
+++ b/taui/src/components/draw-route.js
@@ -5,16 +5,14 @@ import {CircleMarker, FeatureGroup, Polyline} from 'react-leaflet'
 
 export default class DrawRoute extends React.PureComponent {
   componentWillReceiveProps (nextProps) {
+    if (!nextProps.showDetails) return
     // Zoom to active route on going to detail view, or back to full extent on returning to list
     const layer = this.refs ? get(this.refs, 'features.leafletElement') : null
     if (!layer || (nextProps.activeNeighborhood &&
       nextProps.activeNeighborhood !== nextProps.id)) {
       return
     }
-    const needToZoomIn = nextProps.showDetails && !this.props.showDetails
-    if (needToZoomIn) {
-      layer._map.fitBounds(layer.getBounds())
-    }
+    layer._map.fitBounds(layer.getBounds())
   }
 
   render () {

--- a/taui/src/components/main-page.js
+++ b/taui/src/components/main-page.js
@@ -150,6 +150,7 @@ export default class MainPage extends React.PureComponent<Props> {
           <Map
             {...p.map}
             activeNeighborhood={p.data.activeNeighborhood}
+            activeNeighborhoodBounds={p.activeNeighborhoodBounds}
             activeNetworkIndex={p.activeNetworkIndex}
             clearStartAndEnd={this._clearStartAndEnd}
             detailNeighborhood={p.detailNeighborhood}

--- a/taui/src/components/main-page.js
+++ b/taui/src/components/main-page.js
@@ -112,6 +112,7 @@ export default class MainPage extends React.PureComponent<Props> {
     return (
       <div className={mapScreenClass}>
         <Dock
+          activeNeighborhood={p.data.activeNeighborhood}
           changeUserProfile={p.changeUserProfile}
           componentError={this.state.componentError}
           detailNeighborhood={p.detailNeighborhood}

--- a/taui/src/components/map.js
+++ b/taui/src/components/map.js
@@ -256,6 +256,7 @@ export default class Map extends PureComponent<Props, State> {
         {!p.isLoading && p.routableNeighborhoods &&
           <DrawNeighborhoodBounds
             key={`start-${this._getKey()}`}
+            activeNeighborhood={p.activeNeighborhood}
             clickNeighborhood={clickNeighborhood}
             hoverNeighborhood={hoverNeighborhood}
             neighborhoods={p.routableNeighborhoods}

--- a/taui/src/components/map.js
+++ b/taui/src/components/map.js
@@ -11,6 +11,12 @@ import {
   ZoomControl
 } from 'react-leaflet'
 
+import {
+  NEIGHBORHOOD_BOUNDS_STYLE,
+  NEIGHBORHOOD_HOVER_COLOR,
+  NEIGHBORHOOD_NONROUTABLE_COLOR,
+  NEIGHBORHOOD_ROUTABLE_COLOR
+} from '../constants'
 import type {
   Coordinate,
   Location,
@@ -96,6 +102,7 @@ export default class Map extends PureComponent<Props, State> {
     super(props)
     this.clickNeighborhood = this.clickNeighborhood.bind(this)
     this.hoverNeighborhood = this.hoverNeighborhood.bind(this)
+    this.styleNeighborhood = this.styleNeighborhood.bind(this)
   }
 
   state = {
@@ -143,6 +150,22 @@ export default class Map extends PureComponent<Props, State> {
       })
       return false
     }
+  }
+
+  // Define neighborhood bounds layer styling here instead of in
+  // `draw-neighborhood-bounds.js` to access `activeNeighborhood` off of the map properties
+  // without having to pass `activeNeighborhood` to the VectorGrid component.
+  // This prevents the bounds layer react component from redrawing when the active neighborhood
+  // changes, while still styling the active neigbhorhood differently on layer load.
+  styleNeighborhood = (feature) => {
+    const activeNeighborhood = this.props.activeNeighborhood
+    return Object.assign({}, NEIGHBORHOOD_BOUNDS_STYLE, {
+      fillColor: activeNeighborhood === feature.id
+        ? NEIGHBORHOOD_HOVER_COLOR
+        : (feature.routable
+          ? NEIGHBORHOOD_ROUTABLE_COLOR
+          : NEIGHBORHOOD_NONROUTABLE_COLOR)
+    })
   }
 
   /**
@@ -211,6 +234,7 @@ export default class Map extends PureComponent<Props, State> {
     const p = this.props
     const clickNeighborhood = this.clickNeighborhood
     const hoverNeighborhood = this.hoverNeighborhood
+    const styleNeighborhood = this.styleNeighborhood
 
     // Index elements with keys to reset them when elements are added / removed
     this._key = 0
@@ -256,10 +280,10 @@ export default class Map extends PureComponent<Props, State> {
         {!p.isLoading && p.routableNeighborhoods &&
           <DrawNeighborhoodBounds
             key={`start-${this._getKey()}`}
-            activeNeighborhood={p.activeNeighborhood}
             clickNeighborhood={clickNeighborhood}
             hoverNeighborhood={hoverNeighborhood}
             neighborhoods={p.routableNeighborhoods}
+            styleNeighborhood={styleNeighborhood}
             zIndex={getZIndex()}
           />}
 

--- a/taui/src/components/map.js
+++ b/taui/src/components/map.js
@@ -11,6 +11,7 @@ import {
   ZoomControl
 } from 'react-leaflet'
 
+import {NEIGHBORHOOD_ACTIVE_BOUNDS_STYLE} from '../constants'
 import type {
   Coordinate,
   Location,
@@ -20,6 +21,7 @@ import type {
 
 import DrawNeighborhoodBounds from './draw-neighborhood-bounds'
 import DrawRoute from './draw-route'
+import VGrid from './vector-grid'
 
 const TILE_URL = Leaflet.Browser.retina && process.env.LEAFLET_RETINA_URL
   ? process.env.LEAFLET_RETINA_URL
@@ -261,6 +263,17 @@ export default class Map extends PureComponent<Props, State> {
             hoverNeighborhood={hoverNeighborhood}
             neighborhoods={p.routableNeighborhoods}
             styleNeighborhood={styleNeighborhood}
+            zIndex={getZIndex()}
+          />}
+
+        {!p.isLoading && p.activeNeighborhoodBounds &&
+          <VGrid
+            data={p.activeNeighborhoodBounds}
+            interactive={false}
+            key={`active-bounds-${p.activeNeighborhood}-${this._getKey()}`}
+            vectorTileLayerStyles={
+              {'sliced': NEIGHBORHOOD_ACTIVE_BOUNDS_STYLE}
+            }
             zIndex={getZIndex()}
           />}
 

--- a/taui/src/components/map.js
+++ b/taui/src/components/map.js
@@ -132,7 +132,7 @@ export default class Map extends PureComponent<Props, State> {
 
   // Hover over neighborhood map bounds or marker
   hoverNeighborhood = (feature, event) => {
-    if (!feature || !feature.properties) return
+    if (this.props.showDetails || !feature || !feature.properties) return
     const sleep = (time) => {
       return new Promise((resolve) => setTimeout(resolve, time))
     }
@@ -273,7 +273,7 @@ export default class Map extends PureComponent<Props, State> {
             </Popup>
           </Marker>}
 
-        {p.displayNeighborhoods && p.displayNeighborhoods.length &&
+        {!p.showDetails && p.displayNeighborhoods && p.displayNeighborhoods.length &&
           p.displayNeighborhoods.map((n) =>
             <Marker
               icon={n.active ? endIcon : otherIcon}

--- a/taui/src/components/map.js
+++ b/taui/src/components/map.js
@@ -11,12 +11,6 @@ import {
   ZoomControl
 } from 'react-leaflet'
 
-import {
-  NEIGHBORHOOD_BOUNDS_STYLE,
-  NEIGHBORHOOD_HOVER_COLOR,
-  NEIGHBORHOOD_NONROUTABLE_COLOR,
-  NEIGHBORHOOD_ROUTABLE_COLOR
-} from '../constants'
 import type {
   Coordinate,
   Location,
@@ -102,7 +96,6 @@ export default class Map extends PureComponent<Props, State> {
     super(props)
     this.clickNeighborhood = this.clickNeighborhood.bind(this)
     this.hoverNeighborhood = this.hoverNeighborhood.bind(this)
-    this.styleNeighborhood = this.styleNeighborhood.bind(this)
   }
 
   state = {
@@ -150,22 +143,6 @@ export default class Map extends PureComponent<Props, State> {
       })
       return false
     }
-  }
-
-  // Define neighborhood bounds layer styling here instead of in
-  // `draw-neighborhood-bounds.js` to access `activeNeighborhood` off of the map properties
-  // without having to pass `activeNeighborhood` to the VectorGrid component.
-  // This prevents the bounds layer react component from redrawing when the active neighborhood
-  // changes, while still styling the active neigbhorhood differently on layer load.
-  styleNeighborhood = (feature) => {
-    const activeNeighborhood = this.props.activeNeighborhood
-    return Object.assign({}, NEIGHBORHOOD_BOUNDS_STYLE, {
-      fillColor: activeNeighborhood === feature.id
-        ? NEIGHBORHOOD_HOVER_COLOR
-        : (feature.routable
-          ? NEIGHBORHOOD_ROUTABLE_COLOR
-          : NEIGHBORHOOD_NONROUTABLE_COLOR)
-    })
   }
 
   /**

--- a/taui/src/components/map.js
+++ b/taui/src/components/map.js
@@ -301,7 +301,7 @@ export default class Map extends PureComponent<Props, State> {
         {!p.showDetails && p.displayNeighborhoods && p.displayNeighborhoods.length &&
           p.displayNeighborhoods.map((n) =>
             <Marker
-              icon={n.active ? endIcon : otherIcon}
+              icon={n.properties.id === p.activeNeighborhood ? endIcon : otherIcon}
               key={`n-${n.properties.id}-${this._getKey()}`}
               onClick={(e) => clickNeighborhood(n)}
               onHover={(e) => hoverNeighborhood(n)}

--- a/taui/src/components/map.js
+++ b/taui/src/components/map.js
@@ -140,10 +140,9 @@ export default class Map extends PureComponent<Props, State> {
     }
     if (feature.properties.routable) {
       // Change active neighborhood after a delay to prevent Leaflet mouse event errors
-      sleep(50).then(() => {
+      sleep(10).then(() => {
         this.props.setActiveNeighborhood(feature.properties.id)
       })
-      return false
     }
   }
 

--- a/taui/src/components/map.js
+++ b/taui/src/components/map.js
@@ -124,8 +124,6 @@ export default class Map extends PureComponent<Props, State> {
   clickNeighborhood = (feature) => {
     // only go to routable neighborhood details
     if (feature.properties.routable) {
-      // Toggle `showDetails` off first to zoom to route on switching detail views
-      this.props.setShowDetails(false)
       this.props.setActiveNeighborhood(feature.properties.id)
       this.props.setShowDetails(true)
     } else {
@@ -133,6 +131,7 @@ export default class Map extends PureComponent<Props, State> {
     }
   }
 
+  // Debounced version of setActiveNeighborhood used on hover
   debouncedSetActive = debounce(this.props.setActiveNeighborhood, 100)
 
   // Hover over neighborhood map bounds or marker

--- a/taui/src/components/map.js
+++ b/taui/src/components/map.js
@@ -1,6 +1,7 @@
 // @flow
 import lonlat from '@conveyal/lonlat'
 import Leaflet from 'leaflet'
+import debounce from 'lodash/debounce'
 import get from 'lodash/get'
 import React, {PureComponent} from 'react'
 import {
@@ -132,17 +133,13 @@ export default class Map extends PureComponent<Props, State> {
     }
   }
 
+  debouncedSetActive = debounce(this.props.setActiveNeighborhood, 100)
+
   // Hover over neighborhood map bounds or marker
   hoverNeighborhood = (feature, event) => {
     if (this.props.showDetails || !feature || !feature.properties) return
-    const sleep = (time) => {
-      return new Promise((resolve) => setTimeout(resolve, time))
-    }
     if (feature.properties.routable) {
-      // Change active neighborhood after a delay to prevent Leaflet mouse event errors
-      sleep(10).then(() => {
-        this.props.setActiveNeighborhood(feature.properties.id)
-      })
+      this.debouncedSetActive(feature.properties.id)
     }
   }
 

--- a/taui/src/components/map.js
+++ b/taui/src/components/map.js
@@ -42,6 +42,13 @@ const iconSize = [iconWidth, iconHeight]
 const iconAnchor = [iconWidth / 2, iconHeight + 13] // height plus the pointer size
 const iconHTML = '' // <div className="innerMarker"></div>'
 
+const endIcon = Leaflet.divIcon({
+  className: 'LeafletIcon End map__marker map__marker--end',
+  html: iconHTML,
+  iconAnchor,
+  iconSize
+})
+
 const startIcon = Leaflet.divIcon({
   className: 'LeafletIcon Start map__marker map__marker--start',
   html: iconHTML,
@@ -189,10 +196,6 @@ export default class Map extends PureComponent<Props, State> {
     const p = this.props
     const clickNeighborhood = this.clickNeighborhood
 
-    const otherNeighborhoods = (p.displayNeighborhoods && !p.showDetails)
-      ? filter(p.displayNeighborhoods, n => !n.active)
-      : []
-
     // Index elements with keys to reset them when elements are added / removed
     this._key = 0
     let zIndex = 0
@@ -253,13 +256,13 @@ export default class Map extends PureComponent<Props, State> {
             </Popup>
           </Marker>}
 
-        {otherNeighborhoods && otherNeighborhoods.length &&
-          otherNeighborhoods.map((other) =>
+        {p.displayNeighborhoods && p.displayNeighborhoods.length &&
+          p.displayNeighborhoods.map((n) =>
             <Marker
-              icon={otherIcon}
-              key={`other-${other.properties.id}-${this._getKey()}`}
-              onClick={(e) => clickNeighborhood(other)}
-              position={lonlat.toLeaflet(other.geometry.coordinates)}
+              icon={n.active ? endIcon : otherIcon}
+              key={`n-${n.properties.id}-${this._getKey()}`}
+              onClick={(e) => clickNeighborhood(n)}
+              position={lonlat.toLeaflet(n.geometry.coordinates)}
               zIndex={getZIndex()}
             />)}
       </LeafletMap> : null

--- a/taui/src/components/route-card.js
+++ b/taui/src/components/route-card.js
@@ -41,6 +41,7 @@ export default class RouteCard extends React.PureComponent<Props> {
 
   render () {
     const {
+      activeNeighborhood,
       isFavorite,
       goToDetails,
       neighborhood,
@@ -51,7 +52,8 @@ export default class RouteCard extends React.PureComponent<Props> {
       userProfile
     } = this.props
 
-    const markerClass = `neighborhood-summary__marker ${neighborhood.active ? 'neighborhood-summary__marker--on' : ''}`
+    const active = activeNeighborhood === neighborhood.properties.id
+    const markerClass = `neighborhood-summary__marker ${active ? 'neighborhood-summary__marker--on' : ''}`
     const { time } = neighborhood
     const originLabel = origin ? origin.label || '' : ''
     const currentDestination = userProfile.destinations.find(d => originLabel.endsWith(d.location.label))

--- a/taui/src/constants.js
+++ b/taui/src/constants.js
@@ -73,6 +73,7 @@ export const TRANSIT_STYLE = {
 
 export const NEIGHBORHOOD_NONROUTABLE_COLOR = '#85929E'
 export const NEIGHBORHOOD_ROUTABLE_COLOR = '#15369d'
+export const NEIGHBORHOOD_HOVER_COLOR = '#159d37'
 
 export const NEIGHBORHOOD_BOUNDS_STYLE = {
   stroke: true,
@@ -82,16 +83,6 @@ export const NEIGHBORHOOD_BOUNDS_STYLE = {
   fill: true,
   fillColor: '#85929E',
   fillOpacity: 0.4
-}
-
-export const NEIGHBORHOOD_BOUNDS_HOVER_STYLE = {
-  stroke: true,
-  weight: 1,
-  color: '#fff',
-  opacity: 0.5,
-  fill: true,
-  fillColor: '#159d37',
-  fillOpacity: 0.6
 }
 
 export const NEIGHBORHOOD_STYLE = {

--- a/taui/src/constants.js
+++ b/taui/src/constants.js
@@ -75,6 +75,16 @@ export const NEIGHBORHOOD_NONROUTABLE_COLOR = '#85929E'
 export const NEIGHBORHOOD_ROUTABLE_COLOR = '#15369d'
 export const NEIGHBORHOOD_HOVER_COLOR = '#159d37'
 
+export const NEIGHBORHOOD_ACTIVE_BOUNDS_STYLE = {
+  stroke: true,
+  weight: 1,
+  color: '#fff',
+  opacity: 1,
+  fill: true,
+  fillColor: '#159d37',
+  fillOpacity: 1
+}
+
 export const NEIGHBORHOOD_BOUNDS_STYLE = {
   stroke: true,
   weight: 1,

--- a/taui/src/index.js
+++ b/taui/src/index.js
@@ -63,6 +63,7 @@ function mapStateToProps (state, ownProps) {
     ...state,
     accessibility: select.accessibility(state, ownProps),
     activeNetworkIndex: select.activeNetworkIndex(state, ownProps),
+    activeNeighborhoodBounds: select.activeNeighborhoodBounds(state, ownProps),
     detailNeighborhood: select.detailNeighborhood(state, ownProps),
     displayPageNeighborhoods: select.displayPageNeighborhoods(state, ownProps),
     drawNeighborhoodRoute: select.drawNeighborhoodRoute(state, ownProps),

--- a/taui/src/selectors/active-neighborhood-bounds.js
+++ b/taui/src/selectors/active-neighborhood-bounds.js
@@ -1,0 +1,19 @@
+// @flow
+import get from 'lodash/get'
+import {createSelector} from 'reselect'
+
+export default createSelector(
+  state => get(state, 'data.activeNeighborhood'),
+  state => get(state, 'data.neighborhoodBounds'),
+  (activeNeighborhood, neighborhoodBounds) => {
+    if (!neighborhoodBounds || !activeNeighborhood) {
+      return null
+    }
+    // Return a GeoJSON feature collection with a single feature,
+    // the MultiPolygon bounds for the currently active neighborhood.
+    const geojson = Object.assign({}, neighborhoodBounds)
+    geojson.features = [neighborhoodBounds.features.find(
+      f => f.properties.id === activeNeighborhood)]
+    return geojson
+  }
+)

--- a/taui/src/selectors/index.js
+++ b/taui/src/selectors/index.js
@@ -1,6 +1,7 @@
 // @flow
 export {default as accessibility} from './accessibility'
 export {default as activeNetworkIndex} from './active-network-index'
+export {default as activeNeighborhoodBounds} from './active-neighborhood-bounds'
 export {default as detailNeighborhood} from './detail-neighborhood'
 export {default as displayPageNeighborhoods} from './display-page-neighborhoods'
 export {default as drawOpportunityDatasets} from './draw-opportunity-datasets'

--- a/taui/src/selectors/neighborhoods-sorted-with-routes.js
+++ b/taui/src/selectors/neighborhoods-sorted-with-routes.js
@@ -62,7 +62,6 @@ export default createSelector(
     const neighborhoodsWithRoutes = filter(neighborhoods.features.map((n, index) => {
       const properties: NeighborhoodProperties = n.properties
       const route = neighborhoodRoutes[index]
-      const active = route.active
       const segments = useTransit ? route.routeSegments : []
       const time = useTransit ? travelTimes[index] : distanceTime(origin, n)
 
@@ -89,7 +88,7 @@ export default createSelector(
         (crimeWeight * crimePercent) +
         (educationWeight * schoolPercent)
 
-      return Object.assign({active,
+      return Object.assign({
         score,
         segments,
         time,

--- a/taui/src/selectors/network-neighborhood-routes.js
+++ b/taui/src/selectors/network-neighborhood-routes.js
@@ -34,19 +34,13 @@ const uniqueSegments = routeSegments => {
 
 export default createSelector(
   selectActiveNetworkIndex,
-  state => get(state, 'data.activeNeighborhood'),
   state => get(state, 'data.networks'),
   state => get(state, 'data.origin'),
   state => get(state, 'data.neighborhoods'),
-  (activeNetworkIndex, activeNeighborhood, networks, start, neighborhoods) => {
+  (activeNetworkIndex, networks, start, neighborhoods) => {
     const network = networks[activeNetworkIndex]
     if (!neighborhoods || !neighborhoods.features || !neighborhoods.features.length || !network) {
       return []
-    }
-
-    // Default to first neighborhood active, as does draw-neighborhood-routes
-    if (!activeNeighborhood) {
-      activeNeighborhood = neighborhoods.features[0].id
     }
 
     const routes = []
@@ -70,7 +64,6 @@ export default createSelector(
         // also repeated for all results: patterns, routes, stops
         const result = memoizedTransitiveRoutes(network, neighborhoodIndex, start, end)
         routes.push({
-          active: neighborhood.properties.id === activeNeighborhood,
           id: neighborhood.properties.id,
           label: neighborhood.properties.town, // not unique
           journeys: result.journeys,

--- a/taui/src/selectors/routable-neighborhoods.js
+++ b/taui/src/selectors/routable-neighborhoods.js
@@ -8,7 +8,8 @@ import neighborhoodsSortedWithRoutes from './neighborhoods-sorted-with-routes'
 export default createSelector(
   neighborhoodsSortedWithRoutes,
   state => get(state, 'data.neighborhoodBounds'),
-  (neighborhoodsSortedWithRoutes, neighborhoods) => {
+  state => get(state, 'data.activeNeighborhood'),
+  (neighborhoodsSortedWithRoutes, neighborhoods, activeNeighborhood) => {
     if (!neighborhoodsSortedWithRoutes || !neighborhoodsSortedWithRoutes.length) {
       return neighborhoods
     }
@@ -17,6 +18,7 @@ export default createSelector(
         s => s.properties.id === n.properties.id)
       const neighborhood = Object.assign({}, n)
       neighborhood.properties.routable = routable
+      neighborhood.properties.active = n.properties.id === activeNeighborhood
       return neighborhood
     })
     return Object.assign({}, neighborhoods, {features: routableNeighborhoods})

--- a/taui/src/selectors/routable-neighborhoods.js
+++ b/taui/src/selectors/routable-neighborhoods.js
@@ -8,8 +8,7 @@ import neighborhoodsSortedWithRoutes from './neighborhoods-sorted-with-routes'
 export default createSelector(
   neighborhoodsSortedWithRoutes,
   state => get(state, 'data.neighborhoodBounds'),
-  state => get(state, 'data.activeNeighborhood'),
-  (neighborhoodsSortedWithRoutes, neighborhoods, activeNeighborhood) => {
+  (neighborhoodsSortedWithRoutes, neighborhoods) => {
     if (!neighborhoodsSortedWithRoutes || !neighborhoodsSortedWithRoutes.length) {
       return neighborhoods
     }
@@ -18,7 +17,6 @@ export default createSelector(
         s => s.properties.id === n.properties.id)
       const neighborhood = Object.assign({}, n)
       neighborhood.properties.routable = routable
-      neighborhood.properties.active = n.properties.id === activeNeighborhood
       return neighborhood
     })
     return Object.assign({}, neighborhoods, {features: routableNeighborhoods})

--- a/taui/yarn.lock
+++ b/taui/yarn.lock
@@ -1026,9 +1026,9 @@
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
 "@octokit/endpoint@^5.1.0":
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-5.1.4.tgz#e6bb3ceda8923fdc9703ded78c9acc28eff88c06"
-  integrity sha512-DypS8gbbcc9rlOCDW0wV9a+B18+ylduj6PpxeE+qa3IK1h5b0eW4CKj5pxxXWOZUYhEKwgOnh3+Q+Y/hx/bOPw==
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-5.1.5.tgz#a9505b835fae98dde5f4b63e53b1605b63424d1a"
+  integrity sha512-Es0Qj6ynp0mznTnayCX8veXev43/fGjwVvctynwgzcnW+KIK6nrHdqQXUnAA1Az0DsRgbGsh9fDHjP/3Ybfyyw==
   dependencies:
     deepmerge "3.2.0"
     is-plain-object "^3.0.0"
@@ -1057,9 +1057,9 @@
     universal-user-agent "^2.1.0"
 
 "@octokit/rest@^16.13.1":
-  version "16.27.3"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.27.3.tgz#20ad5d0c7043364d1e1f72fa74f825c181771fc0"
-  integrity sha512-WWH/SHF4kus6FG+EAfX7/JYH70EjgFYa4AAd2Lf1hgmgzodhrsoxpXPSZliZ5BdJruZPMP7ZYaPoTrYCCKYzmQ==
+  version "16.28.1"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.28.1.tgz#a10c3d4fe61e994878d66a4c12b9923b18548236"
+  integrity sha512-9H/5F0f2bSVhk78ypu/A9dkK5GCH/aI8CxRJ0L8JU/XEYNIYozxqD6HVC7shsofrCfR61YORfjTE+GxfZ/wasQ==
   dependencies:
     "@octokit/request" "^4.0.1"
     "@octokit/request-error" "^1.0.2"
@@ -1194,9 +1194,9 @@
     "@babel/types" "^7.0.0"
 
 "@types/babel__traverse@*", "@types/babel__traverse@^7.0.6":
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.0.6.tgz#328dd1a8fc4cfe3c8458be9477b219ea158fd7b2"
-  integrity sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.0.7.tgz#2496e9ff56196cc1429c72034e07eab6121b6f3f"
+  integrity sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==
   dependencies:
     "@babel/types" "^7.3.0"
 
@@ -1240,9 +1240,9 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*":
-  version "12.0.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.6.tgz#215fa05292dab13e0ebc066f54d14eb983c5ad78"
-  integrity sha512-3sV/MUw6uYxPaRIoooI/MjO0j1A06JNlbpkGc56F+zikO52qavehD/Qw85so47gWhO82tNzEFoF6adXqIfK+EA==
+  version "12.0.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.8.tgz#551466be11b2adc3f3d47156758f610bd9f6b1d8"
+  integrity sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -1758,10 +1758,10 @@ aws-sdk@2.329.0:
     uuid "3.1.0"
     xml2js "0.4.19"
 
-aws-sdk@~2.469.0:
-  version "2.469.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.469.0.tgz#b52dbbffdcb52f3f01981eaad1559e0cdca53bd9"
-  integrity sha512-VaIrO3aBX83gKkBPk9xM0RHmu7fmq76kaF0SqbsWlPImgxc5foJ4rBlRMMlmeNogFZZ/XTQdI+gkFDVosV14Ig==
+aws-sdk@~2.473.0:
+  version "2.473.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.473.0.tgz#2dd7e661471f21bdab399e93e606ee97e57e6960"
+  integrity sha512-1Qr16lOcz4ANzl/oPQRR+fxchfvUx4PVQhUNnDU3FH9OBfU3Xj+Vh6bGYFbreFQgqIqXUTEuJR5pC44uK70YfA==
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -2000,9 +2000,9 @@ boolify@^1.0.0:
   integrity sha1-tcCeF8rNET0Rt7s+04TMASmU2Gs=
 
 bottleneck@^2.0.1:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.0.tgz#deafece998dd99506f6a387de5723cc0953e6b7b"
-  integrity sha512-0U9t0ALx89RC0AlHVxmDNl1UdlBZYE6RusW57EsR808WirvWbP2VNAp7i3FyIemGqTxQlaZ0MICAet9Myp0N1Q==
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.1.tgz#f7657aed83edff1fa41d438cdbdf3e0931a1d3f0"
+  integrity sha512-TrdmthuOG5SpYfFQTprSQOtqQUTreAgPkCFfow/aVOnryRRpIwiwfiQmmJUiiHUKgPV7LBNlfGecJ5hCVs30gw==
 
 boxen@^1.2.1:
   version "1.3.0"
@@ -2205,13 +2205,13 @@ browserify@^16.1.0, browserify@^16.2.3, browserify@~16.2.3:
     xtend "^4.0.0"
 
 browserslist@^4.0.0, browserslist@^4.4.2, browserslist@^4.6.0, browserslist@^4.6.1:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.6.1.tgz#ee5059b1aec18cbec9d055d6cb5e24ae50343a9b"
-  integrity sha512-1MC18ooMPRG2UuVFJTHFIAkk6mpByJfxCrnUyvSlu/hyQSFHMrlhM02SzNuCV+quTP4CKmqtOMAIjrifrpBJXQ==
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.6.2.tgz#574c665950915c2ac73a4594b8537a9eba26203f"
+  integrity sha512-2neU/V0giQy9h3XMPwLhEY3+Ao0uHSwHvU8Q1Ea6AgLVL1sXbX3dzPrJ8NWe5Hi4PoTkCYXOtVR9rfRLI0J/8Q==
   dependencies:
-    caniuse-lite "^1.0.30000971"
-    electron-to-chromium "^1.3.137"
-    node-releases "^1.1.21"
+    caniuse-lite "^1.0.30000974"
+    electron-to-chromium "^1.3.150"
+    node-releases "^1.1.23"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -2446,7 +2446,7 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000939, caniuse-lite@^1.0.30000971, caniuse-lite@~1.0.30000973:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000939, caniuse-lite@^1.0.30000971, caniuse-lite@^1.0.30000974, caniuse-lite@~1.0.30000974:
   version "1.0.30000974"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz#b7afe14ee004e97ce6dc73e3f878290a12928ad8"
   integrity sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==
@@ -2729,6 +2729,13 @@ clone-regexp@^1.0.0:
   dependencies:
     is-regexp "^1.0.0"
     is-supported-regexp-flag "^1.0.0"
+
+clone-regexp@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/clone-regexp/-/clone-regexp-2.2.0.tgz#7d65e00885cd8796405c35a737e7a86b7429e36f"
+  integrity sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==
+  dependencies:
+    is-regexp "^2.0.0"
 
 clone@^1.0.2:
   version "1.0.4"
@@ -3598,7 +3605,7 @@ debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@~4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@^1.0.1:
+debuglog@*, debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -3929,10 +3936,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.137:
-  version "1.3.149"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.149.tgz#80c9ea1cf9d2bcebc4fbdcc9c829bebf636d6dac"
-  integrity sha512-XO+s6imdgjUS5hHDwh31fpkzxiIz7hFX8B5qnJdlP/BnzqqDF2A/YoitbGt5TknCm8dS9tIYdiXwDbarsonaFA==
+electron-to-chromium@^1.3.150:
+  version "1.3.157"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.157.tgz#6211d69e8c4ee18df8c84e74e8644bcafc09486c"
+  integrity sha512-vxGi3lOGqlupuogZxJOMfu+Q1vaOlG6XbsblWw8XnUZSr/ptbt3D6jhHT5LJPZuFUpKhbEo1u4QipivSory1Kg==
 
 elliptic@^6.0.0:
   version "6.4.1"
@@ -4047,7 +4054,7 @@ es-to-primitive@^1.2.0:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
+es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.9, es5-ext@~0.10.14:
   version "0.10.50"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.50.tgz#6d0e23a0abdb27018e5ac4fd09b412bc5517a778"
   integrity sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==
@@ -4056,7 +4063,7 @@ es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
     es6-symbol "~3.1.1"
     next-tick "^1.0.0"
 
-es6-iterator@^2.0.1, es6-iterator@~2.0.1, es6-iterator@~2.0.3:
+es6-iterator@^2.0.3, es6-iterator@~2.0.1, es6-iterator@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
   integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
@@ -4114,13 +4121,13 @@ es6-symbol@3.1.1, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
     es5-ext "~0.10.14"
 
 es6-weak-map@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
-  integrity sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.3.tgz#b6da1f16cc2cc0d9be43e6bdbfc5e7dfcdf31d53"
+  integrity sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==
   dependencies:
     d "1"
-    es5-ext "^0.10.14"
-    es6-iterator "^2.0.1"
+    es5-ext "^0.10.46"
+    es6-iterator "^2.0.3"
     es6-symbol "^3.1.1"
 
 escape-html@^1.0.3, escape-html@~1.0.3:
@@ -4189,10 +4196,10 @@ eslint-plugin-es@^1.4.0:
     eslint-utils "^1.3.0"
     regexpp "^2.0.1"
 
-eslint-plugin-flowtype@~3.9.1:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.9.1.tgz#6491d930e1f96d53c510e0393e635fddd4a4cac5"
-  integrity sha512-ZlV6SbIXqz2ysvG0F64ZH07dqzLrwMdM1s0UNfoxdXjr4kMKuPPoLViwK+gFC952QIf341AmP4BKtKOhcB96Ug==
+eslint-plugin-flowtype@~3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.10.1.tgz#f83d4c9a4594b3444433c8efb1caf91dcc0be32a"
+  integrity sha512-TnwILo1XT5w6Fgz8j+NEqivmgsYJA7FYFnnE2jdXot/H7Pb9C2Fp+Tqdzb//O+PSVi5X2ureYqCCn7KDfon4iQ==
   dependencies:
     lodash "^4.17.11"
 
@@ -4520,6 +4527,13 @@ execall@^1.0.0:
   dependencies:
     clone-regexp "^1.0.0"
 
+execall@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/execall/-/execall-2.0.0.tgz#16a06b5fe5099df7d00be5d9c06eecded1663b45"
+  integrity sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==
+  dependencies:
+    clone-regexp "^2.1.0"
+
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -4836,10 +4850,10 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
   integrity sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=
 
-flow-bin@~0.100.0:
-  version "0.100.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.100.0.tgz#729902726658cfa0a81425d6401f9625cf9f5534"
-  integrity sha512-jcethhgrslBJukH7Z7883ohFFpzLrdsOEwHxvn5NwuTWbNaE71GAl55/PEBRJwYpDvYkRlqgcNkANTv0x5XjqA==
+flow-bin@~0.101.0:
+  version "0.101.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.101.0.tgz#c56fa0afb9c151eeba7954136e9066d408691063"
+  integrity sha512-2xriPEOSrGQklAArNw1ixoIUiLTWhIquYV26WqnxEu7IcXWgoZUcfJXufG9kIvrNbdwCNd5RBjTwbB0p6L6XaA==
 
 flow-runtime@~0.17.0:
   version "0.17.0"
@@ -5514,6 +5528,11 @@ html-tags@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
   integrity sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=
 
+html-tags@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.0.0.tgz#41f57708c9e6b7b46a00a22317d614c4a2bab166"
+  integrity sha512-xiXEBjihaNI+VZ2mKEoI5ZPxqUsevTKM+aeeJ/W4KAg2deGE35minmCJMn51BvwJZmiHaeAxrb2LAS0yZJxuuA==
+
 htmlescape@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/htmlescape/-/htmlescape-1.1.1.tgz#3a03edc2214bca3b66424a3e7959349509cb0351"
@@ -5678,6 +5697,11 @@ import-lazy@^3.1.0:
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-3.1.0.tgz#891279202c8a2280fdbd6674dbd8da1a1dfc67cc"
   integrity sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==
 
+import-lazy@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
+  integrity sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==
+
 import-local@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-2.0.0.tgz#55070be38a5993cf18ef6db7e961f5bee5c5a09d"
@@ -5686,7 +5710,7 @@ import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@^0.1.4:
+imurmurhash@*, imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -6194,6 +6218,11 @@ is-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
   integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
+
+is-regexp@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-2.1.0.tgz#cd734a56864e23b956bf4e7c66c396a4c0b22c2d"
+  integrity sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==
 
 is-resolvable@^1.0.0:
   version "1.1.0"
@@ -6957,10 +6986,10 @@ known-css-properties@^0.11.0:
   resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.11.0.tgz#0da784f115ea77c76b81536d7052e90ee6c86a8a"
   integrity sha512-bEZlJzXo5V/ApNNa5z375mJC6Nrz4vG43UgcSCrg2OHC+yuB6j0iDSrY7RQ/+PRofFB03wNIIt9iXIVLr4wc7w==
 
-known-css-properties@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.13.0.tgz#2750fde566cbf542a9876d4acd6bb0257ebadd2c"
-  integrity sha512-6VWDxNr7cQXPDtMdCWLZMK3E8hdLrpyPPRdx6RbyvqklqgM6/XNFsVopv8QOZ+hRB6iHG/urEDwzlWbmMCv/kw==
+known-css-properties@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.14.0.tgz#d7032b4334a32dc22e6e46b081ec789daf18756c"
+  integrity sha512-P+0a/gBzLgVlCnK8I7VcD0yuYJscmWn66wH9tlKsQnmVdg689tLEmziwB9PuazZYLkcm07fvWOKCJJqI55sD5Q==
 
 labeled-stream-splicer@^2.0.0:
   version "2.0.2"
@@ -7081,7 +7110,7 @@ libnpm@^2.0.1:
     read-package-json "^2.0.13"
     stringify-package "^1.0.0"
 
-libnpmaccess@^3.0.1:
+libnpmaccess@*, libnpmaccess@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/libnpmaccess/-/libnpmaccess-3.0.1.tgz#5b3a9de621f293d425191aa2e779102f84167fa8"
   integrity sha512-RlZ7PNarCBt+XbnP7R6PoVgOq9t+kou5rvhaInoNibhPO7eMlRfS0B8yjatgn2yaHIwWNyoJDolC/6Lc5L/IQA==
@@ -7110,7 +7139,7 @@ libnpmhook@^5.0.2:
     get-stream "^4.0.0"
     npm-registry-fetch "^3.8.0"
 
-libnpmorg@^1.0.0:
+libnpmorg@*, libnpmorg@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/libnpmorg/-/libnpmorg-1.0.0.tgz#979b868c48ba28c5820e3bb9d9e73c883c16a232"
   integrity sha512-o+4eVJBoDGMgRwh2lJY0a8pRV2c/tQM/SxlqXezjcAg26Qe9jigYVs+Xk0vvlYDWCDhP0g74J8UwWeAgsB7gGw==
@@ -7135,16 +7164,16 @@ libnpmpublish@^1.1.0:
     semver "^5.5.1"
     ssri "^6.0.1"
 
-libnpmsearch@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/libnpmsearch/-/libnpmsearch-2.0.0.tgz#de05af47ada81554a5f64276a69599070d4a5685"
-  integrity sha512-vd+JWbTGzOSfiOc+72MU6y7WqmBXn49egCCrIXp27iE/88bX8EpG64ST1blWQI1bSMUr9l1AKPMVsqa2tS5KWA==
+libnpmsearch@*, libnpmsearch@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/libnpmsearch/-/libnpmsearch-2.0.1.tgz#eccc73a8fbf267d765d18082b85daa2512501f96"
+  integrity sha512-K0yXyut9MHHCAH+DOiglQCpmBKPZXSUu76+BE2maSEfQN15OwNaA/Aiioe9lRFlVFOr7WcuJCY+VSl+gLi9NTA==
   dependencies:
     figgy-pudding "^3.5.1"
     get-stream "^4.0.0"
     npm-registry-fetch "^3.8.0"
 
-libnpmteam@^1.0.1:
+libnpmteam@*, libnpmteam@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/libnpmteam/-/libnpmteam-1.0.1.tgz#ff704b1b6c06ea674b3b1101ac3e305f5114f213"
   integrity sha512-gDdrflKFCX7TNwOMX1snWojCoDE5LoRWcfOC0C/fqF7mBq8Uz9zWAX4B2RllYETNO7pBupBaSyBDkTAC15cAMg==
@@ -7250,6 +7279,11 @@ lodash-es@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
   integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==
 
+lodash._baseindexof@*:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
+  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
+
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -7258,10 +7292,32 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
+lodash._bindcallback@*:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
+  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
+
+lodash._cacheindexof@*:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
+  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
+
+lodash._createcache@*:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
+  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
+  dependencies:
+    lodash._getnative "^3.0.0"
+
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
+
+lodash._getnative@*, lodash._getnative@^3.0.0:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
+  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
@@ -7322,6 +7378,11 @@ lodash.merge@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
   integrity sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==
+
+lodash.restparam@*:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
+  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -7390,6 +7451,13 @@ log-symbols@^2.0.0, log-symbols@^2.2.0:
   dependencies:
     chalk "^2.0.1"
 
+log-symbols@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-3.0.0.tgz#f3a08516a5dea893336a7dee14d18a1cfdab77c4"
+  integrity sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==
+  dependencies:
+    chalk "^2.4.2"
+
 loglevel-colored-level-prefix@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz#6a40218fdc7ae15fc76c3d0f3e676c465388603e"
@@ -7399,9 +7467,9 @@ loglevel-colored-level-prefix@^1.0.0:
     loglevel "^1.4.1"
 
 loglevel@^1.4.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.2.tgz#668c77948a03dbd22502a3513ace1f62a80cc372"
-  integrity sha512-Jt2MHrCNdtIe1W6co3tF5KXGRkzF+TYffiQstfXa04mrss9IKXzAAXYWak8LbZseAQY03sH2GzMCMU0ZOUc9bg==
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.3.tgz#77f2eb64be55a404c9fd04ad16d57c1d6d6b1280"
+  integrity sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==
 
 logrocket-react@~3.0.0:
   version "3.0.0"
@@ -7464,9 +7532,9 @@ lru-cache@^5.1.1:
     yallist "^3.0.2"
 
 macos-release@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.2.0.tgz#ab58d55dd4714f0a05ad4b0e90f4370fef5cdea8"
-  integrity sha512-iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
+  integrity sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==
 
 magic-string@^0.23.2:
   version "0.23.2"
@@ -7586,7 +7654,7 @@ marked@^0.6.0:
 
 "mastarm@https://github.com/azavea/mastarm.git#dev":
   version "0.1.0"
-  resolved "https://github.com/azavea/mastarm.git#10c6c062c0f1f751dac9c7c5c0601beb9d2c2dd6"
+  resolved "https://github.com/azavea/mastarm.git#3e8601c8e1aabf4a2a27d577ab1bcff55ee3cedb"
   dependencies:
     "@babel/core" "~7.4.5"
     "@babel/plugin-proposal-class-properties" "~7.4.4"
@@ -7599,7 +7667,7 @@ marked@^0.6.0:
     "@babel/preset-react" "~7.0.0"
     "@babel/runtime" "~7.4.5"
     "@babel/runtime-corejs3" "^7.4.5"
-    aws-sdk "~2.469.0"
+    aws-sdk "~2.473.0"
     babel-core "~7.0.0-bridge.0"
     babel-eslint "~10.0.1"
     babel-jest "~24.8.0"
@@ -7611,7 +7679,7 @@ marked@^0.6.0:
     browserify "~16.2.3"
     browserify-css "~0.15.0"
     budo "~11.6.2"
-    caniuse-lite "~1.0.30000973"
+    caniuse-lite "~1.0.30000974"
     chokidar "~3.0.1"
     commander "~2.20.0"
     commitizen "~3.1.1"
@@ -7625,7 +7693,7 @@ marked@^0.6.0:
     eslint "~5.16.0"
     eslint-config-standard "~12.0.0"
     eslint-config-standard-jsx "~6.0.2"
-    eslint-plugin-flowtype "~3.9.1"
+    eslint-plugin-flowtype "~3.10.1"
     eslint-plugin-import "~2.17.3"
     eslint-plugin-jest "~22.6.4"
     eslint-plugin-jsx-a11y "~6.2.1"
@@ -7634,7 +7702,7 @@ marked@^0.6.0:
     eslint-plugin-react "~7.13.0"
     eslint-plugin-standard "~4.0.0"
     exorcist "~1.0.1"
-    flow-bin "~0.100.0"
+    flow-bin "~0.101.0"
     flow-runtime "~0.17.0"
     glob "~7.1.4"
     isomorphic-fetch "~2.2.1"
@@ -7642,7 +7710,7 @@ marked@^0.6.0:
     jest-yaml-transform "~0.2.0"
     lodash.uniq "~4.5.0"
     middleware-proxy "~2.0.5"
-    mime "~2.4.3"
+    mime "~2.4.4"
     minify-stream "~1.2.0"
     mkdirp "~0.5.1"
     node-emoji "~1.10.0"
@@ -7656,7 +7724,7 @@ marked@^0.6.0:
     rimraf "~2.6.3"
     scssify "~3.0.1"
     slack-node "~0.1.8"
-    stylelint "^10.0.1"
+    stylelint "^10.1.0"
     stylelint-config-recommended "^2.2.0"
     this-commit "~1.0.0"
     through2 "~3.0.1"
@@ -7867,10 +7935,10 @@ mime@1.6.0, mime@^1.3.6:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.0.3, mime@~2.4.3:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.3.tgz#229687331e86f68924e6cb59e1cdd937f18275fe"
-  integrity sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw==
+mime@^2.0.3, mime@~2.4.4:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
+  integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -8242,7 +8310,7 @@ node-pre-gyp@^0.12.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.1.21:
+node-releases@^1.1.23:
   version "1.1.23"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.23.tgz#de7409f72de044a2fa59c097f436ba89c39997f0"
   integrity sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==
@@ -8400,7 +8468,7 @@ npm-pick-manifest@^2.2.3:
     npm-package-arg "^6.0.0"
     semver "^5.4.1"
 
-npm-profile@^4.0.1:
+npm-profile@*, npm-profile@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/npm-profile/-/npm-profile-4.0.1.tgz#d350f7a5e6b60691c7168fbb8392c3603583f5aa"
   integrity sha512-NQ1I/1Q7YRtHZXkcuU1/IyHeLy6pd+ScKg4+DQHdfsm769TGq6HPrkbuNJVJS4zwE+0mvvmeULzQdWn2L2EsVA==
@@ -9445,7 +9513,7 @@ postcss-initial@^3.0.0:
     lodash.template "^4.2.4"
     postcss "^7.0.2"
 
-postcss-jsx@^0.36.0:
+postcss-jsx@^0.36.0, postcss-jsx@^0.36.1:
   version "0.36.1"
   resolved "https://registry.yarnpkg.com/postcss-jsx/-/postcss-jsx-0.36.1.tgz#ab5e469e7449b84bd1a5973ff555fbe84c39f91d"
   integrity sha512-xaZpy01YR7ijsFUtu5rViYCFHurFIPHir+faiOQp8g/NfTfWqZCKDhKrydQZ4d8WlSAmVdXGwLjpFbsNUI26Sw==
@@ -10005,9 +10073,9 @@ prettier-eslint@^8.5.0:
     vue-eslint-parser "^2.0.2"
 
 prettier@^1.7.0:
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.1.tgz#ed64b4e93e370cb8a25b9ef7fef3e4fd1c0995db"
-  integrity sha512-TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg==
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
 pretty-format@^23.0.1:
   version "23.6.0"
@@ -10226,9 +10294,9 @@ query-string@^4.2.2, query-string@^4.2.3:
     strict-uri-encode "^1.0.0"
 
 query-string@^6.2.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.6.0.tgz#a6b7dfd57ad67e346b143d033df2b1e4cfb6b53a"
-  integrity sha512-Xhvaa80rZzfvI7gYXF6ism5otKTyea90XROstBTBKiWE/tDfnIDbQwkGLguJaQBNweVCW4T9DoTe5eyox0CbZQ==
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.7.0.tgz#7e92bf8525140cf8c5ebf500f26716b0de5b7023"
+  integrity sha512-oQ01H1jrgDRbPq5SjtJF470S418GOrKkds+fpvAt6DQatHXl7bmkaJulHbTIM+QNGtoPpa8f5k9W3Zk50zXRPQ==
   dependencies:
     decode-uri-component "^0.2.0"
     split-on-first "^1.0.0"
@@ -10637,7 +10705,7 @@ readable-stream@~1.1.10:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=
@@ -11092,9 +11160,9 @@ resolve@1.1.7:
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
 resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
-  integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.0.tgz#4014870ba296176b86343d50b60f3b50609ce232"
+  integrity sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==
   dependencies:
     path-parse "^1.0.6"
 
@@ -11537,6 +11605,11 @@ slash@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
   integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
+
+slash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
+  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
 slice-ansi@1.0.0:
   version "1.0.0"
@@ -12108,30 +12181,30 @@ stylelint-scss@^3.3.1:
     postcss-selector-parser "^6.0.2"
     postcss-value-parser "^3.3.1"
 
-stylelint@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-10.0.1.tgz#f85cd9755e905d826023d67df62b32716fa6dfb4"
-  integrity sha512-NbpD9BvQRmPe7QfaLB2OqhhDr5g6SAn43AAH2XLyqtQ9ZcioQECgadkIbormfhzxLhccAQWBZbVNiZz1oqEf8g==
+stylelint@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-10.1.0.tgz#1bc4c4ce878107e7c396b19226d91ba28268911a"
+  integrity sha512-OmlUXrgzEMLQYj1JPTpyZPR9G4bl0StidfHnGJEMpdiQ0JyTq0MPg1xkHk1/xVJ2rTPESyJCDWjG8Kbpoo7Kuw==
   dependencies:
     autoprefixer "^9.5.1"
     balanced-match "^1.0.0"
     chalk "^2.4.2"
     cosmiconfig "^5.2.0"
     debug "^4.1.1"
-    execall "^1.0.0"
+    execall "^2.0.0"
     file-entry-cache "^5.0.1"
     get-stdin "^7.0.0"
     global-modules "^2.0.0"
     globby "^9.2.0"
     globjoin "^0.1.4"
-    html-tags "^2.0.0"
+    html-tags "^3.0.0"
     ignore "^5.0.6"
-    import-lazy "^3.1.0"
+    import-lazy "^4.0.0"
     imurmurhash "^0.1.4"
-    known-css-properties "^0.13.0"
+    known-css-properties "^0.14.0"
     leven "^3.1.0"
     lodash "^4.17.11"
-    log-symbols "^2.2.0"
+    log-symbols "^3.0.0"
     mathml-tag-names "^2.1.0"
     meow "^5.0.0"
     micromatch "^4.0.0"
@@ -12139,7 +12212,7 @@ stylelint@^10.0.1:
     pify "^4.0.1"
     postcss "^7.0.14"
     postcss-html "^0.36.0"
-    postcss-jsx "^0.36.0"
+    postcss-jsx "^0.36.1"
     postcss-less "^3.1.4"
     postcss-markdown "^0.36.0"
     postcss-media-query-parser "^0.2.3"
@@ -12153,9 +12226,10 @@ stylelint@^10.0.1:
     postcss-value-parser "^3.3.1"
     resolve-from "^5.0.0"
     signal-exit "^3.0.2"
-    slash "^2.0.0"
+    slash "^3.0.0"
     specificity "^0.4.1"
     string-width "^4.1.0"
+    strip-ansi "^5.2.0"
     style-search "^0.1.0"
     sugarss "^2.0.0"
     svg-tags "^1.0.0"
@@ -12651,9 +12725,9 @@ trough@^1.0.0:
     glob "^7.1.2"
 
 tslib@^1.9.0:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
-  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
 tty-browserify@0.0.1:
   version "0.0.1"
@@ -12703,9 +12777,9 @@ typescript@^2.5.1:
   integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
 ua-parser-js@^0.7.18:
-  version "0.7.19"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
-  integrity sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==
+  version "0.7.20"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.20.tgz#7527178b82f6a62a0f243d1f94fd30e3e3c21098"
+  integrity sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==
 
 uglify-js@^3.1.4:
   version "3.6.0"
@@ -12830,9 +12904,9 @@ unique-filename@^1.1.1:
     unique-slug "^2.0.0"
 
 unique-slug@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.1.tgz#5e9edc6d1ce8fb264db18a507ef9bd8544451ca6"
-  integrity sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.2.tgz#baabce91083fc64e945b0f3ad613e264f7cd4e6c"
+  integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
   dependencies:
     imurmurhash "^0.1.4"
 
@@ -13441,9 +13515,9 @@ yargs-parser@^11.1.1:
     decamelize "^1.2.0"
 
 yargs-parser@^13.1.0:
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.0.tgz#7016b6dd03e28e1418a510e258be4bff5a31138f"
-  integrity sha512-Yq+32PrijHRri0vVKQEm+ys8mbqWjLiwQkMFNXEENutzLPP0bE4Lcd4iA3OQY5HF+GD3xXxf0MEHb8E4/SA3AA==
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.1.tgz#d26058532aa06d365fe091f6a1fc06b2f7e5eca0"
+  integrity sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"


### PR DESCRIPTION
## Overview

Modify map interactivity:

 - make tooltips dynamic (show message in toolitp if neighborhood is not reachable)
 - make map marker green on list card hover (fixes #212)
 - set active neighborhood on map hover in list view, but not detail view (shows route)
 - style reachable neighborhood bounds as green on hover in both list and detail views


### Demo

On list card or neighborhood map bounds hover:
![image](https://user-images.githubusercontent.com/960264/59223334-a79f4180-8b99-11e9-99b6-86a489790685.png)

Hovering over a reachable neighborhood in details view:

![echo_routable_hover](https://user-images.githubusercontent.com/960264/59223534-285e3d80-8b9a-11e9-9a3f-faa9bf5b73f5.png)

Hovering over a non-reachable neighborhood in details view (see tooltip at bottom):

![echo_nonroutable_hover](https://user-images.githubusercontent.com/960264/59223541-2bf1c480-8b9a-11e9-993f-4fa3ee051eaf.png)


### Notes

The end leg and neighborhood centroid end marker were removed from route rendering in #189, as requested by the client. The centroid markers are still present here in list view for the three currently listed neighborhoods, but not in the detail view, and the end leg does not render anywhere.

No modifications are made to map cursor appearance, as Leaflet doesn't support per-feature interactivity (see [this comment](https://github.com/azavea/echo-locator/issues/161#issuecomment-500472444)).

There is a small delay added here to showing the route on hover, as doing so immediately would cause Leaflet event errors as the data updates on the change to the active neighborhood.


## Testing Instructions

 * Map and list card interactions should function as expected
 * Reachable neighborhood bounds should turn green on hover, and in list view, show route
 * Non-reachable neighborhood bounds should only show special tooltip on hover, and not turn green


Closes #161 
Fixes #212 
