### PR TITLE
Feature/kak/add hotpads link

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -57,6 +57,7 @@ NeighborhoodDetails:
   FromOrigin: from
   GoogleSearchLink: Google
   GoogleMapsLink: Google Maps
+  GoSection8SearchLink: GoSection8
   HotpadsSearchLink: Hotpads
   MassHousingLink: Mass Housing
   MaxRent: Est. max rent

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -57,6 +57,7 @@ NeighborhoodDetails:
   FromOrigin: from
   GoogleSearchLink: Google
   GoogleMapsLink: Google Maps
+  HotpadsSearchLink: Hotpads
   MassHousingLink: Mass Housing
   MaxRent: Est. max rent
   ModeSummary: via

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -9,6 +9,7 @@ import type {AccountProfile, NeighborhoodImageMetadata} from '../types'
 import getCraigslistSearchLink from '../utils/craigslist-search-link'
 import getGoogleDirectionsLink from '../utils/google-directions-link'
 import getGoogleSearchLink from '../utils/google-search-link'
+import getHotpadsSearchLink from '../utils/hotpads-search-link';
 import getNeighborhoodImage from '../utils/neighborhood-images'
 import getZillowSearchLink from '../utils/zillow-search-link'
 import PolygonIcon from '../icons/polygon-icon'
@@ -139,6 +140,16 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
             target='_blank'
           >
             {message('NeighborhoodDetails.CraigslistSearchLink')}
+          </a>
+          <a
+            className='neighborhood-details__link'
+            href={getHotpadsSearchLink(
+              neighborhood.properties.id,
+              userProfile.rooms,
+              maxSubsidy)}
+            target='_blank'
+          >
+            {message('NeighborhoodDetails.HotpadsSearchLink')}
           </a>
         </div>
         <h6 className='neighborhood-details__link-heading'>

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -9,7 +9,8 @@ import type {AccountProfile, NeighborhoodImageMetadata} from '../types'
 import getCraigslistSearchLink from '../utils/craigslist-search-link'
 import getGoogleDirectionsLink from '../utils/google-directions-link'
 import getGoogleSearchLink from '../utils/google-search-link'
-import getHotpadsSearchLink from '../utils/hotpads-search-link';
+import getGoSection8SearchLink from '../utils/gosection8-search-link'
+import getHotpadsSearchLink from '../utils/hotpads-search-link'
 import getNeighborhoodImage from '../utils/neighborhood-images'
 import getZillowSearchLink from '../utils/zillow-search-link'
 import PolygonIcon from '../icons/polygon-icon'
@@ -150,6 +151,16 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
             target='_blank'
           >
             {message('NeighborhoodDetails.HotpadsSearchLink')}
+          </a>
+          <a
+            className='neighborhood-details__link'
+            href={getGoSection8SearchLink(
+              neighborhood.properties.id,
+              userProfile.rooms,
+              maxSubsidy)}
+            target='_blank'
+          >
+            {message('NeighborhoodDetails.GoSection8SearchLink')}
           </a>
         </div>
         <h6 className='neighborhood-details__link-heading'>

--- a/taui/src/utils/gosection8-search-link.js
+++ b/taui/src/utils/gosection8-search-link.js
@@ -1,0 +1,7 @@
+// @flow
+// Returns a link to GoSection8 housing search for zipcode and number of bedrooms
+const GOSECTION8_BASE_URL = 'https://www.gosection8.com/Tenant/tn_Results.aspx'
+export default function getGoSection8SearchLink (zipcode, rooms, maxSubsidy) {
+  return GOSECTION8_BASE_URL + '?Address=' + encodeURIComponent(zipcode) +
+    '&bedrooms=' + encodeURIComponent(rooms) + '&maxRent=' + encodeURIComponent(maxSubsidy)
+}

--- a/taui/src/utils/hotpads-search-link.js
+++ b/taui/src/utils/hotpads-search-link.js
@@ -1,0 +1,7 @@
+// @flow
+// Returns a link to Hotpads housing search for zipcode and number of bedrooms
+const HOTPADS_BASE_URL = 'https://hotpads.com/'
+export default function getHotpadsSearchLink (zipcode, rooms, maxSubsidy) {
+  return HOTPADS_BASE_URL + encodeURIComponent(zipcode) + '/apartments-for-rent/?beds=' +
+    encodeURIComponent(rooms) + '&price=0-' + encodeURIComponent(maxSubsidy)
+}


### PR DESCRIPTION
## Overview

Add links to housing search for Hotpads and GoSection8.


### Demo

![image](https://user-images.githubusercontent.com/960264/73079584-78bcae00-3e92-11ea-9149-de45ac4a3a7e.png)


### Notes

GoSection8 apparently has few listings, and generally does not return any results.


## Testing Instructions

 * Go to the details page for a neighborhood
 * Should have new links for Hotpads and GoSection8
 * Clicking links should open new tab with expected search terms
 
Closes #300 
Closes #301 
