### PR TITLE
Feature/kak/tooltip schools#219

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -134,6 +134,7 @@ Tooltips:
   AboveAverage: above average
   Average: about average
   BelowAverage: below average
+  Education: "<p>%(town) schools are %(averageRelation) for the state and rank<br />higher than %(edPercentile)% of other school districts when considering<br />overall school quality and performance of low-income students.<br />(Source: <a href=\"http://profiles.doe.mass.edu/\" target=\"blank\">MA DOE</a>.)</p>"
   ViolentCrime: "<p>%(town) has %(averageRelation) public safety,<br />safer than %(crimePercentile)% of other zipcodes in the state.<br />(Source: <a href=\"https://www.fbi.gov/services/cjis/ucr\" target=\"blank\">FBI Uniform Crime Reporting violent crime data</a>.)</p>"
   ViolentCrimeBoston: "<p>%(town) has %(averageRelation) public safety,<br />safer than %(crimePercentile)% of other zipcodes in the state.<br />(Source: <a href=\"https://data.boston.gov/\" target=\"blank\">Boston Police Department Incident Reports</a>.)</p>"
   RentalUnits: "<p>%(town) has an %(averageRelation) number of rental units for the state.<br />From 2017-2018 there were %(totalMapc) units listed on Craigslist.<br />(Source: <a href=\"https://www.mapc.org/\" target=\"blank\">MAPC</a>.)</p>"

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -64,6 +64,7 @@ NeighborhoodDetails:
   WikipediaLink: Wikipedia
   ZillowSearchLink: Zillow
 NeighborhoodInfo:
+  SchoolChoice: "%(townArea) has school choice"
   EducationCategory: Schools
   Population: Population
   RentalUnits: Rental units

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -64,7 +64,7 @@ NeighborhoodDetails:
   WikipediaLink: Wikipedia
   ZillowSearchLink: Zillow
 NeighborhoodInfo:
-  SchoolChoice: "%(townArea) has school choice"
+  SchoolChoice: School choice
   EducationCategory: Schools
   Population: Population
   RentalUnits: Rental units

--- a/taui/src/components/neighborhood-list-info.js
+++ b/taui/src/components/neighborhood-list-info.js
@@ -39,30 +39,26 @@ export default function NeighborhoodListInfo ({neighborhood}) {
     town: town
   })
 
