### PR TITLE
Use education rankings for all neighborhoods

### DIFF
--- a/taui/src/selectors/neighborhoods-sorted-with-routes.js
+++ b/taui/src/selectors/neighborhoods-sorted-with-routes.js
@@ -120,13 +120,6 @@ export default createSelector(
       } else {
         educationWeight = 0 // Not important
       }
-      // Re-assign education weight for Boston zipcodes evenly to the other two factors
-      if (includes(DOWNTOWN_AREAS, properties['town_area'])) {
-        const halfEdPercent = schoolPercent / 2
-        crimePercent += halfEdPercent
-        accessibilityPercent += halfEdPercent
-        schoolPercent = 0
-      }
       let crimeWeight = 0
       // Handle missing values (zero in spreadsheet) by re-assigning crime weight
       // evenly to the other two factors. Also do so if crime set as unimportant.


### PR DESCRIPTION
## Overview

Remove special handling to ignore education rankings for Boston neighborhoods.

Closes #317.


## Notes

I've confirmed the existing Boston neighborhood boosting logic already works as requested (boosts a Boston neighborhood into the sixth slot if there are none in the top six.)


## Testing Instructions

 * Neighborhoods should be ranked as expected
