### PR TITLE
Feature/kak/tooltip safety#220

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -133,7 +133,9 @@ Tooltips:
   AboveAverage: above average
   Average: about average
   BelowAverage: below average
-  RentalUnits: "<p>%(town) has an %(averageRelation) number of rental units for the state.<br />From 2017-2018 there were %(totalMapc) units listed on Craigslist (source: <a href=\"https://www.mapc.org/\" target=\"blank\">MAPC</a>).</p>"
+  ViolentCrime: "<p>%(town) has %(averageRelation) public safety,<br />safer than %(crimePercentile)% of other zipcodes in the state.<br />(Source: <a href=\"https://www.fbi.gov/services/cjis/ucr\" target=\"blank\">FBI Uniform Crime Reporting violent crime data</a>.)</p>"
+  ViolentCrimeBoston: "<p>%(town) has %(averageRelation) public safety,<br />safer than %(crimePercentile)% of other zipcodes in the state.<br />(Source: <a href=\"https://data.boston.gov/\" target=\"blank\">Boston Police Department Incident Reports</a>.)</p>"
+  RentalUnits: "<p>%(town) has an %(averageRelation) number of rental units for the state.<br />From 2017-2018 there were %(totalMapc) units listed on Craigslist.<br />(Source: <a href=\"https://www.mapc.org/\" target=\"blank\">MAPC</a>.)</p>"
 ImportanceLabels:
   1: Not important
   2: Somewhat important

--- a/taui/src/components/meter.js
+++ b/taui/src/components/meter.js
@@ -1,6 +1,7 @@
 // @flow
 import ReactTooltip from 'react-tooltip'
 
