### PR TITLE
Add Rent Estimator link to detail view

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -58,6 +58,7 @@ NeighborhoodDetails:
   MaxRent: Est. max rent
   ModeSummary: via
   MoreSearchToolsLinksHeading: More search tools
+  RentEstimatorLink: Rent Estimator
   Section8Link: Section 8
   TransitMode: transit
   WebsiteLink: Website

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -166,6 +166,13 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
           >
             {message('NeighborhoodDetails.ChildCareSearchLink')}
           </a>
+          <a
+            className='neighborhood-details__link'
+            href='http://bha.cvrapps.com/'
+            target='_blank'
+          >
+            {message('NeighborhoodDetails.RentEstimatorLink')}
+          </a>
         </div>
         <h6 className='neighborhood-details__link-heading'>
           {message('NeighborhoodDetails.AboutNeighborhoodLinksHeading')}

--- a/taui/src/sass/06_components/_neighborhood-details.scss
+++ b/taui/src/sass/06_components/_neighborhood-details.scss
@@ -144,7 +144,7 @@
     }
 
     &:not(:last-child) {
-      margin-right: 2.4rem;
+      margin-right: 1.6rem;
     }
   }
 }


### PR DESCRIPTION
## Overview

Add a static link to http://bha.cvrapps.com/ to the neighborhood detail page.


### Demo

![Screen Shot 2019-06-27 at 10 48 43 AM](https://user-images.githubusercontent.com/128699/60276338-67de9680-98c9-11e9-865b-c6d8ffc04eba.png)


## Testing Instructions

 * Open a detail page.
 * Confirm new link is present and opens http://bha.cvrapps.com/ in a new tab.