### PR TITLE
Feature/kak/modify weighting#178

### DIFF
--- a/taui/src/selectors/neighborhoods-sorted-with-routes.js
+++ b/taui/src/selectors/neighborhoods-sorted-with-routes.js
@@ -26,6 +26,9 @@ const MAX_QUINTILE = 5
 const DEFAULT_EDUCATION_QUINTILE = 5
 const DEFAULT_CRIME_QUINTILE = 5
 
+// extra constant weighting always given to travel time over the other two factors
+const EXTRA_ACCESS_WEIGHT = 1
+
 export default createSelector(
   selectNeighborhoodRoutes,
   neighborhoodTravelTimes,
@@ -52,6 +55,9 @@ export default createSelector(
     if ((accessibilityImportance + crimeImportance + schoolsImportance) === 0) {
       accessibilityImportance = crimeImportance = schoolsImportance = 1
     }
+
+    // Give accessibility (travel time) extra weighting
+    accessibilityImportance += EXTRA_ACCESS_WEIGHT
 
     const totalImportance = accessibilityImportance + crimeImportance + schoolsImportance
 

--- a/taui/src/selectors/neighborhoods-sorted-with-routes.js
+++ b/taui/src/selectors/neighborhoods-sorted-with-routes.js
@@ -8,7 +8,8 @@ import {createSelector} from 'reselect'
 import {
   DEFAULT_ACCESSIBILITY_IMPORTANCE,
   DEFAULT_CRIME_IMPORTANCE,
-  DEFAULT_SCHOOLS_IMPORTANCE
+  DEFAULT_SCHOOLS_IMPORTANCE,
+  MAX_IMPORTANCE
 } from '../constants'
 import {NeighborhoodProperties} from '../types'
 import scale from '../utils/scaling'
@@ -77,13 +78,26 @@ export default createSelector(
       // Smaller travel time is better; larger timeWeight is better (reverse range).
       const timeWeight = time < MAX_TRAVEL_TIME ? scale(time, 0, MAX_TRAVEL_TIME, 1, 0) : 1
 
-      const eduationQuintile = properties.education_percentile_quintile
-        ? properties.education_percentile_quintile
-        : DEFAULT_EDUCATION_QUINTILE
+      // Weight schools either by percentile binned into quarters if given max importance,
+      // or otherwise weight by quintile.
+      let educationWeight
+      if (schoolsImportance === (MAX_IMPORTANCE - 1)) {
+        // Group percentile ranking into quarters instead of using quintiles
+        // if the importance of schools is the max importance.
+        const edPercent = properties.education_percentile
+          ? properties.education_percentile
+          : (DEFAULT_EDUCATION_QUINTILE - 1) * 20
+        const edPercentQuarter = Math.round(scale(edPercent, 0, 100, 3, 0))
+        educationWeight = scale(edPercentQuarter, 0, 3, 1, 0)
+      } else {
+        // Use quintiles if the importance of schools is anything less than the max importance.
+        const educationQuintile = properties.education_percentile_quintile
+          ? properties.education_percentile_quintile
+          : DEFAULT_EDUCATION_QUINTILE
 
-      // Lowest education quintile is best (reverse range).
-      const educationWeight = scale(eduationQuintile, MIN_QUINTILE, MAX_QUINTILE, 1, 0)
-
+        // Lowest education quintile is best (reverse range).
+        educationWeight = scale(educationQuintile, MIN_QUINTILE, MAX_QUINTILE, 1, 0)
+      }
       // Lowest crime quintile is best (reverse range).
       const crimeQuintile = properties.violentcrime_quintile
         ? properties.violentcrime_quintile : DEFAULT_CRIME_QUINTILE

--- a/taui/src/selectors/neighborhoods-sorted-with-routes.js
+++ b/taui/src/selectors/neighborhoods-sorted-with-routes.js
@@ -98,9 +98,13 @@ export default createSelector(
         // Lowest education quintile is best (reverse range).
         educationWeight = scale(educationQuintile, MIN_QUINTILE, MAX_QUINTILE, 1, 0)
       }
-      // Lowest crime quintile is best (reverse range).
-      const crimeQuintile = properties.violentcrime_quintile
+      let crimeQuintile = properties.violentcrime_quintile
         ? properties.violentcrime_quintile : DEFAULT_CRIME_QUINTILE
+      // Treat lowest two (safest) violent crime quintiles equally
+      if (crimeQuintile === 2) {
+        crimeQuintile = 1
+      }
+      // Lowest crime quintile is best (reverse range).
       const crimeWeight = scale(crimeQuintile, MIN_QUINTILE, MAX_QUINTILE, 1, 0)
 
       // Handle missing values (zero in spreadsheet) by re-assigning crime weight


### PR DESCRIPTION
## Overview

Modify neighborhood weighting algorithm to:
 - always give travel time (accessibility) extra weight over the other two variables
 - weight schools differently when schools are given maximum importance
 - treat the safest two quintiles for violent crime equally


### Demo

All profile options weighted equally, top transit results:

![image](https://user-images.githubusercontent.com/960264/59702344-7c35db80-91c5-11e9-97b6-fe87cebf45a2.png)

Default profile options weights (travel time 'important', other two 'somewhat'):

![image](https://user-images.githubusercontent.com/960264/59702446-ba32ff80-91c5-11e9-811b-e35ea9ce57cd.png)

Schools 'very important', other two options 'not important':

![image](https://user-images.githubusercontent.com/960264/59702513-e64e8080-91c5-11e9-8a4a-fc48f04c29bb.png)


### Notes

Travel time effectively always has a one higher importance rating than whatever it has assigned in the profile with this.

When schools are ranked as 'very important' (and the other two options aren't also 'very important'), this changes the algorithm to weight by percentile binned into quarters; for other school importance rankings, or when all have the same importance, schools are still ranked by quintile.

From the client:
 > IF Very Important strongly prioritize school districts in top 75 education percentile and above. No distinction within 75 and above. [I use percentiles here instead of quintiles to reflect the distribution of education quality in the state, which is concentrated more in the top 25% than in the top quintile]
> If important prioritize schools quintile 2 and above.
> Somewhat important prioritize schools in quintile 3 and above.
> Not important not weighted at all.


## Testing Instructions

 * Try different profile importance rankings for the three variables
 * Result sorting should vary as expected


Closes #178.
