### PR TITLE
Vary color breaks by chart

### DIFF
--- a/taui/src/components/meter.js
+++ b/taui/src/components/meter.js
@@ -13,7 +13,7 @@ export default function Meter ({
 }) {
   const percentage = value / max
   const percentageLabel = Math.round(percentage * 100)
-  const tier = getTier(percentage)
+  const tier = getTier(value, category)
 
   return (
     <div className='meter' data-tip={tooltip} data-for={`tooltip-${id}`}>

--- a/taui/src/components/rental-units-meter.js
+++ b/taui/src/components/rental-units-meter.js
@@ -23,7 +23,7 @@ export default function RentalUnitsMeter ({
   }
 
   const unfilledCount = NUM_ICONS - value
-  const tier = getTier(value / NUM_ICONS)
+  const tier = getTier(value, 'rental')
 
   const filledIcons = []
   for (let i = 0; i < value; i++) {

--- a/taui/src/utils/scaling.js
+++ b/taui/src/utils/scaling.js
@@ -1,15 +1,33 @@
 // @flow
+import get from 'lodash/get'
 
 // Labels for meter shading CSS categories
 const METER_TIERS = ['low', 'med', 'high']
+
+// Inclusive ranges for the 'med' tier, keyed by chart category.
+const BREAKS = {
+  'crime': [21, 40],
+  'school': [46, 65],
+  'rental': [3, 3]
+}
 
 // Map value from one range to another
 export default function scale (num, startMin, startMax, rangeMin, rangeMax) {
   return (num - startMin) * (rangeMax - rangeMin) / (startMax - startMin) + rangeMin
 }
 
-// Return CSS label for meter shading
-export function getTier (percentage) {
-  // Convert percentange to third to find shading tier
-  return METER_TIERS[Math.round(scale(percentage, 0, 1, 0, 2))]
+// Return CSS label for meter shading. Chart coloring breaks vary by `category`.
+export function getTier (value, category) {
+  const midBreak = get(BREAKS, category)
+  if (!midBreak) {
+    console.error('Could not find chart breaks for chart category ' + category)
+    return METER_TIERS[1]
+  }
+  if (value < midBreak[0]) {
+    return METER_TIERS[0]
+  } else if (value <= midBreak[1]) {
+    return METER_TIERS[1]
+  } else {
+    return METER_TIERS[2]
+  }
 }


### PR DESCRIPTION
## Overview

Each chart uses its own breaks for the three different colors.


### Demo

Safety medium break is 21-40%, inclusive (the second quintile):
![image](https://user-images.githubusercontent.com/960264/60282833-dc1f3700-98d5-11e9-94d8-e4fe58a9e997.png)

![image](https://user-images.githubusercontent.com/960264/60282921-0d980280-98d6-11e9-85f9-3fe448595c62.png)

Schools medium break is 46-65%, inclusive:
![image](https://user-images.githubusercontent.com/960264/60283007-3cae7400-98d6-11e9-9c2d-c001851cf728.png)


## Testing Instructions

 * Chart colors should be as expected
 

Closes #243.
