### PR TITLE
Add BHA search tools link. Style profile page transit description.

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -50,6 +50,7 @@ Dock:
 NeighborhoodDetails:
   AboutNeighborhoodLinksHeading: Learn about this neighborhood
   ApartmentsDotComLink: Apartments.com
+  BHAApartmentsLink: Boston Housing Authority
   ChildCareSearchLink: Child Care Search
   CraigslistSearchLink: Craigslist
   DirectionsLink: Directions

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -813,9 +813,9 @@ export default class EditProfile extends PureComponent<Props> {
                   </label>
                 </div>}
               </div>
-              {!hasVehicle && <div>
-                <span>{useCommuterRail ? message('Profile.UseCommuterRailExplanation')
-                  : message('Profile.ByTransitExplanation')}</span>
+              {!hasVehicle && <div className='account-profile__field-description'>
+                {useCommuterRail ? message('Profile.UseCommuterRailExplanation')
+                  : message('Profile.ByTransitExplanation')}
               </div>}
             </div>
             <DestinationsList

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -169,17 +169,24 @@ export default class NeighborhoodDetails extends PureComponent<Props> {
         <div className='neighborhood-details__links'>
           <a
             className='neighborhood-details__link'
-            href='https://www.apartments.com/'
-            target='_blank'
-          >
-            {message('NeighborhoodDetails.ApartmentsDotComLink')}
-          </a>
-          <a
-            className='neighborhood-details__link'
             href='https://www.masshousing.com/portal/server.pt/community/rental_housing/240/looking_for_an_affordable_apartment_'
             target='_blank'
           >
             {message('NeighborhoodDetails.MassHousingLink')}
+          </a>
+          <a
+            className='neighborhood-details__link'
+            href='https://www.bostonhousing.org/en/Apartment-Listing.aspx?btype=8,7,6,5,4,3,2,1'
+            target='_blank'
+          >
+            {message('NeighborhoodDetails.BHAApartmentsLink')}
+          </a>
+          <a
+            className='neighborhood-details__link'
+            href='https://www.apartments.com/'
+            target='_blank'
+          >
+            {message('NeighborhoodDetails.ApartmentsDotComLink')}
           </a>
           <a
             className='neighborhood-details__link'

--- a/taui/src/sass/06_components/_account-profile.scss
+++ b/taui/src/sass/06_components/_account-profile.scss
@@ -39,6 +39,11 @@
     }
   }
 
+  &__field-description {
+    max-width: 48rem;
+    font-size: 1.3rem;
+  }
+
   &__label {
     @include text(400);
     @include font-weight(bold);


### PR DESCRIPTION
## Overview

1. Add "More search tools" link to [BHA apartment search](https://www.bostonhousing.org/en/Apartment-Listing.aspx?btype=8,7,6,5,4,3,2,1). Reordered the links to maximize the likelihood they'll fit on two lines.

2. Styled the new transit description added in #305 to use a small font-size for hierarchy and max-width to maintain container width.


### Demo

![Screen Shot 2020-01-27 at 10 06 44 AM](https://user-images.githubusercontent.com/128699/73186121-3e028200-40ed-11ea-982d-0a397f42dce1.png)

![Screen Shot 2020-01-27 at 10 06 56 AM](https://user-images.githubusercontent.com/128699/73186123-4064dc00-40ed-11ea-8e7f-8ddc04857614.png)

![Screen Shot 2020-01-27 at 10 07 02 AM](https://user-images.githubusercontent.com/128699/73186130-422e9f80-40ed-11ea-83a2-45ca0503ea28.png)


Resolves #302 
