### PR TITLE
Maintain aspect ratio in neighborhood thumbnails

### DIFF
--- a/taui/src/sass/06_components/_neighborhood-summary.scss
+++ b/taui/src/sass/06_components/_neighborhood-summary.scss
@@ -65,6 +65,8 @@
     img {
       width: 100%;
       max-width: 120px;
+      aspect-ratio: 4 / 3;
+      object-fit: cover;
     }
   }
 


### PR DESCRIPTION
## Overview

Some neighborhood thumbnails (eg, Fenway 02115) render with a different aspect ratio from the expected 4:3. This PR enforces the 4:3 aspect ratio.

## Demo

### Before

![image](https://user-images.githubusercontent.com/128699/151197515-279a4010-b6c3-4691-8e46-70b31d74aaef.png)

### After

![image](https://user-images.githubusercontent.com/128699/151197613-ead89d58-f024-4c95-b644-02aa43ce8ce2.png)


## Testing Instructions

 * Page through the neighborhood cards until you see "Boston - Fenway: 02115"
 * Confirm that the thumbnail has the same aspect ratio as other cards and the card layout is okay.
