### PR TITLE
Add info about demo site to deployment README

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -4,6 +4,7 @@
 * [Terraform](#terraform)
 * [Taui](#taui)
 * [Amplify](#amplify)
+* [Demo site](#demo-site)
 
 ## AWS Credentials
 
@@ -100,3 +101,14 @@ $ cp deployment/amplify/staging/aws-exports.js taui/src/aws-exports.js
 
 (Note that CI will properly bundle the appropriate Amplify configuration file
 during deployment depending on the environment.)
+
+## Demo site
+There is a demo site deployed to demo.echosearch.org.
+
+Its infrastructure was created using the Terraform and Amplify methods
+described above, but it is not connected to CI; the functionality of the site
+was copied over from the staging site before returning to active CI use.
+
+It uses the same Cognito assets as the staging site, so this infrastructure
+should be left in place even after the staging and production sites are shifted
+to a Django authentication backend.


### PR DESCRIPTION
## Overview

Rolls the `develop` branch back to approximately where we left off a few years ago, and moves changes that have happened since then over onto a `demo` branch for future reference.

### Notes

- This PR is mostly symbolic; the actual work is already done, but I did include a commit to add some explanatory text about the new demo site.
- Creating and logging in with a counselor account works just fine, but I haven't managed to get things working with a non-counselor (i.e. voucher) account yet, and it is failing in a way that makes me suspect that the staging authentication machinery may not have been reconstituted completely. However, a counselor account will be sufficient for most of the changes we need to make at this point, so I'm leaving further investigation of the login issue for #359 and if we can't solve it then we can at least decide on an approach.

## Testing Instructions

 * Log in to https://demo.echosearch.org using the "BHA ECHO Staging" credentials. Search for a voucher (`11111111` is one that exists). Confirm that the site seems to work.
 * Perform the same steps on https://staging.echolocator.org -- the site should also work, but should be noticeably different from `demo.echosearch.org` in terms of features.
 * Verify that this branch is built by Travis and that it's successful.
 * Inspect the logs for [the most recent `develop` build on Travis](https://app.travis-ci.com/github/azavea/echo-locator/builds/239763436) and confirm that the deploy succeeded.
 * Use the GitHub interface to inspect the commit history for the `demo` and `develop` branches and confirm that `develop` has only a limited amount of non-Azavea code (which was necessary to get logins working), while `demo` has quite a bit.


Resolves #351 , Resolves #350 
