### PR TITLE
Update README with correct AWS Amplify path

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Next, move the AWS Amplify JavaScript configuration for the staging environment
 into the Taui source code:
 
 ```
-$ cp deployment/amplify/staging/aws-exports.js taui/src/aws-exports.js
+$ cp deployment/amplify/staging/src/aws-exports.js taui/src/aws-exports.js
 ```
 
 ### Optional step for local deployment


### PR DESCRIPTION
## Overview

The instructions in the `develop` branch `README.md` currently have the wrong path to the AWS Amplify JavaScript configuration. This PR corrects the path and resolves that issue.

## Testing Instructions

 * Read through the `Development` section and make sure there are no typos and the path is correct: `deployment/amplify/staging/src/aws-exports.js`
 * Confirm the AWS Amplify JavaScript configuration file is at that path in the `develop` branch