-  const schoolChoiceText = message('NeighborhoodInfo.SchoolChoice', {
-    townArea: townArea
-  })
-
   const schoolChoiceLink = isBoston ? BOSTON_SCHOOL_CHOICE_LINK : CAMBRIDGE_SCHOOL_CHOICE_LINK
 
   return (
     <table className='neighborhood-facts'>
       <tbody>
-        {!isSchoolChoice && <tr>
+        <tr>
           <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.EducationCategory')}</td>
-          <td className='neighborhood-facts__cell'>
+          {!isSchoolChoice && <td className='neighborhood-facts__cell'>
             <Meter
               category='school'
               value={edPercentile}
               id={zipcode}
               tooltip={edTooltip} />
-          </td>
-        </tr>}
-        {isSchoolChoice && <tr>
-          <td className='neighborhood-facts__text' />
-          <td className='neighborhood-facts__text'>
-            <a href={schoolChoiceLink} target='blank'>{schoolChoiceText}</a></td>
-        </tr>}
+          </td>}
+          {isSchoolChoice && <td className='neighborhood-facts__text'>
+            <a href={schoolChoiceLink} target='blank'>
+              {message('NeighborhoodInfo.SchoolChoice')}
+            </a>
+          </td>}
+        </tr>
         {crime >= 0 && <tr>
           <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.ViolentCrime')}</td>
           <td className='neighborhood-facts__cell'>

--- a/taui/src/components/neighborhood-list-info.js
+++ b/taui/src/components/neighborhood-list-info.js
@@ -33,6 +33,12 @@ export default function NeighborhoodListInfo ({neighborhood}) {
     town: town
   })
 
+  const edTooltip = message('Tooltips.Education', {
+    averageRelation: getAverageRelationPercentage(edPercentile),
+    edPercentile: edPercentile,
+    town: town
+  })
+
   const schoolChoiceText = message('NeighborhoodInfo.SchoolChoice', {
     townArea: townArea
   })
@@ -49,7 +55,7 @@ export default function NeighborhoodListInfo ({neighborhood}) {
               category='school'
               value={edPercentile}
               id={zipcode}
-              tooltip={message('NeighborhoodInfo.EducationCategory')} />
+              tooltip={edTooltip} />
           </td>
         </tr>}
         {isSchoolChoice && <tr>

--- a/taui/src/components/neighborhood-list-info.js
+++ b/taui/src/components/neighborhood-list-info.js
@@ -2,7 +2,9 @@
 import message from '@conveyal/woonerf/message'
 
 import {
-  BOSTON_TOWN_AREA
+  BOSTON_TOWN_AREA,
+  BOSTON_SCHOOL_CHOICE_LINK,
+  CAMBRIDGE_SCHOOL_CHOICE_LINK
 } from '../constants'
 
 import Meter from './meter'
@@ -22,14 +24,20 @@ export default function NeighborhoodListInfo ({neighborhood}) {
   const totalMapc = props['total_mapc']
   const town = props['town']
   const townArea = props['town_area']
+  const isBoston = townArea && townArea === BOSTON_TOWN_AREA
 
-  const crimeMessage = townArea && townArea === BOSTON_TOWN_AREA
-    ? 'Tooltips.ViolentCrimeBoston' : 'Tooltips.ViolentCrime'
+  const crimeMessage = isBoston ? 'Tooltips.ViolentCrimeBoston' : 'Tooltips.ViolentCrime'
   const crimeTooltip = message(crimeMessage, {
     averageRelation: getAverageRelationPercentage(crime),
     crimePercentile: crime,
     town: town
   })
+
+  const schoolChoiceText = message('NeighborhoodInfo.SchoolChoice', {
+    townArea: townArea
+  })
+
+  const schoolChoiceLink = isBoston ? BOSTON_SCHOOL_CHOICE_LINK : CAMBRIDGE_SCHOOL_CHOICE_LINK
 
   return (
     <table className='neighborhood-facts'>
@@ -43,6 +51,11 @@ export default function NeighborhoodListInfo ({neighborhood}) {
               id={zipcode}
               tooltip={message('NeighborhoodInfo.EducationCategory')} />
           </td>
+        </tr>}
+        {isSchoolChoice && <tr>
+          <td className='neighborhood-facts__text' />
+          <td className='neighborhood-facts__text'>
+            <a href={schoolChoiceLink} target='blank'>{schoolChoiceText}</a></td>
         </tr>}
         {crime >= 0 && <tr>
           <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.ViolentCrime')}</td>

--- a/taui/src/constants.js
+++ b/taui/src/constants.js
@@ -15,6 +15,9 @@ export const IMAGE_FIELDS = [
 // Value in `town_area` column of source data for grouping zip codes in Boston
 export const BOSTON_TOWN_AREA = 'Boston'
 
+export const BOSTON_SCHOOL_CHOICE_LINK = 'https://discover.bostonpublicschools.org/'
+export const CAMBRIDGE_SCHOOL_CHOICE_LINK = 'https://www.cpsd.us/'
+
 // Allow clicking links in tooltips by delaying hide/update
 export const TOOLTIP_HIDE_DELAY_MS = 1000
 

--- a/taui/src/sass/06_components/_neighborhood-facts.scss
+++ b/taui/src/sass/06_components/_neighborhood-facts.scss
@@ -19,11 +19,11 @@
   }
 
   &__text {
+    padding-top: 0.6rem;
+    padding-right: 0.8rem;
+    padding-bottom: 0.8rem;
     text-align: left;
     vertical-align: middle;
-    padding-top: 0.6rem;
-    padding-bottom: 0.8rem;
-    padding-right: 0.8rem;
 
     a {
       text-decoration: underline;

--- a/taui/src/sass/06_components/_neighborhood-facts.scss
+++ b/taui/src/sass/06_components/_neighborhood-facts.scss
@@ -17,4 +17,16 @@
     padding-top: 0.6rem;
     padding-bottom: 0.8rem;
   }
+
+  &__text {
+    text-align: left;
+    vertical-align: middle;
+    padding-top: 0.6rem;
+    padding-bottom: 0.8rem;
+    padding-right: 0.8rem;
+
+    a {
+      text-decoration: underline;
+    }
+  }
 }


### PR DESCRIPTION
## Overview

Show a link in the school chart's place for Boston and Cambridge (school choice) zip codes, and display a tooltip for the chart.


### Demo

Tooltip:
![image](https://user-images.githubusercontent.com/960264/59855697-736b1400-9343-11e9-828e-e1dad1ec0be6.png)

Boston school choice:

![image](https://user-images.githubusercontent.com/960264/59855766-94336980-9343-11e9-9b6e-4306fc8ff1ae.png)

Cambridge school choice:

![image](https://user-images.githubusercontent.com/960264/59855802-a90ffd00-9343-11e9-977b-ee6a82bfe0f2.png)


### Notes

The school choice messages are abbreviated from what was requested, as the text would overflow the table.


## Testing Instructions

 * Zipcodes with a school ranking chart should display the tooltip as expected
 * The link should work and open in a new tab
 * Zipcodes for Boston or Cambridge should display a school choice link instead


Closes #219.
