### PR TITLE
Fix multiple tooltips bug

### DIFF
--- a/taui/src/components/meter.js
+++ b/taui/src/components/meter.js
@@ -16,7 +16,7 @@ export default function Meter ({
   const tier = getTier(percentage)
 
   return (
-    <div className='meter' data-tip={tooltip}>
+    <div className='meter' data-tip={tooltip} data-for={`tooltip-${id}`}>
       <svg
         className='meter__chart'
         viewBox={`0 0 ${width} ${height}`}

--- a/taui/src/components/meter.js
+++ b/taui/src/components/meter.js
@@ -1,7 +1,4 @@
 // @flow
-import ReactTooltip from 'react-tooltip'
-
-import {TOOLTIP_HIDE_DELAY_MS} from '../constants'
 import {getTier} from '../utils/scaling'
 
 export default function Meter ({
@@ -19,23 +16,7 @@ export default function Meter ({
   const tier = getTier(percentage)
 
   return (
-    <div className='meter'
-      data-iscapture
-      data-delay-hide={TOOLTIP_HIDE_DELAY_MS}
-      data-effect='solid'
-      data-for={`meter-tooltip-${category}-${id}`}
-      data-id={`meter-${category}-${id}`}
-      id={`meter-${category}-${id}`}
-      data-tip={tooltip}>
-      <ReactTooltip
-        clickable
-        html
-        effect='solid'
-        isCapture
-        delayHide={TOOLTIP_HIDE_DELAY_MS}
-        className='map-sidebar__tooltip'
-        data-id={`meter-tooltip-${category}-${id}`}
-        id={`meter-tooltip-${category}-${id}`} />
+    <div className='meter' data-tip={tooltip}>
       <svg
         className='meter__chart'
         viewBox={`0 0 ${width} ${height}`}

--- a/taui/src/components/neighborhood-list-info.js
+++ b/taui/src/components/neighborhood-list-info.js
@@ -1,7 +1,8 @@
 // @flow
 import message from '@conveyal/woonerf/message'
+import ReactTooltip from 'react-tooltip'
 
-import {
+import {TOOLTIP_HIDE_DELAY_MS,
   BOSTON_TOWN_AREA,
   BOSTON_SCHOOL_CHOICE_LINK,
   CAMBRIDGE_SCHOOL_CHOICE_LINK
@@ -42,41 +43,52 @@ export default function NeighborhoodListInfo ({neighborhood}) {
   const schoolChoiceLink = isBoston ? BOSTON_SCHOOL_CHOICE_LINK : CAMBRIDGE_SCHOOL_CHOICE_LINK
 
   return (
-    <table className='neighborhood-facts'>
-      <tbody>
-        <tr>
-          <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.EducationCategory')}</td>
-          {!isSchoolChoice && <td className='neighborhood-facts__cell'>
-            <Meter
-              category='school'
-              value={edPercentile}
-              id={zipcode}
-              tooltip={edTooltip} />
-          </td>}
-          {isSchoolChoice && <td className='neighborhood-facts__text'>
-            <a href={schoolChoiceLink} target='_blank' className='neighborhood-facts__school-choice'>
-              {message('NeighborhoodInfo.SchoolChoice')}
-            </a>
-          </td>}
-        </tr>
-        {crime >= 0 && <tr>
-          <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.ViolentCrime')}</td>
-          <td className='neighborhood-facts__cell'>
-            <Meter
-              category='crime'
-              value={crime}
-              id={zipcode}
-              tooltip={crimeTooltip} />
-          </td>
-        </tr>}
-        <tr>
-          <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.RentalUnits')}</td>
-          <td className='neighborhood-facts__cell'>
-            <RentalUnitsMeter value={houses} totalMapc={totalMapc} id={zipcode} town={town} />
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <>
+      <table className='neighborhood-facts'>
+        <tbody>
+          <tr>
+            <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.EducationCategory')}</td>
+            {!isSchoolChoice && <td className='neighborhood-facts__cell'>
+              <Meter
+                category='school'
+                value={edPercentile}
+                id={zipcode}
+                tooltip={edTooltip} />
+            </td>}
+            {isSchoolChoice && <td className='neighborhood-facts__text'>
+              <a href={schoolChoiceLink} target='_blank' className='neighborhood-facts__school-choice'>
+                {message('NeighborhoodInfo.SchoolChoice')}
+              </a>
+            </td>}
+          </tr>
+          {crime >= 0 && <tr>
+            <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.ViolentCrime')}</td>
+            <td className='neighborhood-facts__cell'>
+              <Meter
+                category='crime'
+                value={crime}
+                id={zipcode}
+                tooltip={crimeTooltip} />
+            </td>
+          </tr>}
+          <tr>
+            <td className='neighborhood-facts__cell'>{message('NeighborhoodInfo.RentalUnits')}</td>
+            <td className='neighborhood-facts__cell'>
+              <RentalUnitsMeter value={houses} totalMapc={totalMapc} id={zipcode} town={town} />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <ReactTooltip
+        clickable
+        html
+        effect='solid'
+        place='right'
+        isCapture
+        delayHide={TOOLTIP_HIDE_DELAY_MS}
+        className='map-sidebar__tooltip'
+      />
+    </>
   )
 }
 

--- a/taui/src/components/neighborhood-list-info.js
+++ b/taui/src/components/neighborhood-list-info.js
@@ -87,6 +87,7 @@ export default function NeighborhoodListInfo ({neighborhood}) {
         isCapture
         delayHide={TOOLTIP_HIDE_DELAY_MS}
         className='map-sidebar__tooltip'
+        id={`tooltip-${zipcode}`}
       />
     </>
   )

--- a/taui/src/components/rental-units-meter.js
+++ b/taui/src/components/rental-units-meter.js
@@ -1,9 +1,7 @@
 // @flow
 import Icon from '@conveyal/woonerf/components/icon'
 import message from '@conveyal/woonerf/message'
-import ReactTooltip from 'react-tooltip'
 
-import {TOOLTIP_HIDE_DELAY_MS} from '../constants'
 import {getTier} from '../utils/scaling'
 
 export default function RentalUnitsMeter ({
@@ -61,23 +59,7 @@ export default function RentalUnitsMeter ({
   })
 
   return (
-    <div className='rental-units-meter'
-      data-tip={tooltip}
-      data-iscapture
-      data-effect='solid'
-      data-delay-hide={TOOLTIP_HIDE_DELAY_MS}
-      data-for={`rental-units-tooltip-${id}`}
-      data-id={`rental-units-${id}`}
-      id={`rental-units-${id}`}>
-      <ReactTooltip
-        clickable
-        html
-        delayHide={TOOLTIP_HIDE_DELAY_MS}
-        effect='solid'
-        isCapture
-        className='map-sidebar__tooltip'
-        data-id={`rental-units-tooltip-${id}`}
-        id={`rental-units-tooltip-${id}`} />
+    <div className='rental-units-meter' data-tip={tooltip}>
       {filledIcons}
       {unfilledIcons}
     </div>

--- a/taui/src/components/rental-units-meter.js
+++ b/taui/src/components/rental-units-meter.js
@@ -59,7 +59,7 @@ export default function RentalUnitsMeter ({
   })
 
   return (
-    <div className='rental-units-meter' data-tip={tooltip}>
+    <div className='rental-units-meter' data-tip={tooltip} data-for={`tooltip-${id}`}>
       {filledIcons}
       {unfilledIcons}
     </div>

--- a/taui/src/constants.js
+++ b/taui/src/constants.js
@@ -19,7 +19,7 @@ export const BOSTON_SCHOOL_CHOICE_LINK = 'https://discover.bostonpublicschools.o
 export const CAMBRIDGE_SCHOOL_CHOICE_LINK = 'https://www.cpsd.us/'
 
 // Allow clicking links in tooltips by delaying hide/update
-export const TOOLTIP_HIDE_DELAY_MS = 1000
+export const TOOLTIP_HIDE_DELAY_MS = 150
 
 // Maximum number of destinations that may be added to a user profile
 export const MAX_ADDRESSES = 3


### PR DESCRIPTION
## Overview

Dialed down the hide delay and changed to one tooltip per card instead of per meter. 

This appears to have largely solved the problem.

~However it introduces a new bug. In search view, when mousing into the tooltip itself, the last card in the list gets selected, as if you've hovered on that card. I don't see any simple way of stopping the propagation of that hover event. Fortunately, clicking the link in the tooltip does not trigger a click on the last card. I think this is a net win, given how bad the multiple tooltips problem was. I'll open a new issue for this new bug.~

### Notes

I initially tried manually hiding all tooltips via `ReactTooltip.hide()` `onMouseEnter` but it didn't work.

Cosmetic change: Tooltips now render to the right, over the map, so as not to occlude other meters.


## Testing Instructions

 * Hover over many meters on search and detail pages, and mouse into tooltips.
 * Confirm that multiple tooltips rarely, if ever, get rendered at once.

Resolves #230 
