### PR TITLE
Pass count instead of all neighborhoods

### DIFF
--- a/taui/src/components/dock.js
+++ b/taui/src/components/dock.js
@@ -6,7 +6,7 @@ import remove from 'lodash/remove'
 import {PureComponent, createRef} from 'react'
 
 import {ANONYMOUS_USERNAME, SIDEBAR_PAGE_SIZE} from '../constants'
-import type {AccountProfile, PointFeature} from '../types'
+import type {AccountProfile} from '../types'
 
 import NeighborhoodDetails from './neighborhood-details'
 import RouteCard from './route-card'
@@ -18,9 +18,9 @@ type Props = {
   endingOffset: number,
   haveAnotherPage: boolean,
   isLoading: boolean,
+  neighborhoodCount: number,
   neighborhoodPage: any[],
   neighborhoodRoutes: any,
-  neighborhoods: Array<PointFeature>,
   origin: any,
   page: number,
   showDetails: boolean,
@@ -257,7 +257,7 @@ export default class Dock extends PureComponent<Props> {
       endingOffset,
       haveAnotherPage,
       isLoading,
-      neighborhoods,
+      neighborhoodCount,
       neighborhoodPage,
       origin,
       page,
@@ -272,7 +272,6 @@ export default class Dock extends PureComponent<Props> {
     const backFromDetails = this.backFromDetails
 
     const startingOffset = page * SIDEBAR_PAGE_SIZE
-    const totalNeighborhoodCount = (neighborhoods && neighborhoods.length) || 0
 
     return <div className='map-sidebar' ref={this.sidebar}>
       {componentError &&
@@ -286,7 +285,7 @@ export default class Dock extends PureComponent<Props> {
           {...this.props}
           changeUserProfile={changeUserProfile}
           neighborhoods={neighborhoodPage}
-          totalNeighborhoodCount={totalNeighborhoodCount}
+          totalNeighborhoodCount={neighborhoodCount}
           endingOffset={endingOffset}
           origin={origin}
           setFavorite={setFavorite}

--- a/taui/src/components/main-page.js
+++ b/taui/src/components/main-page.js
@@ -108,7 +108,8 @@ export default class MainPage extends React.PureComponent<Props> {
   render () {
     const p = this.props
     const mapScreenClass = p.isLoading ? 'map-screen isLoading' : 'map-screen'
-    const neighborhoods = p.data.neighborhoods ? p.data.neighborhoods.features : null
+    const neighborhoodCount = p.data.neighborhoods && p.data.neighborhoods.features
+      ? p.data.neighborhoods.features.length : 0
 
     return (
       <div className={mapScreenClass}>
@@ -120,7 +121,7 @@ export default class MainPage extends React.PureComponent<Props> {
           endingOffset={p.pageEndingOffset}
           haveAnotherPage={p.haveAnotherPage}
           isLoading={p.isLoading}
-          neighborhoods={neighborhoods}
+          neighborhoodCount={neighborhoodCount}
           neighborhoodPage={p.displayPageNeighborhoods}
           origin={p.data.origin}
           page={p.data.page}


### PR DESCRIPTION
## Overview

Pass the total count of neighborhoods to the `Dock` component, instead of all neighborhoods.


## Testing Instructions

 * Total record counter should still work

Connects #233.
