### PR TITLE
Fix error messages not appearing on login page

### DIFF
--- a/taui/src/components/with-authenticator.js
+++ b/taui/src/components/with-authenticator.js
@@ -7,6 +7,7 @@ import { Authenticator } from 'aws-amplify-react/dist/Auth'
 import LogRocket from 'logrocket'
 import AmplifyMessageMap from 'aws-amplify-react/dist/AmplifyMessageMap.js'
 import message from '@conveyal/woonerf/message'
+import { Translation } from 'react-i18next'
 
 import {clearLocalStorage, storeConfig} from '../config'
 import {AMPLIFY_API_NAME,
@@ -27,7 +28,7 @@ function customAuthErrorMessageMap (error) {
   }
 
   if (customMessages.hasOwnProperty(error)) {
-    return message(customMessages[error])
+    return <Translation>{(t) => t(message(error, customMessages[error]))}</Translation>
   }
   // Fall back to the default messages if we can't find a custom one.
   return AmplifyMessageMap(error)

--- a/taui/src/components/with-authenticator.js
+++ b/taui/src/components/with-authenticator.js
@@ -6,7 +6,6 @@ import { Component, Fragment } from 'react'
 import { Authenticator } from 'aws-amplify-react/dist/Auth'
 import LogRocket from 'logrocket'
 import AmplifyMessageMap from 'aws-amplify-react/dist/AmplifyMessageMap.js'
-import message from '@conveyal/woonerf/message'
 import { Translation } from 'react-i18next'
 
 import {clearLocalStorage, storeConfig} from '../config'
@@ -28,7 +27,7 @@ function customAuthErrorMessageMap (error) {
   }
 
   if (customMessages.hasOwnProperty(error)) {
-    return <Translation>{(t) => t(message(error, customMessages[error]))}</Translation>
+    return <Translation>{(t) => t(customMessages[error])}</Translation>
   }
   // Fall back to the default messages if we can't find a custom one.
   return AmplifyMessageMap(error)


### PR DESCRIPTION
## Overview

This PR fixes the issue with error messages not appearing correctly following a user entering incorrect login credentials.


### Demo
![Screen Shot 2022-01-26 at 3 32 50 PM](https://user-images.githubusercontent.com/77936689/151243693-b688335d-b725-4174-8f29-b40172a430fe.png)
Error message displayed when username does not exist.

![Screen Shot 2022-01-26 at 3 33 31 PM](https://user-images.githubusercontent.com/77936689/151243698-00da332a-1b90-45f8-b1e0-4bb77de2b8c9.png)
Error message displayed when password is incorrect.


### Notes

The `customMessages` dictionary was written to work with `react18next`; this PR also adds that translation capability into the `customAuthErrorMessageMap` function so that the correct message displays once we have corresponding errors in the Spanish and Chinese translation files.


## Testing Instructions

 * Either run `./scripts/server` or `cd taui` → `yarn start`
 * Try to log in with a fake username. You should see a banner at the top as in the image above.
 * Try to log in with a real username but a fake password. You should see a banner at the top as in the image above.


Resolves #395 
