### PR TITLE
Feature/kak/modify rankings

### DIFF
--- a/taui/src/selectors/neighborhoods-sorted-with-routes.js
+++ b/taui/src/selectors/neighborhoods-sorted-with-routes.js
@@ -35,7 +35,7 @@ const DEFAULT_EDUCATION_QUINTILE = 5
 const DEFAULT_CRIME_QUINTILE = 5
 
 // extra constant weighting always given to travel time over the other two factors
-const EXTRA_ACCESS_WEIGHT = 1
+const EXTRA_ACCESS_WEIGHT = 2
 
 export default createSelector(
   selectNeighborhoodRoutes,
@@ -66,6 +66,10 @@ export default createSelector(
 
     // Give accessibility (travel time) extra weighting
     accessibilityImportance += EXTRA_ACCESS_WEIGHT
+    if (accessibilityImportance === MAX_IMPORTANCE) {
+      // if set to very important, add more extra weight to travel time
+      accessibilityImportance += EXTRA_ACCESS_WEIGHT
+    }
 
     const totalImportance = accessibilityImportance + crimeImportance + schoolsImportance
 

--- a/taui/src/selectors/neighborhoods-sorted-with-routes.js
+++ b/taui/src/selectors/neighborhoods-sorted-with-routes.js
@@ -29,6 +29,8 @@ const MAX_DISTANCE = 130000
 const MAX_TRAVEL_TIME = 120
 const MIN_QUINTILE = 1
 const MAX_QUINTILE = 5
+// stored profile importance is offset by one from MAX_IMPORTANCE
+const PROFILE_MAX_IMPORTANCE = MAX_IMPORTANCE - 1
 
 // default to worst, if unknown
 const DEFAULT_EDUCATION_QUINTILE = 5
@@ -65,12 +67,13 @@ export default createSelector(
       accessibilityImportance = crimeImportance = schoolsImportance = 1
     }
 
-    // Give accessibility (travel time) extra weighting
-    accessibilityImportance += EXTRA_ACCESS_WEIGHT
-    if (accessibilityImportance === MAX_IMPORTANCE) {
+    if (accessibilityImportance === PROFILE_MAX_IMPORTANCE) {
       // if set to very important, add more extra weight to travel time
-      accessibilityImportance += EXTRA_ACCESS_WEIGHT
+      accessibilityImportance += 1
     }
+
+    // Alwasy give accessibility (travel time) some extra weighting
+    accessibilityImportance += EXTRA_ACCESS_WEIGHT
 
     const totalImportance = accessibilityImportance + crimeImportance + schoolsImportance
 
@@ -89,7 +92,7 @@ export default createSelector(
       // Weight schools either by percentile binned into quarters if given max importance,
       // or otherwise weight by quintile.
       let educationWeight
-      if (schoolsImportance === (MAX_IMPORTANCE - 1)) {
+      if (schoolsImportance === PROFILE_MAX_IMPORTANCE) {
         // "very important": instead of quintiles, group percentile ranking into quarters
         const edPercent = properties.education_percentile
           ? properties.education_percentile
@@ -138,7 +141,7 @@ export default createSelector(
         } else if (crimeImportance === 2 && crimeQuintile < 4) {
           // "important"; treat all but worst two quintiles the same
           crimeQuintile = 1
-        } else if (crimeImportance === (MAX_IMPORTANCE - 1) && crimeQuintile > 3) {
+        } else if (crimeImportance === PROFILE_MAX_IMPORTANCE && crimeQuintile > 3) {
           // "very important"; push results for worst two quintiles to bottom
           // by reassigning weights for those quintiles to be 90% crime
           crimePercent = 90


### PR DESCRIPTION
## Overview

Modify neighborhood ranking logic to:
 - increase weight for transit time
 - weight equally category buckets for school and crime when certain criteria are met


### Notes

Transit times have been weighted more heavily rather than implementing the cutoff categories requested, as they don't make much sense with a weighted algorithm. The safety and school ranking changes are implemented as described; the changes were essentially to group ranking values depending on the combination of value and assigned importance to the category.


## Testing Instructions

 * View results for `VERIFY1` and `VERIFY2` test profiles
 * Results should be ordered as expected


Closes #297 