+import {TOOLTIP_HIDE_DELAY_MS} from '../constants'
 import {getTier} from '../utils/scaling'
 
 export default function Meter ({
@@ -9,15 +10,31 @@ export default function Meter ({
   average = 50,
   width = 100,
   height = 10,
-  tooltip
+  tooltip,
+  category,
+  id
 }) {
   const percentage = value / max
   const percentageLabel = Math.round(percentage * 100)
   const tier = getTier(percentage)
 
   return (
-    <div className='meter' data-tip={tooltip}>
-      <ReactTooltip />
+    <div className='meter'
+      data-iscapture
+      data-delay-hide={TOOLTIP_HIDE_DELAY_MS}
+      data-effect='solid'
+      data-for={`meter-tooltip-${category}-${id}`}
+      data-id={`meter-${category}-${id}`}
+      id={`meter-${category}-${id}`}
+      data-tip={tooltip}>
+      <ReactTooltip
+        clickable
+        html
+        effect='solid'
+        isCapture
+        delayHide={TOOLTIP_HIDE_DELAY_MS}
+        data-id={`meter-tooltip-${category}-${id}`}
+        id={`meter-tooltip-${category}-${id}`} />
       <svg
         className='meter__chart'
         viewBox={`0 0 ${width} ${height}`}

--- a/taui/src/components/neighborhood-list-info.js
+++ b/taui/src/components/neighborhood-list-info.js
@@ -1,6 +1,10 @@
 // @flow
 import message from '@conveyal/woonerf/message'
 
+import {
+  BOSTON_TOWN_AREA
+} from '../constants'
+
 import Meter from './meter'
 import RentalUnitsMeter from './rental-units-meter'
 
@@ -10,12 +14,22 @@ export default function NeighborhoodListInfo ({neighborhood}) {
   }
 
   const props = neighborhood.properties
+  const zipcode = props['id']
   const crime = props['crime_percentile']
   const edPercentile = props['education_percentile']
   const houses = props['house_number_symbol']
   const isSchoolChoice = !!props['school_choice']
   const totalMapc = props['total_mapc']
   const town = props['town']
+  const townArea = props['town_area']
+
+  const crimeMessage = townArea && townArea === BOSTON_TOWN_AREA
+    ? 'Tooltips.ViolentCrimeBoston' : 'Tooltips.ViolentCrime'
+  const crimeTooltip = message(crimeMessage, {
+    averageRelation: getAverageRelationPercentage(crime),
+    crimePercentile: crime,
+    town: town
+  })
 
   return (
     <table className='neighborhood-facts'>
@@ -23,23 +37,38 @@ export default function NeighborhoodListInfo ({neighborhood}) {
         {!isSchoolChoice && <tr>
           <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.EducationCategory')}</td>
           <td className='neighborhood-facts__cell'>
-            <Meter value={edPercentile} tooltip={message('NeighborhoodInfo.EducationCategory')} />
+            <Meter
+              category='school'
+              value={edPercentile}
+              id={zipcode}
+              tooltip={message('NeighborhoodInfo.EducationCategory')} />
           </td>
         </tr>}
         {crime >= 0 && <tr>
           <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.ViolentCrime')}</td>
           <td className='neighborhood-facts__cell'>
-            <Meter value={crime}
-              tooltip={message('NeighborhoodInfo.ViolentCrime')} />
+            <Meter
+              category='crime'
+              value={crime}
+              id={zipcode}
+              tooltip={crimeTooltip} />
           </td>
         </tr>}
         <tr>
           <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.RentalUnits')}</td>
           <td className='neighborhood-facts__cell'>
-            <RentalUnitsMeter value={houses} totalMapc={totalMapc} town={town} />
+            <RentalUnitsMeter value={houses} totalMapc={totalMapc} id={zipcode} town={town} />
           </td>
         </tr>
       </tbody>
     </table>
   )
+}
+
+// Fetch the UI string for percentage meter tooltips to say above/about/below average
+const AVERAGE_PERCENTAGE = 50
+const getAverageRelationPercentage = (val) => {
+  return val > AVERAGE_PERCENTAGE
+    ? message('Tooltips.AboveAverage')
+    : (val < AVERAGE_PERCENTAGE ? message('Tooltips.BelowAverage') : message('Tooltips.Average'))
 }

--- a/taui/src/components/rental-units-meter.js
+++ b/taui/src/components/rental-units-meter.js
@@ -3,16 +3,14 @@ import Icon from '@conveyal/woonerf/components/icon'
 import message from '@conveyal/woonerf/message'
 import ReactTooltip from 'react-tooltip'
 
-import {
-  TOOLTIP_HIDE_DELAY_MS,
-  TOOLTIP_UPDATE_DELAY_MS
-} from '../constants'
+import {TOOLTIP_HIDE_DELAY_MS} from '../constants'
 import {getTier} from '../utils/scaling'
 
 export default function RentalUnitsMeter ({
   totalMapc,
   town,
-  value
+  value,
+  id
 }) {
   const NUM_ICONS = 5
   const AVERAGE_VALUE = 3
@@ -66,16 +64,19 @@ export default function RentalUnitsMeter ({
     <div className='rental-units-meter'
       data-tip={tooltip}
       data-iscapture
+      data-effect='solid'
       data-delay-hide={TOOLTIP_HIDE_DELAY_MS}
-      data-delay-update={TOOLTIP_UPDATE_DELAY_MS}
-      data-for={`rental-units-tooltip-${town}`}
-      id={`rental-units-${town}`}>
+      data-for={`rental-units-tooltip-${id}`}
+      data-id={`rental-units-${id}`}
+      id={`rental-units-${id}`}>
       <ReactTooltip
         clickable
         html
+        delayHide={TOOLTIP_HIDE_DELAY_MS}
         effect='solid'
         isCapture
-        id={`rental-units-tooltip-${town}`} />
+        data-id={`rental-units-tooltip-${id}`}
+        id={`rental-units-tooltip-${id}`} />
       {filledIcons}
       {unfilledIcons}
     </div>

--- a/taui/src/components/rental-units-meter.js
+++ b/taui/src/components/rental-units-meter.js
@@ -66,12 +66,12 @@ export default function RentalUnitsMeter ({
     <div className='rental-units-meter'
       data-tip={tooltip}
       data-iscapture
+      data-delay-hide={TOOLTIP_HIDE_DELAY_MS}
+      data-delay-update={TOOLTIP_UPDATE_DELAY_MS}
       data-for={`rental-units-tooltip-${town}`}
       id={`rental-units-${town}`}>
       <ReactTooltip
         clickable
-        delayHide={TOOLTIP_HIDE_DELAY_MS}
-        delayUpdate={TOOLTIP_UPDATE_DELAY_MS}
         html
         effect='solid'
         isCapture

--- a/taui/src/constants.js
+++ b/taui/src/constants.js
@@ -12,9 +12,11 @@ export const IMAGE_FIELDS = [
   'street'
 ]
 
+// Value in `town_area` column of source data for grouping zip codes in Boston
+export const BOSTON_TOWN_AREA = 'Boston'
+
 // Allow clicking links in tooltips by delaying hide/update
 export const TOOLTIP_HIDE_DELAY_MS = 1000
-export const TOOLTIP_UPDATE_DELAY_MS = 1000
 
 // Maximum number of destinations that may be added to a user profile
 export const MAX_ADDRESSES = 3


### PR DESCRIPTION
## Overview

Add dynamic text with hyperlinks to the tooltips for the "public safety" neighborhood charts.


### Demo

Tooltip for a Boston zipcode:
![echo_safety_tooltip_boston](https://user-images.githubusercontent.com/960264/59792716-d22c8100-92a2-11e9-8a21-c78038d0e805.png)

Tooltip for a non-Boston zipcode:
![echo_safety_tooltip_not_boston](https://user-images.githubusercontent.com/960264/59792740-dd7fac80-92a2-11e9-94cb-d6d7565c5fa3.png)


### Notes

This removes the [delayUpdate tooltip option](https://github.com/wwayne/react-tooltip#options), intended to prevent other tooltips popping underneath, as it was instead causing the tooltip to jitter to a new location after the delay window, despite the `effect='solid'` setting.


## Testing Instructions

 * Hover over "public safety" chart
 * Tooltip should display expected text
 * Tooltip source and link should be different for zip codes with names starting with "Boston"
 * Tooltip links should open in a new window as expected
 
Closes #220.
