### PR TITLE
Check for exact voucher match at /profiles

### DIFF
--- a/deployment/amplify/staging/amplify/#current-cloud-backend/amplify-meta.json
+++ b/deployment/amplify/staging/amplify/#current-cloud-backend/amplify-meta.json
@@ -31,7 +31,7 @@
 				"s3TemplateURL": "https://s3.amazonaws.com/amplify-echolocatorstaging-staging-202454-deployment/amplify-cfn-templates/auth/template.json",
 				"logicalId": "authuserPoolGroups"
 			},
-			"lastPushTimeStamp": "2019-11-19T02:54:58.357Z",
+			"lastPushTimeStamp": "2019-11-22T18:10:20.630Z",
 			"output": {
 				"counselorsGroupRole": "arn:aws:iam::715496170458:role/us-east-1_JUROw4bAA-counselorsGroupRole"
 			},
@@ -45,7 +45,7 @@
 				"s3TemplateURL": "https://s3.amazonaws.com/amplify-echolocatorstaging-staging-202454-deployment/amplify-cfn-templates/auth/echolocatorStagingAuth-cloudformation-template.yml",
 				"logicalId": "authecholocatorStagingAuth"
 			},
-			"lastPushTimeStamp": "2019-11-19T02:54:58.360Z",
+			"lastPushTimeStamp": "2019-11-22T18:10:20.631Z",
 			"output": {
 				"AppClientSecret": "1j0gpob90aulc3cnopv27ndaepechmbvo5mt0epac455tq2cuto2",
 				"UserPoolId": "us-east-1_JUROw4bAA",
@@ -82,7 +82,7 @@
 				"s3TemplateURL": "https://s3.amazonaws.com/amplify-echolocatorstaging-staging-202454-deployment/amplify-cfn-templates/storage/s3-cloudformation-template.json",
 				"logicalId": "storageecholocatorStagingStorage"
 			},
-			"lastPushTimeStamp": "2019-11-19T02:54:58.368Z",
+			"lastPushTimeStamp": "2019-11-22T18:10:20.639Z",
 			"output": {
 				"BucketName": "echolocator-staging-profiles-staging",
 				"Region": "us-east-1"
@@ -111,7 +111,7 @@
 				"s3TemplateURL": "https://s3.amazonaws.com/amplify-echolocatorstaging-staging-202454-deployment/amplify-cfn-templates/function/echolocatorStagingClients-cloudformation-template.json",
 				"logicalId": "functionecholocatorStagingClients"
 			},
-			"lastPushTimeStamp": "2019-11-19T02:54:58.374Z",
+			"lastPushTimeStamp": "2019-11-22T18:10:20.640Z",
 			"output": {
 				"Region": "us-east-1",
 				"Arn": "arn:aws:lambda:us-east-1:715496170458:function:echolocatorStagingClientsLambda-staging",
@@ -140,21 +140,21 @@
 					]
 				}
 			],
-			"lastBuildTimeStamp": "2019-11-19T02:53:39.450Z",
-			"lastPackageTimeStamp": "2019-11-19T02:53:42.556Z",
-			"distZipFilename": "echolocatorStagingProfiles-46754967626e4d743754-build.zip",
+			"lastBuildTimeStamp": "2019-11-21T22:16:33.839Z",
+			"lastPackageTimeStamp": "2019-11-22T18:09:17.275Z",
+			"distZipFilename": "echolocatorStagingProfiles-4e655577652f6565614d-build.zip",
 			"providerMetadata": {
 				"s3TemplateURL": "https://s3.amazonaws.com/amplify-echolocatorstaging-staging-202454-deployment/amplify-cfn-templates/function/echolocatorStagingProfiles-cloudformation-template.json",
 				"logicalId": "functionecholocatorStagingProfiles"
 			},
