### PR TITLE
Add explanatory text for transit options on profile page

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -119,6 +119,7 @@ Profile:
   AddressMissing: All destinations should have an address. Please set or remove any empty destinations.
   ByCar: Car
   ByTransit: Transit
+  ByTransitExplanation: Search results will include subway and local bus.
   ChooseTravelMode: Will travel by
   DeleteAddress: Delete this address
   DeletePrimaryAddressError: Cannot delete primary destination. Set another as the primary first.
@@ -144,7 +145,8 @@ Profile:
   NameRequired: Please enter a name for the head of household.
   SaveError: Failed to save profile. Please try again.
   Title: Profile
-  UseCommuterRail: Include commuter rail and express bus
+  UseCommuterRail: Including commuter rail and express bus
+  UseCommuterRailExplanation: Search results will include subway, local bus, commuter rail, and express bus. Commuter rail and express bus will make more communities accessible, but typically cost more than subway and local bus service.
 Tooltips:
   AboveAverage: above average
   Average: about average

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -813,6 +813,10 @@ export default class EditProfile extends PureComponent<Props> {
                   </label>
                 </div>}
               </div>
+              {!hasVehicle && <div>
+                <span>{useCommuterRail ? message('Profile.UseCommuterRailExplanation')
+                  : message('Profile.ByTransitExplanation')}</span>
+              </div>}
             </div>
             <DestinationsList
               addAddress={addAddress}


### PR DESCRIPTION
## Overview

Adds explanatory text under the transit options on the profile page.


### Demo

Car:
![image](https://user-images.githubusercontent.com/960264/73091144-c859a480-3ea7-11ea-9114-5243a84e223c.png)

No commuter rail:
![image](https://user-images.githubusercontent.com/960264/73091167-d90a1a80-3ea7-11ea-9b63-96dfff8fa465.png)

With commuter rail:
![image](https://user-images.githubusercontent.com/960264/73091197-e6bfa000-3ea7-11ea-96dd-0b5d7f75854b.png)


### Notes

The example in #303 shows bolded text for the transit option names, but React doesn't like embedded HTML. (It works with the tooltip messages because they are fed through the tooltip library, which accepts HTML.) If wrapping in `<strong>` tags is important, we could hard-code the strings instead of putting them in `messages.yml`, but this would get in the way of translating the app in future.


## Testing Instructions

 * Go to 'edit profile'
 * Toggle the transit options and check the explanatory text
 * Explanatory text should not show when 'car' is selected
 * Text should only be for subway and bus when commuter rail box is unchecked
 * Longer text should display when commuter rail box is checked


Closes #303.

