### PR TITLE
Copy changes to profile page

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -108,7 +108,7 @@ Accounts:
   CreateError: Failed to create profile. Please try again.
   InvalidVoucherNumber: Client ID should be six to eight digits or letters.
   MissingVoucherNumber: Enter a client ID to create a profile.
-  Name: Name of head of household
+  Name: Your full name
   Search: Search
   SelectError: Failed to set profile. Please try again.
   NoResults: Profile not found. Create one now?
@@ -121,7 +121,7 @@ Profile:
   ByCar: Car
   ByTransit: Transit
   ByTransitExplanation: Search results will include subway and local bus.
-  ChooseTravelMode: Will travel by
+  ChooseTravelMode: How will you most often get to the above addresses?
   DeleteAddress: Delete this address
   DeletePrimaryAddressError: Cannot delete primary destination. Set another as the primary first.
   Cancel: Cancel
@@ -135,12 +135,12 @@ Profile:
   DeleteProfileError: Failed to delete profile. Please try again.
   Destinations: Where do you go most frequently (besides your home)?
   ImportanceAccessibility: Commute time
-  ImportanceHeading: How important are these factors when choosing a home?
+  ImportanceHeading: How important are these factors below when choosing a place to live?
   ImportanceSchools: School quality
   ImportanceViolentCrime: Public safety
   Primary: Primary
   Purpose: Purpose
-  Rooms: Number of bedrooms in voucher
+  Rooms: Number of bedrooms on your voucher
   Go: Save profile
   NameRequired: Please enter a name for the head of household.
   SaveError: Failed to save profile. Please try again.

--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -135,7 +135,7 @@ Profile:
   DeleteProfileError: Failed to delete profile. Please try again.
   Destinations: Where do you go most frequently (besides your home)?
   ImportanceAccessibility: Commute time
-  ImportanceHeading: How important are these factors below when choosing a place to live?
+  ImportanceHeading: How important are the factors below when choosing a place to live?
   ImportanceSchools: School quality
   ImportanceViolentCrime: Public safety
   Primary: Primary

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -738,6 +738,17 @@ export default class EditProfile extends PureComponent<Props> {
                 rooms={rooms}
                 changeField={changeField} />
             </div>
+            <DestinationsList
+              addAddress={addAddress}
+              deleteAddress={deleteAddress}
+              destinations={destinations}
+              editAddress={editAddress}
+              geocode={geocode}
+              reverseGeocode={reverseGeocode}
+              setGeocodeLocation={setGeocodeLocation}
+              setPrimaryAddress={setPrimaryAddress}
+              TripPurposeOptions={TripPurposeOptions}
+            />
             <div className='account-profile__field'>
               <div
                 className='account-profile__label'
@@ -796,17 +807,6 @@ export default class EditProfile extends PureComponent<Props> {
                   : message('Profile.ByTransitExplanation')}
               </div>}
             </div>
-            <DestinationsList
-              addAddress={addAddress}
-              deleteAddress={deleteAddress}
-              destinations={destinations}
-              editAddress={editAddress}
-              geocode={geocode}
-              reverseGeocode={reverseGeocode}
-              setGeocodeLocation={setGeocodeLocation}
-              setPrimaryAddress={setPrimaryAddress}
-              TripPurposeOptions={TripPurposeOptions}
-            />
             <div className='account-profile__importance-options'>
               <h3 className='account-profile__label'>
                 {message('Profile.ImportanceHeading')}


### PR DESCRIPTION
## Overview

Assorted small copy changes to the profile page.

Closes #314.


### Demo

![echo_profile_page_copy_changes](https://user-images.githubusercontent.com/960264/76217241-70bd9100-61e8-11ea-982e-94bfaa41712d.png)


### Notes

The requested copy included colons at the end of a couple of field labels, which I've omitted here, for consistency with existing field labels.


## Testing Instructions

 * (re-)start server (note `messages.yml` changes are not picked up by live reload)
 * Text changes should display as requested
 * Destination address list section should be above travel mode section

