### PR TITLE
Show directions link for transit, too.

### DIFF
--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -9,7 +9,6 @@ import type {AccountProfile, NeighborhoodImageMetadata} from '../types'
 import getCraigslistSearchLink from '../utils/craigslist-search-link'
 import getGoogleDirectionsLink from '../utils/google-directions-link'
 import getGoogleSearchLink from '../utils/google-search-link'
-import getGoogleMapsLink from '../utils/google-maps-link'
 import getNeighborhoodImage from '../utils/neighborhood-images'
 import getZillowSearchLink from '../utils/zillow-search-link'
 import PolygonIcon from '../icons/polygon-icon'
@@ -193,13 +192,6 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
           >
             {message('NeighborhoodDetails.GoogleSearchLink')}
           </a>
-          <a
-            className='neighborhood-details__link'
-            href={getGoogleMapsLink(neighborhood.properties.id)}
-            target='_blank'
-          >
-            {message('NeighborhoodDetails.GoogleMapsLink')}
-          </a>
         </div>
       </>
     )
@@ -254,7 +246,7 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
             <ModesList segments={bestJourney} />&nbsp;
             {message('NeighborhoodDetails.FromOrigin')}&nbsp;
             {currentDestination && currentDestination.purpose.toLowerCase()}
-            {hasVehicle && <a
+            <a
               className='neighborhood-details__directions'
               href={getGoogleDirectionsLink(
                 originCoordinateString,
@@ -263,7 +255,7 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
               target='_blank'
             >
               {message('NeighborhoodDetails.DirectionsLink')}
-            </a>}
+            </a>
           </div>
           {!hasVehicle && <RouteSegments
             hasVehicle={hasVehicle}

--- a/taui/src/sass/06_components/_neighborhood-details.scss
+++ b/taui/src/sass/06_components/_neighborhood-details.scss
@@ -44,15 +44,15 @@
     @include font-weight(bold);
     display: flex;
     flex-flow: row nowrap;
-    justify-content: flex-start;
-    align-items: center;
+    justify-content: space-between;
+    align-items: flex-start;
   }
 
   &__directions {
     @include link-states() {
       color: $primary;
     }
-    margin-left: auto;
+    margin-left: 1.6rem;
   }
 
   .route-segments {

--- a/taui/src/utils/google-maps-link.js
+++ b/taui/src/utils/google-maps-link.js
@@ -1,6 +1,0 @@
-// @flow
-// Returns a link to Google Maps with the given search term
-const GOOGLE_BASE_URL = 'https://www.google.com/maps/place/'
-export default function getGoogleSearchLink (query) {
-  return GOOGLE_BASE_URL + encodeURIComponent(query)
-}


### PR DESCRIPTION
## Overview

Show "Directions" link for transit, too. 

Remove "Google Maps" link from "Learn about…"


### Demo

![Screen Shot 2019-06-26 at 9 24 46 AM](https://user-images.githubusercontent.com/128699/60183478-67280080-97f4-11e9-955d-31a0541cd700.png)



## Testing Instructions

 * Go to a detail page.
 * Click "Directions".
 * Confirm Google Maps opens with directions between active neighborhood and selected frequent destination, via current travel mode.
 * Repeat for both transit and driving.