### PR TITLE
Feature/kak/rental units tooltip#221

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -133,7 +133,7 @@ Tooltips:
   AboveAverage: above average
   Average: about average
   BelowAverage: below average
-  RentalUnits: "<p>%(town) has an %(averageRelation) number of rental units for the state.<br />From 2017-2018 there were %(totalMapc) units listed on craigslist (source: <a href=\"https://www.mapc.org/\" target=\"blank\">MAPC</a>).</p>"
+  RentalUnits: "<p>%(town) has an %(averageRelation) number of rental units for the state.<br />From 2017-2018 there were %(totalMapc) units listed on Craigslist (source: <a href=\"https://www.mapc.org/\" target=\"blank\">MAPC</a>).</p>"
 ImportanceLabels:
   1: Not important
   2: Somewhat important

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -129,6 +129,11 @@ Profile:
   SaveError: Failed to save profile. Please try again.
   Title: Profile
   UseCommuterRail: Include commuter rail and express bus
+Tooltips:
+  AboveAverage: above average
+  Average: about average
+  BelowAverage: below average
+  RentalUnits: %(town) has an %(averageRelation) number of rental units for the state.<br />From 2017-2018 there were %(totalMapc) units listed on craigslist (source MAPC).
 ImportanceLabels:
   1: Not important
   2: Somewhat important

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -133,7 +133,7 @@ Tooltips:
   AboveAverage: above average
   Average: about average
   BelowAverage: below average
-  RentalUnits: %(town) has an %(averageRelation) number of rental units for the state.<br />From 2017-2018 there were %(totalMapc) units listed on craigslist (source MAPC).
+  RentalUnits: "<p>%(town) has an %(averageRelation) number of rental units for the state.<br />From 2017-2018 there were %(totalMapc) units listed on craigslist (source: <a href=\"https://www.mapc.org/\" target=\"blank\">MAPC</a>).</p>"
 ImportanceLabels:
   1: Not important
   2: Somewhat important

