### PR TITLE
Scroll sidebar to top when paging or switching search/detail view

### DIFF
--- a/taui/src/components/dock.js
+++ b/taui/src/components/dock.js
@@ -3,7 +3,7 @@ import Storage from '@aws-amplify/storage'
 import Icon from '@conveyal/woonerf/components/icon'
 import message from '@conveyal/woonerf/message'
 import remove from 'lodash/remove'
-import {PureComponent} from 'react'
+import {PureComponent, createRef} from 'react'
 
 import {ANONYMOUS_USERNAME, SIDEBAR_PAGE_SIZE} from '../constants'
 import type {AccountProfile, PointFeature} from '../types'
@@ -46,9 +46,16 @@ export default class Dock extends PureComponent<Props> {
     this.neighborhoodSection = this.neighborhoodSection.bind(this)
     this.setFavorite = this.setFavorite.bind(this)
     this.setShowFavorites = this.setShowFavorites.bind(this)
+    this.sidebar = createRef()
 
     this.state = {
       componentError: props.componentError
+    }
+  }
+
+  componentDidUpdate (prevProps) {
+    if (this.props.page !== prevProps.page || this.props.showDetails !== prevProps.showDetails) {
+      this.sidebar.current.scrollTop = 0
     }
   }
 
@@ -260,7 +267,7 @@ export default class Dock extends PureComponent<Props> {
 
     const startingOffset = page * SIDEBAR_PAGE_SIZE
 
-    return <div className='map-sidebar'>
+    return <div className='map-sidebar' ref={this.sidebar}>
       {componentError &&
         <p className='map-sidebar__error'>
           <Icon type='exclamation-triangle' />


### PR DESCRIPTION
## Overview

When paging search results, or when switching between search and detail views, the sidebar is now automatically scrolled to the top.


## Testing Instructions

 * Make browser viewport short enough to require sidebar scrolling.
 * Page search results forward and backward, with sidebar scrolled each time…
 * … new pages should always start with sidebar scrolled to top
 * Same when drilling into detail view, and returning back to search
