### PR TITLE
Boost downtown results

### DIFF
--- a/taui/src/constants.js
+++ b/taui/src/constants.js
@@ -15,6 +15,13 @@ export const IMAGE_FIELDS = [
 // Value in `town_area` column of source data for grouping zip codes in Boston
 export const BOSTON_TOWN_AREA = 'Boston'
 
+// `town-area`s considered to be downtown, for special boosting in results
+export const DOWNTOWN_AREAS = [BOSTON_TOWN_AREA]
+// Include at least one downtown result in this many of the top results
+export const RESULTS_WITH_DOWNTOWN = 6
+// Place in the top results for boosted downtown results
+export const BOOST_DOWNTOWN_RESULT_PLACE = 3
+
 export const BOSTON_SCHOOL_CHOICE_LINK = 'https://discover.bostonpublicschools.org/'
 export const CAMBRIDGE_SCHOOL_CHOICE_LINK = 'https://www.cpsd.us/'
 


### PR DESCRIPTION
## Overview

Boost the first "downtown" (Boston) zip code into 3rd place, if none are in the top six.


### Demo

Top results, before:
![image](https://user-images.githubusercontent.com/960264/59947134-74cb3800-943a-11e9-999b-13c0253906c7.png)

Top result for Boston is in 13th place:

![image](https://user-images.githubusercontent.com/960264/59947321-e99e7200-943a-11e9-864f-c481c18abc38.png)

After, Beacon Hill is boosted to 3rd place:

![image](https://user-images.githubusercontent.com/960264/59947185-8f9dac80-943a-11e9-820d-2728735c087d.png)

And another neighborhood is in 13th place:

![image](https://user-images.githubusercontent.com/960264/59947371-0c308b00-943b-11e9-9df0-4df741c3ab47.png)


## Testing Instructions

 * Set origin to a location far from downtown
 * The first result for a Boston-area zip code should be in third place
 * That result should not appear in its previous position (should only be listed once)


Closes #238.
