### PR TITLE
Change voucher validation and label

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -96,14 +96,14 @@ Header:
 Accounts:
   Create: Create new profile
   CreateError: Failed to create profile. Please try again.
-  InvalidVoucherNumber: Voucher number should be eight digits, or two letters followed by six digits.
-  MissingVoucherNumber: Enter a voucher number to create a profile.
+  InvalidVoucherNumber: Client ID should be six to eight digits or letters.
+  MissingVoucherNumber: Enter a client ID to create a profile.
   Name: Name of head of household
   Search: Search
   SelectError: Failed to set profile. Please try again.
   NoResults: Profile not found. Create one now?
   Title: Profiles
-  Voucher: Voucher number
+  Voucher: Client ID
 Profile:
   AddAddress: Add another destination
   Address: Address

--- a/taui/src/utils/validate-voucher-number.js
+++ b/taui/src/utils/validate-voucher-number.js
@@ -1,6 +1,6 @@
 // @flow
-// Returns true if `voucherNumber` is six to eight characters total, numeric,
-// with optionally two letters prefixed.
+// Returns true if `voucherNumber` is six to eight characters total,
+// alphanumeric, and upper case.
 export default function validateVoucherNumber (voucherNumber: string) {
-  return /^\d{8}$/.test(voucherNumber) || /^[A-Z]{2}\d{6}$/.test(voucherNumber)
+  return /^[A-Z0-9]{6,8}$/.test(voucherNumber)
 }


### PR DESCRIPTION
Make voucher ID validation more lax, and relabel as client ID.

Closes #232.

## Overview

Make the validation rules for voucher IDs more lax, and relabel them as client IDs.


### Demo

![image](https://user-images.githubusercontent.com/960264/59928199-3454c580-940c-11e9-8166-8c5e2a5d6aee.png)

![image](https://user-images.githubusercontent.com/960264/59928700-5438b900-940d-11e9-9139-bd3bae015959.png)


## Testing Instructions

 * Search for client IDs
 * 6-8 alphanumeric characters should validate


Closes #232.
