### PR TITLE
Feature/kak/boston sort modifications#272

### DIFF
--- a/taui/src/constants.js
+++ b/taui/src/constants.js
@@ -28,7 +28,7 @@ export const DOWNTOWN_AREAS = [BOSTON_TOWN_AREA]
 // Include at least one downtown result in this many of the top results
 export const RESULTS_WITH_DOWNTOWN = 6
 // Place in the top results for boosted downtown results
-export const BOOST_DOWNTOWN_RESULT_PLACE = 3
+export const BOOST_DOWNTOWN_RESULT_PLACE = 6
 
 export const BOSTON_SCHOOL_CHOICE_LINK = 'https://discover.bostonpublicschools.org/'
 export const CAMBRIDGE_SCHOOL_CHOICE_LINK = 'https://www.cpsd.us/'

--- a/taui/src/selectors/neighborhoods-sorted-with-routes.js
+++ b/taui/src/selectors/neighborhoods-sorted-with-routes.js
@@ -120,6 +120,13 @@ export default createSelector(
       } else {
         educationWeight = 0 // Not important
       }
+      // Re-assign education weight for Boston zipcodes evenly to the other two factors
+      if (includes(DOWNTOWN_AREAS, properties['town_area'])) {
+        const halfEdPercent = schoolPercent / 2
+        crimePercent += halfEdPercent
+        accessibilityPercent += halfEdPercent
+        schoolPercent = 0
+      }
       let crimeWeight = 0
       // Handle missing values (zero in spreadsheet) by re-assigning crime weight
       // evenly to the other two factors. Also do so if crime set as unimportant.


### PR DESCRIPTION
## Overview

Ignore school rankings for Boston zip codes.

When boosting Boston zip codes into the top results, boost into the top six (first two pages) rather than the top three (first results page).

## Demo

Top three results for VERIFY2 on staging (before change):
![image](https://user-images.githubusercontent.com/960264/73217574-2e535f80-4126-11ea-94d9-62a428addbb8.png)


Top three results for VERIFY2 staging/dev profile on this branch:
![image](https://user-images.githubusercontent.com/960264/73217439-eaf8f100-4125-11ea-8ea0-a816d1a47f7b.png)


## Testing Instructions

 * When schools are at least "somewhat important," Boston zipcodes should appear more frequently near the top of the list
 * Boosted Boston zipcode results should go on the second page

Closes #272 