--- a/taui/src/components/dock.js
+++ b/taui/src/components/dock.js
@@ -77,6 +77,10 @@ export default class Dock extends PureComponent<Props> {
   }
 
   goToDetails (e, neighborhood) {
+    // Do not go to details if user clicked a link (for chart tooltip links)
+    if (e.target.tagName.toLowerCase() === 'a') {
+      return
+    }
     e.stopPropagation()
     this.props.setActiveNeighborhood(neighborhood.properties.id)
     this.props.setShowDetails(true)

--- a/taui/src/components/neighborhood-list-info.js
+++ b/taui/src/components/neighborhood-list-info.js
@@ -14,6 +14,8 @@ export default function NeighborhoodListInfo ({neighborhood}) {
   const edPercentile = props['education_percentile']
   const houses = props['house_number_symbol']
   const isSchoolChoice = !!props['school_choice']
+  const totalMapc = props['total_mapc']
+  const town = props['town']
 
   return (
     <table className='neighborhood-facts'>
@@ -34,7 +36,7 @@ export default function NeighborhoodListInfo ({neighborhood}) {
         <tr>
           <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.RentalUnits')}</td>
           <td className='neighborhood-facts__cell'>
-            <RentalUnitsMeter value={houses} tooltip={message('NeighborhoodInfo.RentalUnits')} />
+            <RentalUnitsMeter value={houses} totalMapc={totalMapc} town={town} />
           </td>
         </tr>
       </tbody>

--- a/taui/src/components/rental-units-meter.js
+++ b/taui/src/components/rental-units-meter.js
@@ -61,11 +61,19 @@ export default function RentalUnitsMeter ({
   return (
     <div className='rental-units-meter'
       data-tip={tooltip}
-      data-effect={'solid'}
-      data-multiline
-      data-event-off={'click'}
-      data-event={'mouseover'}>
-      <ReactTooltip globalEventOff='click' />
+      data-event-off='click'
+      data-event='mouseover'
+      data-iscapture
+      data-for={`rental-units-tooltip-${town}`}
+      id={`rental-units-${town}`}>
+      <ReactTooltip
+        clickable
+        html
+        effect='solid'
+        event='mouseover'
+        globalEventOff='click'
+        isCapture
+        id={`rental-units-tooltip-${town}`} />
       {filledIcons}
       {unfilledIcons}
     </div>

--- a/taui/src/components/rental-units-meter.js
+++ b/taui/src/components/rental-units-meter.js
@@ -60,8 +60,12 @@ export default function RentalUnitsMeter ({
 
   return (
     <div className='rental-units-meter'
-      data-tip={tooltip} data-multiline>
-      <ReactTooltip />
+      data-tip={tooltip}
+      data-effect={'solid'}
+      data-multiline
+      data-event-off={'click'}
+      data-event={'mouseover'}>
+      <ReactTooltip globalEventOff='click' />
       {filledIcons}
       {unfilledIcons}
     </div>

--- a/taui/src/components/rental-units-meter.js
+++ b/taui/src/components/rental-units-meter.js
@@ -1,14 +1,17 @@
 // @flow
 import Icon from '@conveyal/woonerf/components/icon'
+import message from '@conveyal/woonerf/message'
 import ReactTooltip from 'react-tooltip'
 
 import {getTier} from '../utils/scaling'
 
 export default function RentalUnitsMeter ({
-  value,
-  tooltip
+  totalMapc,
+  town,
+  value
 }) {
   const NUM_ICONS = 5
+  const AVERAGE_VALUE = 3
 
   if (value > NUM_ICONS || value < 0) {
     console.warn('Rental unit meter count out of range')
@@ -46,9 +49,18 @@ export default function RentalUnitsMeter ({
     )
   }
 
+  const averageRelation = value > AVERAGE_VALUE
+    ? message('Tooltips.AboveAverage')
+    : (value < AVERAGE_VALUE ? message('Tooltips.BelowAverage') : message('Tooltips.Average'))
+  const tooltip = message('Tooltips.RentalUnits', {
+    averageRelation: averageRelation,
+    town: town,
+    totalMapc: totalMapc ? (totalMapc).toLocaleString() : message('UnknownValue')
+  })
+
   return (
     <div className='rental-units-meter'
-      data-tip={tooltip}>
+      data-tip={tooltip} data-multiline>
       <ReactTooltip />
       {filledIcons}
       {unfilledIcons}

--- a/taui/src/components/rental-units-meter.js
+++ b/taui/src/components/rental-units-meter.js
@@ -3,6 +3,10 @@ import Icon from '@conveyal/woonerf/components/icon'
 import message from '@conveyal/woonerf/message'
 import ReactTooltip from 'react-tooltip'
 
+import {
+  TOOLTIP_HIDE_DELAY_MS,
+  TOOLTIP_UPDATE_DELAY_MS
+} from '../constants'
 import {getTier} from '../utils/scaling'
 
 export default function RentalUnitsMeter ({
@@ -61,17 +65,15 @@ export default function RentalUnitsMeter ({
   return (
     <div className='rental-units-meter'
       data-tip={tooltip}
-      data-event-off='click'
-      data-event='mouseover'
       data-iscapture
       data-for={`rental-units-tooltip-${town}`}
       id={`rental-units-${town}`}>
       <ReactTooltip
         clickable
+        delayHide={TOOLTIP_HIDE_DELAY_MS}
+        delayUpdate={TOOLTIP_UPDATE_DELAY_MS}
         html
         effect='solid'
-        event='mouseover'
-        globalEventOff='click'
         isCapture
         id={`rental-units-tooltip-${town}`} />
       {filledIcons}

--- a/taui/src/constants.js
+++ b/taui/src/constants.js
@@ -12,6 +12,10 @@ export const IMAGE_FIELDS = [
   'street'
 ]
 
+// Allow clicking links in tooltips by delaying hide/update
+export const TOOLTIP_HIDE_DELAY_MS = 1000
+export const TOOLTIP_UPDATE_DELAY_MS = 1000
+
 // Maximum number of destinations that may be added to a user profile
 export const MAX_ADDRESSES = 3
 


### PR DESCRIPTION
## Overview

Generate dynamic rental units tooltips. Support links in tooltip text.


### Demo

![echo_tooltip_rental_units](https://user-images.githubusercontent.com/960264/59717457-04c47400-91e6-11e9-9e73-3d58eaae441c.png)


### Notes

To support having clickable links in the tooltips, they do not dismiss until the user clicks somewhere. For this tooltip, the provided text did not include a link. I've added one to the MAPC site (sited as the data source).


## Testing Instructions

 * Tooltip should appear on hovering over rental unit houses chart in list and detail views
 * Tooltip should dismiss on clicking somewhere
 * Clicking the "MAPC" text in the tooltip should open the MAPC site in a new tab
 * Tooltip text above/about/below average text should correspond number of houses
 * Total number of MAPC units in the zip code should appear, comma-separated, in the tooltip


Closes #221 
