### PR TITLE
Custom signin error messages

### DIFF
--- a/taui/configurations/default/messages.yml
+++ b/taui/configurations/default/messages.yml
@@ -99,6 +99,8 @@ SignIn:
   Anonymous: Continue without an account
   AnonymousExplanation: Don't have an account?
   Greeting: Improving Housing Search for Voucher Families
+  UserNotFound: Could not find that username as entered. Usernames are case-sensitive.
+  BadUsernameOrPassword: Username or password was incorrect. Both usernames and passwords are case-sensitive.
 Header:
   New: New search
   Edit: Edit profile
@@ -151,11 +153,11 @@ Tooltips:
   AboveAverage: above average
   Average: about average
   BelowAverage: below average
-  Education: "<p><strong>%(town)</strong> schools are <strong>%(averageRelation)</strong> for the state and rank higher than <strong>%(edPercentile)%</strong> of other school districts when considering overall school quality and performance of low-income students. (Source: <a href=\"http://profiles.doe.mass.edu/\" target=\"_blank\">MA DOE</a>)</p>"
-  ExpandedChoice: "<p>Expanded Choice communities are TK</p>"
-  ViolentCrime: "<p><strong>%(town)</strong> has <strong>%(averageRelation)</strong> public safety, safer than <strong>%(crimePercentile)%</strong> of other zipcodes in the state. (Source: <a href=\"https://www.fbi.gov/services/cjis/ucr\" target=\"_blank\">FBI Uniform Crime Reporting violent crime data</a>)</p>"
-  ViolentCrimeBoston: "<p><strong>%(town)</strong> has <strong>%(averageRelation)</strong> public safety, safer than <strong>%(crimePercentile)%</strong> of other zipcodes in the state. (Source: <a href=\"https://data.boston.gov/\" target=\"_blank\">Boston Police Department Incident Reports</a>)</p>"
-  RentalUnits: "<p><strong>%(town)</strong> has an <strong>%(averageRelation)</strong> number of rental units for the state. From 2017-2018 there were <strong>%(totalMapc)</strong> units listed on Craigslist. (Source: <a href=\"https://www.mapc.org/\" target=\"_blank\">MAPC</a>)</p>"
+  Education: '<p><strong>%(town)</strong> schools are <strong>%(averageRelation)</strong> for the state and rank higher than <strong>%(edPercentile)%</strong> of other school districts when considering overall school quality and performance of low-income students. (Source: <a href="http://profiles.doe.mass.edu/" target="_blank">MA DOE</a>)</p>'
+  ExpandedChoice: '<p>Expanded Choice communities are TK</p>'
+  ViolentCrime: '<p><strong>%(town)</strong> has <strong>%(averageRelation)</strong> public safety, safer than <strong>%(crimePercentile)%</strong> of other zipcodes in the state. (Source: <a href="https://www.fbi.gov/services/cjis/ucr" target="_blank">FBI Uniform Crime Reporting violent crime data</a>)</p>'
+  ViolentCrimeBoston: '<p><strong>%(town)</strong> has <strong>%(averageRelation)</strong> public safety, safer than <strong>%(crimePercentile)%</strong> of other zipcodes in the state. (Source: <a href="https://data.boston.gov/" target="_blank">Boston Police Department Incident Reports</a>)</p>'
+  RentalUnits: '<p><strong>%(town)</strong> has an <strong>%(averageRelation)</strong> number of rental units for the state. From 2017-2018 there were <strong>%(totalMapc)</strong> units listed on Craigslist. (Source: <a href="https://www.mapc.org/" target="_blank">MAPC</a>)</p>'
 ImportanceLabels:
   1: Not important
   2: Somewhat important

--- a/taui/src/components/with-authenticator.js
+++ b/taui/src/components/with-authenticator.js
@@ -5,6 +5,8 @@ import Storage from '@aws-amplify/storage'
 import { Component, Fragment } from 'react'
 import { Authenticator } from 'aws-amplify-react/dist/Auth'
 import LogRocket from 'logrocket'
+import AmplifyMessageMap from 'aws-amplify-react/dist/AmplifyMessageMap.js'
+import message from '@conveyal/woonerf/message'
 
 import {clearLocalStorage, storeConfig} from '../config'
 import {AMPLIFY_API_NAME,
@@ -15,6 +17,20 @@ import type {AccountProfile} from '../types'
 import storeDefaultProfile from '../utils/store-default-profile'
 
 import CustomHeaderBar from './custom-header-bar'
+
+// Override the default error messages with ones that we've defined.
+function customAuthErrorMessageMap (error) {
+  const customMessages = {
+    'User does not exist.': 'SignIn.UserNotFound',
+    'Incorrect username or password.': 'SignIn.BadUsernameOrPassword'
+  }
+
+  if (customMessages.hasOwnProperty(error)) {
+    return message(customMessages[error])
+  }
+  // Fall back to the default messages if we can't find a custom one.
+  return AmplifyMessageMap(error)
+}
 
 // Override authentication wrapper to use custom header bar
 // based on:
@@ -372,17 +388,22 @@ export default function withAuthenticator (Comp, includeGreetings = false,
         )
       }
 
-      return <Authenticator
-        {...this.props}
-        theme={this.authConfig.theme}
-        federated={this.authConfig.federated || this.props.federated}
-        hideDefault={this.authConfig.authenticatorComponents &&
-            this.authConfig.authenticatorComponents.length > 0}
-        signUpConfig={this.authConfig.signUpConfig}
-        onStateChange={this.handleAuthStateChange}
-        changeUserProfile={this.changeUserProfile}
-        children={this.authConfig.authenticatorComponents || []}
-      />
+      return (
+        <Authenticator
+          {...this.props}
+          theme={this.authConfig.theme}
+          federated={this.authConfig.federated || this.props.federated}
+          hideDefault={
+            this.authConfig.authenticatorComponents &&
+            this.authConfig.authenticatorComponents.length > 0
+          }
+          signUpConfig={this.authConfig.signUpConfig}
+          onStateChange={this.handleAuthStateChange}
+          changeUserProfile={this.changeUserProfile}
+          children={this.authConfig.authenticatorComponents || []}
+          errorMessage={customAuthErrorMessageMap}
+        />
+      )
     }
   }
 }


### PR DESCRIPTION
## Overview

Adds custom error messages to the sign-in page so that users are reminded that usernames are case-sensitive.

### Demo

![Screenshot_2021-10-28_12-16-43](https://user-images.githubusercontent.com/447977/139295502-e4662e7d-b9b1-4161-8105-ea5e0675e2d0.png)


### Notes

This relies on the error message from the Cognito API exactly matching the keys in the mapping of overridden error messages. The Amplify source code from which this was adapted uses regular expressions in an apparent attempt to be more robust to API changes, but at the cost of significant additional complexity (it turns the one-step lookup here into a loop plus a lookup because you have to check for a match against all the regexes, and then associate a key with each regex to map to the message that you want to display). The additional complexity of adding a regex didn't seem worth it to me because without guarantees about what the format of the message will be, there's only so flexible you can be without losing the ability to distinguish between different error messages, so it'll always be possible for API changes to cause problems. So this keeps the logic simple (and brittle).


## Testing Instructions

 * Make a small change to the `UserNotFound` or `BadUsernameOrPassword` messages in `messages.yml` 
 * Fire up `./scripts/server` (you may need to restart it if it was already running when you changed `messages.yml`).
 * Try to log in with bad credentials and confirm you see your changes reflected in the error message.

Resolves #360 