-			"lastPushTimeStamp": "2019-11-19T02:54:58.374Z",
+			"lastPushTimeStamp": "2019-11-22T18:10:20.642Z",
 			"output": {
 				"Region": "us-east-1",
 				"Arn": "arn:aws:lambda:us-east-1:715496170458:function:echolocatorStagingProfilesLambda-staging",
 				"Name": "echolocatorStagingProfilesLambda-staging",
 				"LambdaExecutionRole": "echolocatorstagingLambdaRole6febe39a-staging"
 			},
-			"lastPushDirHash": "tmg/4PGe19o8Y7Nl/72qvwqhSVw="
+			"lastPushDirHash": "erlubS5hDBBK1z/kUkDzq6W/j7s="
 		}
 	},
 	"api": {
@@ -197,7 +197,7 @@
 				"s3TemplateURL": "https://s3.amazonaws.com/amplify-echolocatorstaging-staging-202454-deployment/amplify-cfn-templates/api/echolocatorStagingApi-cloudformation-template.json",
 				"logicalId": "apiecholocatorStagingApi"
 			},
-			"lastPushTimeStamp": "2019-11-19T02:54:58.371Z",
+			"lastPushTimeStamp": "2019-11-22T18:10:20.641Z",
 			"output": {
 				"ApiName": "echolocatorStagingApi",
 				"RootUrl": "https://zbg2hyg4yc.execute-api.us-east-1.amazonaws.com/staging"

--- a/deployment/amplify/staging/amplify/backend/amplify-meta.json
+++ b/deployment/amplify/staging/amplify/backend/amplify-meta.json
@@ -31,7 +31,7 @@
 				"s3TemplateURL": "https://s3.amazonaws.com/amplify-echolocatorstaging-staging-202454-deployment/amplify-cfn-templates/auth/template.json",
 				"logicalId": "authuserPoolGroups"
 			},
-			"lastPushTimeStamp": "2019-11-19T02:54:58.357Z",
+			"lastPushTimeStamp": "2019-11-22T18:10:20.630Z",
 			"output": {
 				"counselorsGroupRole": "arn:aws:iam::715496170458:role/us-east-1_JUROw4bAA-counselorsGroupRole"
 			},
@@ -45,7 +45,7 @@
 				"s3TemplateURL": "https://s3.amazonaws.com/amplify-echolocatorstaging-staging-202454-deployment/amplify-cfn-templates/auth/echolocatorStagingAuth-cloudformation-template.yml",
 				"logicalId": "authecholocatorStagingAuth"
 			},
-			"lastPushTimeStamp": "2019-11-19T02:54:58.360Z",
+			"lastPushTimeStamp": "2019-11-22T18:10:20.631Z",
 			"output": {
 				"AppClientSecret": "1j0gpob90aulc3cnopv27ndaepechmbvo5mt0epac455tq2cuto2",
 				"UserPoolId": "us-east-1_JUROw4bAA",
@@ -82,7 +82,7 @@
 				"s3TemplateURL": "https://s3.amazonaws.com/amplify-echolocatorstaging-staging-202454-deployment/amplify-cfn-templates/storage/s3-cloudformation-template.json",
 				"logicalId": "storageecholocatorStagingStorage"
 			},
-			"lastPushTimeStamp": "2019-11-19T02:54:58.368Z",
+			"lastPushTimeStamp": "2019-11-22T18:10:20.639Z",
 			"output": {
 				"BucketName": "echolocator-staging-profiles-staging",
 				"Region": "us-east-1"
@@ -111,7 +111,7 @@
 				"s3TemplateURL": "https://s3.amazonaws.com/amplify-echolocatorstaging-staging-202454-deployment/amplify-cfn-templates/function/echolocatorStagingClients-cloudformation-template.json",
 				"logicalId": "functionecholocatorStagingClients"
 			},
