### PR TITLE
Copy changes to profile page

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -119,9 +119,9 @@ Profile:
   Address: Address
   AddressMissing: All destinations should have an address. Please set or remove any empty destinations.
   ByCar: Car
-  ByTransit: Transit
+  ByTransit: Bus and/or train
   ByTransitExplanation: Search results will include subway and local bus.
-  ChooseTravelMode: How will you most often get to the above addresses?
+  ChooseTravelMode: How do you usually travel to these places?
   DeleteAddress: Delete this address
   DeletePrimaryAddressError: Cannot delete primary destination. Set another as the primary first.
   Cancel: Cancel
@@ -133,7 +133,7 @@ Profile:
   DeleteDestination: Delete this destination
   DeleteProfile: Delete profile
   DeleteProfileError: Failed to delete profile. Please try again.
-  Destinations: Where do you go most frequently (besides your home)?
+  Destinations: What places do you visit often (besides your home)?
   ImportanceAccessibility: Commute time
   ImportanceHeading: How important are the factors below when choosing a place to live?
   ImportanceSchools: School quality
@@ -145,8 +145,8 @@ Profile:
   NameRequired: Please enter a name for the head of household.
   SaveError: Failed to save profile. Please try again.
   Title: Profile
-  UseCommuterRail: Including commuter rail and express bus
-  UseCommuterRailExplanation: Search results will include subway, local bus, commuter rail, and express bus. Commuter rail and express bus will make more communities accessible, but typically cost more than subway and local bus service.
+  UseCommuterRail: I’m willing to take the express bus or commuter rail
+  UseCommuterRailExplanation: The Commuter rail and express bus allow us to recommend more neighborhoods, but they usually cost more than the subway or local bus.
 Tooltips:
   AboveAverage: above average
   Average: about average


### PR DESCRIPTION
## Overview

Copy changes for profile page, consistent with `demo` branch.

### Demo

![Screen Shot 2021-10-20 at 4 40 48 PM](https://user-images.githubusercontent.com/36374797/138168961-292a57a2-0782-4ef6-91f8-3f339e14e779.png)

### Notes

There are fields and tooltips present in the profile page of the `demo` branch that are not present on the `develop` branch and so were not updated. If those eventually become included we will need to make the appropriate copy changes.

## Testing Instructions

 * Restart the server and navigate to http://localhost:9966/profile
 * In a separate window, navigate to https://demo.echosearch.org/profile
 * Confirm that copy and error messages are the same


Resolves #352 