-			"lastPushTimeStamp": "2019-11-19T02:54:58.374Z",
+			"lastPushTimeStamp": "2019-11-22T18:10:20.640Z",
 			"output": {
 				"Region": "us-east-1",
 				"Arn": "arn:aws:lambda:us-east-1:715496170458:function:echolocatorStagingClientsLambda-staging",
@@ -140,21 +140,21 @@
 					]
 				}
 			],
-			"lastBuildTimeStamp": "2019-11-19T02:53:39.450Z",
-			"lastPackageTimeStamp": "2019-11-19T02:53:42.556Z",
-			"distZipFilename": "echolocatorStagingProfiles-46754967626e4d743754-build.zip",
+			"lastBuildTimeStamp": "2019-11-21T22:16:33.839Z",
+			"lastPackageTimeStamp": "2019-11-22T18:09:17.275Z",
+			"distZipFilename": "echolocatorStagingProfiles-4e655577652f6565614d-build.zip",
 			"providerMetadata": {
 				"s3TemplateURL": "https://s3.amazonaws.com/amplify-echolocatorstaging-staging-202454-deployment/amplify-cfn-templates/function/echolocatorStagingProfiles-cloudformation-template.json",
 				"logicalId": "functionecholocatorStagingProfiles"
 			},
-			"lastPushTimeStamp": "2019-11-19T02:54:58.374Z",
+			"lastPushTimeStamp": "2019-11-22T18:10:20.642Z",
 			"output": {
 				"Region": "us-east-1",
 				"Arn": "arn:aws:lambda:us-east-1:715496170458:function:echolocatorStagingProfilesLambda-staging",
 				"Name": "echolocatorStagingProfilesLambda-staging",
 				"LambdaExecutionRole": "echolocatorstagingLambdaRole6febe39a-staging"
 			},
-			"lastPushDirHash": "tmg/4PGe19o8Y7Nl/72qvwqhSVw="
+			"lastPushDirHash": "erlubS5hDBBK1z/kUkDzq6W/j7s="
 		}
 	},
 	"api": {
@@ -197,7 +197,7 @@
 				"s3TemplateURL": "https://s3.amazonaws.com/amplify-echolocatorstaging-staging-202454-deployment/amplify-cfn-templates/api/echolocatorStagingApi-cloudformation-template.json",
 				"logicalId": "apiecholocatorStagingApi"
 			},
-			"lastPushTimeStamp": "2019-11-19T02:54:58.371Z",
+			"lastPushTimeStamp": "2019-11-22T18:10:20.641Z",
 			"output": {
 				"ApiName": "echolocatorStagingApi",
 				"RootUrl": "https://zbg2hyg4yc.execute-api.us-east-1.amazonaws.com/staging"

--- a/deployment/amplify/staging/amplify/backend/function/echolocatorStagingProfiles/echolocatorStagingProfiles-cloudformation-template.json
+++ b/deployment/amplify/staging/amplify/backend/function/echolocatorStagingProfiles/echolocatorStagingProfiles-cloudformation-template.json
@@ -77,7 +77,7 @@
 				"Timeout": "25",
 				"Code": {
 					"S3Bucket": "amplify-echolocatorstaging-staging-202454-deployment",
-					"S3Key": "amplify-builds/echolocatorStagingProfiles-46754967626e4d743754-build.zip"
+					"S3Key": "amplify-builds/echolocatorStagingProfiles-4e655577652f6565614d-build.zip"
 				}
 			}
 		},


### PR DESCRIPTION
## Overview

Fix "multiple profiles exist" error being returned for inexact matches.


### Notes

This has already been pushed to the staging stack.

The `app.js` file is the only one here in need of review; the other changes were autogenerated by pushing the Amplify stack.


## Testing Instructions

 * Log in as a counselor
 * Create a profile for a six-character voucher number
 * Send a client user invite to the six-character voucher profile
 * Create a seven- or eight-character voucher number that contains the six-character voucher above
 * Log in as client user
 * Site should load and go to counselor-created profile matching the voucher for the client


Fixes #278.

