### PR TITLE
Add final translations and replace sentences with bullets

### DIFF
--- a/taui/src/components/dock.js
+++ b/taui/src/components/dock.js
@@ -232,12 +232,12 @@ class Dock extends PureComponent<Props> {
             {showFavorites && <>
               {t('Dock.Favorites')}
               &nbsp;
-              {endingOffset > 0 && `(${startingOffset + 1}–${endingOffset} of ${totalNeighborhoodCount})`}
+              {endingOffset > 0 && `(${startingOffset + 1}–${endingOffset} / ${totalNeighborhoodCount})`}
             </>}
             {!showFavorites && <>
               {t('Dock.Recommendations')}
               &nbsp;
-              {endingOffset > 0 && `(${startingOffset + 1}–${endingOffset} of ${totalNeighborhoodCount})`}
+              {endingOffset > 0 && `(${startingOffset + 1}–${endingOffset} / ${totalNeighborhoodCount})`}
             </>}
           </h2>
           <div className='map-sidebar__neighborhoods-actions'>

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -72,11 +72,11 @@ class NeighborhoodDetails extends PureComponent<Props> {
     return (
       <div className='neighborhood-details__trip'>
         {bestJourney && <span className='neighborhood-details__route'>
-          <strong>{`${t('NeighborhoodDetails.TravelTime')}: `}</strong>
-          {`${tripTime} ${t('Units.Mins')}`}<br />
-          <strong>{`${t('NeighborhoodDetails.FromOrigin')}: `}</strong>
+          <strong>{t('NeighborhoodDetails.TravelTime')}: </strong>
+          {tripTime} {t('Units.Mins')}<br />
+          <strong>{t('NeighborhoodDetails.FromOrigin')}: </strong>
           {currentDestination && t('TripPurpose.' + currentDestination.purpose).toLowerCase()}<br />
-          <strong>{`${t('NeighborhoodDetails.ModeSummary')}: `}</strong>
+          <strong>{t('NeighborhoodDetails.ModeSummary')}: </strong>
           <ModesList segments={bestJourney} /></span>}
         {!bestJourney && !hasVehicle && <span className='neighborhood-details__route'>{t('Systems.TripsEmpty')}</span>}
         <a
@@ -163,7 +163,7 @@ class NeighborhoodDetails extends PureComponent<Props> {
     return (
       <>
         <h6 className='neighborhood-details__link-heading'>
-          {`${t('NeighborhoodDetails.MainSearchToolsSearch')}: ${rooms} ${t('NeighborhoodDetails.BedroomAbbr')} ($${estMaxRent.toLocaleString(i18n.language)} ${t('NeighborhoodDetails.MaxRentSearch')})`}
+          {t('NeighborhoodDetails.MainSearchToolsSearch')}: {rooms} {t('NeighborhoodDetails.BedroomAbbr')} (${estMaxRent.toLocaleString(i18n.language)} {t('NeighborhoodDetails.MaxRentSearch')})
         </h6>
         <div className='neighborhood-details__links'>
           <a

--- a/taui/src/components/neighborhood-details.js
+++ b/taui/src/components/neighborhood-details.js
@@ -4,7 +4,6 @@ import Icon from '@conveyal/woonerf/components/icon'
 import uniq from 'lodash/uniq'
 import {PureComponent} from 'react'
 
-import {ROUND_TRIP_MINUTES} from '../constants'
 import type {AccountProfile, ActiveListingDetail, NeighborhoodImageMetadata} from '../types'
 import getCraigslistSearchLink from '../utils/craigslist-search-link'
 import getGoogleDirectionsLink from '../utils/google-directions-link'
@@ -62,7 +61,7 @@ class NeighborhoodDetails extends PureComponent<Props> {
     ) : (
       neighborhood.segments && neighborhood.segments.length ? neighborhood.segments[0] : null
     )
-    const roundedTripTime = Math.round((listing ? listing.time : neighborhood.time) / ROUND_TRIP_MINUTES) * ROUND_TRIP_MINUTES
+    const tripTime = listing ? listing.time : neighborhood.time
 
     // lat,lon strings for Google Directions link from neighborhood to current destination
     const destinationCoordinateString = origin.position.lat + ',' + origin.position.lon
@@ -72,13 +71,13 @@ class NeighborhoodDetails extends PureComponent<Props> {
 
     return (
       <div className='neighborhood-details__trip'>
-        {bestJourney && <span className='neighborhood-details__route'>{t('Units.About')}&nbsp;
-          {roundedTripTime}&nbsp;
-          {t('Units.Mins')}&nbsp;
-          <ModesList segments={bestJourney} />&nbsp;
-          {t('NeighborhoodDetails.FromOrigin')}&nbsp;
-          {currentDestination && t('TripPurpose.' + currentDestination.purpose).toLowerCase()}
-        </span>}
+        {bestJourney && <span className='neighborhood-details__route'>
+          <strong>{`${t('NeighborhoodDetails.TravelTime')}: `}</strong>
+          {`${tripTime} ${t('Units.Mins')}`}<br />
+          <strong>{`${t('NeighborhoodDetails.FromOrigin')}: `}</strong>
+          {currentDestination && t('TripPurpose.' + currentDestination.purpose).toLowerCase()}<br />
+          <strong>{`${t('NeighborhoodDetails.ModeSummary')}: `}</strong>
+          <ModesList segments={bestJourney} /></span>}
         {!bestJourney && !hasVehicle && <span className='neighborhood-details__route'>{t('Systems.TripsEmpty')}</span>}
         <a
           className='neighborhood-details__directions'
@@ -164,7 +163,7 @@ class NeighborhoodDetails extends PureComponent<Props> {
     return (
       <>
         <h6 className='neighborhood-details__link-heading'>
-          {t('NeighborhoodDetails.MainSearchToolsLinksHeading', {rooms: rooms, maxSubsidy: estMaxRent.toLocaleString(i18n.language)})}
+          {`${t('NeighborhoodDetails.MainSearchToolsSearch')}: ${rooms} ${t('NeighborhoodDetails.BedroomAbbr')} ($${estMaxRent.toLocaleString(i18n.language)} ${t('NeighborhoodDetails.MaxRentSearch')})`}
         </h6>
         <div className='neighborhood-details__links'>
           <a
@@ -361,8 +360,7 @@ const ModesList = ({segments}) => {
 
   return segments && segments.length ? (
     <>
-      {t('NeighborhoodDetails.ModeSummary')}&nbsp;
-      {uniq(segments.map(s => s.type)).join('/')}
+      {uniq(segments.map(s => t(`TransportationMethod.${s.type}`))).join('/')}
     </>
   ) : t('NeighborhoodDetails.DriveMode')
 }

--- a/taui/src/components/route-card.js
+++ b/taui/src/components/route-card.js
@@ -98,12 +98,9 @@ class RouteCard extends React.PureComponent<Props> {
               </div>
               <div className='neighborhood-summary__trajectory'>
                 <span className='neighborhood-summary__mode'>
-                  {t(modeKey)}
-                  &nbsp;
-                  {t('NeighborhoodDetails.FromOrigin')}
-                </span>
-                {' '}
-                <span className='neighborhood-summary__location'>
+                  <strong>{`${t('NeighborhoodDetails.ModeSummary').toLowerCase()}: `}</strong>
+                  {t(modeKey)}<br />
+                  <strong>{`${t('NeighborhoodDetails.FromOrigin').toLowerCase()}: `}</strong>
                   {currentDestination && t('TripPurpose.' + currentDestination.purpose).toLowerCase()}
                 </span>
               </div>

--- a/taui/src/components/route-card.js
+++ b/taui/src/components/route-card.js
@@ -98,9 +98,9 @@ class RouteCard extends React.PureComponent<Props> {
               </div>
               <div className='neighborhood-summary__trajectory'>
                 <span className='neighborhood-summary__mode'>
-                  <strong>{`${t('NeighborhoodDetails.ModeSummary').toLowerCase()}: `}</strong>
+                  <strong>{t('NeighborhoodDetails.ModeSummary').toLowerCase()}: </strong>
                   {t(modeKey)}<br />
-                  <strong>{`${t('NeighborhoodDetails.FromOrigin').toLowerCase()}: `}</strong>
+                  <strong>{t('NeighborhoodDetails.FromOrigin').toLowerCase()}: </strong>
                   {currentDestination && t('TripPurpose.' + currentDestination.purpose).toLowerCase()}
                 </span>
               </div>

--- a/taui/src/components/route-segments.js
+++ b/taui/src/components/route-segments.js
@@ -13,14 +13,14 @@ export default function RouteSegments ({hasVehicle, routeSegments, travelTime}) 
   return (
     <div className='route-segments'>
       <div className='route-segments__best-trip'>
-        <strong>{`${t('Systems.Route')}: `}</strong>
+        <strong>{t('Systems.Route')}: </strong>
         {bestJourney.map((segment, index) => (
           <Segment key={index} segment={segment} />
         ))}
       </div>
       {routeSegments.length > 1 &&
         <div className='route-segments__alt-trips'>
-          <strong>{`${t('Systems.AlternateTripsTitle')}: `}</strong>
+          <strong>{t('Systems.AlternateTripsTitle')}: </strong>
           {alternateJourneys.map((segments, jindex) => (
             <span key={jindex}>
               {segments.map((segment, index) => (

--- a/taui/src/components/route-segments.js
+++ b/taui/src/components/route-segments.js
@@ -13,27 +13,20 @@ export default function RouteSegments ({hasVehicle, routeSegments, travelTime}) 
   return (
     <div className='route-segments'>
       <div className='route-segments__best-trip'>
-        {t('Systems.Take')}&nbsp;
+        <strong>{`${t('Systems.Route')}: `}</strong>
         {bestJourney.map((segment, index) => (
           <Segment key={index} segment={segment} />
         ))}
-        {travelTime > 120 ? (
-          <span className='decrease'>
-            {t('System.InaccessibleWithin')} 120 {t('Units.Mins')}
-          </span>
-        ) : (
-          <span>{t('Units.In')} <strong>{travelTime}</strong> {t('Units.Mins')}</span>
-        )}
       </div>
       {routeSegments.length > 1 &&
         <div className='route-segments__alt-trips'>
-          {t('Systems.AlternateTripsTitle')}&nbsp;
+          <strong>{`${t('Systems.AlternateTripsTitle')}: `}</strong>
           {alternateJourneys.map((segments, jindex) => (
             <span key={jindex}>
               {segments.map((segment, index) => (
                 <Segment key={index} segment={segment} />
               ))}
-              {jindex < alternateJourneys.length - 1 && 'or '}
+              {jindex < alternateJourneys.length - 1 && `${t('NeighborhoodDetails.Or')} `}
             </span>
           ))}
         </div>

--- a/taui/src/locales/en/translations.js
+++ b/taui/src/locales/en/translations.js
@@ -56,6 +56,7 @@ export default {
     FeedbackLink: 'ECHO needs your feedback',
     GoBackToRecommendations: 'Back to your recommendations',
     GoBackToFavorites: 'Back to saved recommendations',
+    RecommendationsCount: 'of',
     GoPreviousPage: 'Go back',
     GoNextPage: 'Show more',
     NoResults: 'No results',

--- a/taui/src/locales/en/translations.js
+++ b/taui/src/locales/en/translations.js
@@ -11,10 +11,10 @@ export default {
     TripsTitle: 'Example trips',
     TripsEmpty: 'No routes found to that destination',
     BestTripTitle: 'Fastest trip',
-    AlternateTripsTitle: 'Alternatively use',
+    AlternateTripsTitle: 'Alternative',
     Waiting: 'waiting included',
     NoAccess: 'No data from this point...',
-    Take: 'Take',
+    Route: 'Route',
     InaccessibleWithin: 'inaccessible within'
   },
   Faster: 'faster',
@@ -73,8 +73,9 @@ export default {
     ChildCareSearchLink: 'Child Care Search',
     CraigslistSearchLink: 'Craigslist',
     DirectionsLink: 'Directions',
-    DriveMode: 'drive',
-    FromOrigin: 'from',
+    DriveMode: 'car',
+    FromOrigin: 'Origin',
+    TravelTime: 'Travel Time',
     GoogleSearchLink: 'Google',
     GoogleMapsLink: 'Google Maps',
     GoSection8SearchLink: 'GoSection8',
@@ -82,9 +83,11 @@ export default {
     ListingsFetchError: 'Could not fetch listings',
     MetroHousingLink: 'Metro Housing',
     MaxRent: 'Est. max rent',
+    MaxRentSearch: 'max rent',
     BedroomAbbr: 'br',
-    ModeSummary: 'via',
-    MainSearchToolsLinksHeading: 'Search for {{rooms}}br with max rent ${{maxSubsidy}}',
+    ModeSummary: 'Mode',
+    Or: 'or',
+    MainSearchToolsSearch: 'Search for apartments',
     MoreSearchToolsLinksHeading: 'More search tools',
     RealtorApartmentsToggle: 'Realtor.com',
     RentEstimatorLink: 'Rent Estimator',
@@ -120,8 +123,7 @@ export default {
   Units: {
     About: 'About',
     Minutes: 'minutes',
-    Mins: 'min',
-    In: 'in'
+    Mins: 'min'
   },
   Agency: 'Boston Housing Authority',
   SignIn: {
@@ -237,5 +239,10 @@ export default {
     Yes: 'Yes',
     No: 'No'
   },
-  UnknownValue: 'Unknown'
+  UnknownValue: 'Unknown',
+  TransportationMethod: {
+    subway: 'subway',
+    bus: 'bus',
+    train: 'train'
+  }
 }

--- a/taui/src/locales/es/translations.js
+++ b/taui/src/locales/es/translations.js
@@ -12,10 +12,10 @@ export default {
     TripsTitle: 'Example trips',
     TripsEmpty: 'No routes found to that destination',
     BestTripTitle: 'Fastest trip',
-    AlternateTripsTitle: 'Alternativamente use',
+    AlternateTripsTitle: 'Alternativa',
     Waiting: 'waiting included',
     NoAccess: 'No data from this point...',
-    Take: 'Tome',
+    Route: 'Ruta',
     InaccessibleWithin: 'inaccessible within'
   },
   Faster: 'faster',
@@ -75,7 +75,8 @@ export default {
     CraigslistSearchLink: 'Craigslist',
     DirectionsLink: 'Direcciones',
     DriveMode: 'en coche',
-    FromOrigin: 'de',
+    FromOrigin: 'Origen',
+    TravelTime: 'Tiempo de Viaje',
     GoogleSearchLink: 'Google',
     GoogleMapsLink: 'Google Maps',
     GoSection8SearchLink: 'GoSection8',
@@ -83,9 +84,12 @@ export default {
     ListingsFetchError: 'Could not fetch listings',
     MetroHousingLink: 'Metro Housing',
     MaxRent: 'El alquiler estimado máximo',
+    MaxRentSearch: 'el alquiler máximo',
     BedroomAbbr: 'dor.',
-    ModeSummary: 'via',
-    MainSearchToolsLinksHeading: 'Busque por {{rooms}}dor. con alquiler máximo ${{maxSubsidy}}',
+    ModeSummary: 'Modo',
+    Or: 'o',
+    MainSearchToolsLinksHeading: 'Búsqueda de una unidad de {{rooms}}dor. con un alquiler máximo de ${{maxSubsidy}}',
+    MainSearchToolsSearch: 'Búsqueda de apartmentos',
     MoreSearchToolsLinksHeading: 'Más herramientas de búsqueda',
     ReadLessLink: 'Read Less',
     ReadMoreLink: 'Read More',
@@ -124,8 +128,7 @@ export default {
   Units: {
     About: 'Sobre',
     Minutes: 'minutes',
-    Mins: 'min',
-    In: 'en'
+    Mins: 'min'
   },
   Agency: 'Autorida de Vivienda de Boston',
   SignIn: {
@@ -245,5 +248,10 @@ export default {
     Yes: 'Sí',
     No: 'No'
   },
-  UnknownValue: 'Unknown'
+  UnknownValue: 'Unknown',
+  TransportationMethod: {
+    subway: 'tren',
+    bus: 'autobús',
+    train: 'tren'
+  }
 }

--- a/taui/src/locales/es/translations.js
+++ b/taui/src/locales/es/translations.js
@@ -10,7 +10,7 @@ export default {
     BaseTitle: 'Proposed Transit',
     ComparisonTitle: 'Current Transit',
     TripsTitle: 'Example trips',
-    TripsEmpty: 'No routes found to that destination',
+    TripsEmpty: 'No se han encontrado rutas hacia ese destino',
     BestTripTitle: 'Fastest trip',
     AlternateTripsTitle: 'Alternativa',
     Waiting: 'waiting included',
@@ -33,10 +33,10 @@ export default {
   Map: {
     SelectNetwork: 'Set time of day',
     NetworkOptions: {
-      Peak: 'Peak',
-      OffPeak: 'Off Peak',
-      PeakNoExpress: 'Peak No Express',
-      OffPeakNoExpress: 'Off Peak No Express'
+      Peak: 'Hora con tráfico',
+      OffPeak: 'Hora con poco tráfico',
+      PeakNoExpress: 'Hora con tráfico que no es express',
+      OffPeakNoExpress: 'Hora de poco tráfico que no es express'
     },
     SetLocationPopup: {
       SetStart: 'Set start',
@@ -57,18 +57,19 @@ export default {
     FeedbackLink: 'ECHO necesita su opinion',
     GoBackToRecommendations: 'Regresar a sus recomendaciones',
     GoBackToFavorites: 'Back to saved recommendations',
+    RecommendationsCount: 'de',
     GoPreviousPage: 'Regresar',
     GoNextPage: 'Muestra mas',
     NoResults: 'Ningun resultado',
     Recommendations: 'Sus recomendaciones',
     ShowAllButton: 'Todo',
     ShowSavedButton: 'Guardado',
-    SiteBy: 'site by Azavea'
+    SiteBy: 'Página Web hecha por de Azavea'
   },
   NeighborhoodDetails: {
     AboutNeighborhoodLinksHeading: 'Aprenda sobre este vecindario',
     ApartmentsDotComLink: 'Apartments.com',
-    ApartmentsToggles: 'Apartamentos',
+    ApartmentsToggles: 'Mostrar apartamentos desde',
     BHAApartmentsLink: 'Boston Housing Authority',
     BHAApartmentsToggle: 'BHA',
     ChildCareSearchLink: 'Child Care Search',
@@ -81,7 +82,7 @@ export default {
     GoogleMapsLink: 'Google Maps',
     GoSection8SearchLink: 'GoSection8',
     HotpadsSearchLink: 'Hotpads',
-    ListingsFetchError: 'Could not fetch listings',
+    ListingsFetchError: 'No se han podido descargar los listados',
     MetroHousingLink: 'Metro Housing',
     MaxRent: 'El alquiler estimado máximo',
     MaxRentSearch: 'el alquiler máximo',

--- a/taui/src/locales/zh/translations.js
+++ b/taui/src/locales/zh/translations.js
@@ -12,10 +12,10 @@ export default {
     TripsTitle: 'Example trips',
     TripsEmpty: 'No routes found to that destination',
     BestTripTitle: 'Fastest trip',
-    AlternateTripsTitle: '您亦可使用',
+    AlternateTripsTitle: '其他線路',
     Waiting: 'waiting included',
     NoAccess: 'No data from this point...',
-    Take: 'Take',
+    Route: '線路',
     InaccessibleWithin: 'inaccessible within'
   },
   Faster: 'faster',
@@ -75,8 +75,9 @@ export default {
     ChildCareSearchLink: 'Child Care Search',
     CraigslistSearchLink: 'Craigslist',
     DirectionsLink: '路線',
-    DriveMode: '駕駛',
-    FromOrigin: '從',
+    DriveMode: '汽車',
+    FromOrigin: '起點',
+    TravelTime: '旅行時長',
     GoogleSearchLink: 'Google',
     GoogleMapsLink: 'Google Maps',
     GoSection8SearchLink: 'GoSection8',
@@ -84,9 +85,11 @@ export default {
     ListingsFetchError: 'Could not fetch listings',
     MetroHousingLink: 'Metro Housing',
     MaxRent: '估計最高租金',
+    MaxRentSearch: '最大月租',
     BedroomAbbr: '臥房',
-    ModeSummary: 'via',
-    MainSearchToolsLinksHeading: 'Search for {{rooms}}br with max rent ${{maxSubsidy}}',
+    ModeSummary: ' 交通方式',
+    Or: '或',
+    MainSearchToolsSearch: '搜索公寓',
     MoreSearchToolsLinksHeading: '更多搜索工具',
     RealtorApartmentsToggle: 'Realtor.com',
     RentEstimatorLink: 'Rent Estimator',
@@ -242,5 +245,10 @@ export default {
     Yes: '是',
     No: '否'
   },
-  UnknownValue: 'Unknown'
+  UnknownValue: 'Unknown',
+  TransportationMethod: {
+    subway: '地鐡',
+    bus: '巴士',
+    train: '火車'
+  }
 }

--- a/taui/src/locales/zh/translations.js
+++ b/taui/src/locales/zh/translations.js
@@ -10,7 +10,7 @@ export default {
     BaseTitle: 'Proposed Transit',
     ComparisonTitle: 'Current Transit',
     TripsTitle: 'Example trips',
-    TripsEmpty: 'No routes found to that destination',
+    TripsEmpty: '未能找到前往該目的地的路綫',
     BestTripTitle: 'Fastest trip',
     AlternateTripsTitle: '其他線路',
     Waiting: 'waiting included',
@@ -33,10 +33,10 @@ export default {
   Map: {
     SelectNetwork: 'Set time of day',
     NetworkOptions: {
-      Peak: '什麼時候高峰期',
-      OffPeak: '非高峰',
-      PeakNoExpress: 'Peak No Express',
-      OffPeakNoExpress: 'Off Peak No Express'
+      Peak: '繁忙',
+      OffPeak: '非繁忙',
+      PeakNoExpress: '繁忙時段沒有快車',
+      OffPeakNoExpress: '非繁忙時段沒有快車'
     },
     SetLocationPopup: {
       SetStart: 'Set start',
@@ -52,11 +52,12 @@ export default {
   Dock: {
     FormHeading: '顯示行程時間',
     LocationLabel: '起點',
-    NetworkLabel: 'when',
+    NetworkLabel: '何時',
     Favorites: '保存建議',
     FeedbackLink: 'ECHO 需要您的回饋',
     GoBackToRecommendations: '返回到您的建議',
     GoBackToFavorites: 'Back to saved recommendations',
+    RecommendationsCount: '的',
     GoPreviousPage: '返回',
     GoNextPage: '顯示更多',
     ShowListings: 'Show apartments',
@@ -64,12 +65,12 @@ export default {
     Recommendations: '您的建議',
     ShowAllButton: '全部',
     ShowSavedButton: '保存的',
-    SiteBy: 'Azavea 網站'
+    SiteBy: '由 Azavea 網站'
   },
   NeighborhoodDetails: {
     AboutNeighborhoodLinksHeading: '了解該社區',
     ApartmentsDotComLink: 'Apartments.com',
-    ApartmentsToggles: 'Show apartments from',
+    ApartmentsToggles: '顯示公寓',
     BHAApartmentsLink: 'Boston Housing Authority',
     BHAApartmentsToggle: 'BHA',
     ChildCareSearchLink: 'Child Care Search',
@@ -82,7 +83,7 @@ export default {
     GoogleMapsLink: 'Google Maps',
     GoSection8SearchLink: 'GoSection8',
     HotpadsSearchLink: 'Hotpads',
-    ListingsFetchError: 'Could not fetch listings',
+    ListingsFetchError: '無法取得列表',
     MetroHousingLink: 'Metro Housing',
     MaxRent: '估計最高租金',
     MaxRentSearch: '最大月租',
@@ -134,7 +135,7 @@ export default {
     Greeting: '家庭類租賃券專用的改善住房搜索'
   },
   Header: {
-    New: 'New search',
+    New: '新搜尋',
     Edit: '編輯文檔',
     SignIn: '登錄'
   },
@@ -156,7 +157,7 @@ export default {
     AddressMissing: 'All destinations should have an address. Please set or remove any empty destinations.',
     ByCar: '汽車',
     ByTransit: '公共交通工具',
-    ByTransitExplanation: 'Search results will include subway and local bus.',
+    ByTransitExplanation: '搜尋結果將包括地鐵和地區巴士。',
     ChooseTravelMode: '您通常如何到達上述地址?',
     DeleteAddress: 'Delete this address',
     DeletePrimaryAddressError: 'Cannot delete primary destination. Set another as the primary first.',
@@ -166,7 +167,7 @@ export default {
     ClientEmailError: 'Please enter a valid email address.',
     CreateClientAccountError: 'Failed to create client login account. Please try again.',
     CreateClientAccountExistsError: 'A client login account already exists for that email with voucher number %(voucher).',
-    RecreateClientAccount: 'Resend invitation email',
+    RecreateClientAccount: '重發邀請電郵',
     DeleteDestination: 'Delete this destination',
     DeleteProfile: '刪除文檔',
     DeleteProfileError: 'Failed to delete profile. Please try again.',
@@ -175,7 +176,7 @@ export default {
     ImportanceHeading: '選擇住處的時候以下因素有多重要？',
     ImportanceSchools: '學校質量',
     ImportanceViolentCrime: '公共安全',
-    Primary: 'Primary',
+    Primary: '主要的',
     Purpose: '目的',
     Rooms: '租賃券上的臥房數目',
     RoomsNoVoucher: 'Desired number of bedrooms',

--- a/taui/src/sass/01_settings/_type.scss
+++ b/taui/src/sass/01_settings/_type.scss
@@ -13,6 +13,7 @@ $default-font-size-heading: 500;
 
 $font-sizes: (
     100: 1rem,
+    150: 1.1rem,
     200: 1.2rem,
     300: 1.4rem,
     400: 1.6rem,
@@ -27,6 +28,12 @@ $text-settings: (
         color: map-get($font-colors, dark),
         font-weight: map-get($font-weights, normal),
         font-size: map-get($font-sizes, 100),
+        line-height: 1.5,
+    ),
+    150: (
+        color: map-get($font-colors, dark),
+        font-weight: map-get($font-weights, normal),
+        font-size: map-get($font-sizes, 150),
         line-height: 1.5,
     ),
     200: (

--- a/taui/src/sass/06_components/_neighborhood-details.scss
+++ b/taui/src/sass/06_components/_neighborhood-details.scss
@@ -51,7 +51,6 @@
 
   &__trip {
     @include text(300);
-    @include font-weight(bold);
     display: flex;
     flex-flow: row nowrap;
     align-items: flex-start;
@@ -69,9 +68,7 @@
   }
 
   .route-segments {
-    @include text(200);
-    margin-top: 0.6rem;
-    line-height: 2.4;
+    line-height: 2;
   }
 
   &__rent {

--- a/taui/src/sass/06_components/_neighborhood-summary.scss
+++ b/taui/src/sass/06_components/_neighborhood-summary.scss
@@ -83,7 +83,7 @@
   }
 
   &__trajectory {
-    @include text(200);
+    @include text(150);
     color: $gray-600;
   }
 


### PR DESCRIPTION
## Overview

This PR adds in the final translations and breaks apart sentences into bullets for flexibility in translation. Initially, the sentence structure of pieces of the route cards and neighborhood details with dynamic values were creating grammatical issues in Spanish and Chinese, which has been fixed here by removing grammar entirely in those cases.


### Demo

![Screen Shot 2022-03-09 at 8 42 07 AM](https://user-images.githubusercontent.com/77936689/157454004-7620d56d-f588-4445-a6b3-e3040846cf2f.png)

![Screen Shot 2022-03-09 at 8 42 21 AM](https://user-images.githubusercontent.com/77936689/157454710-5ec74138-d1da-42be-8eae-a1e090aa64ce.png)

Dynamically translated sentences have been replaced with bulleted lists on both the neighborhood detail page and the route card.


### Notes

In replacing the sentences with bullets, I found that the check for travel times over 120 minutes in `route-segments.js` lines 20-26 was not being triggered at all; I can't tell exactly where the app is catching them, but trips that are over 120 minutes just don't display anything. As this would have been a sentence in need of replacing anyway, I've simply removed the check entirely.

The app also initially displayed 2 travel times on neighborhood detail pages: a rounded estimate ("about 5 minutes") and an exact travel time beside the best route ("in 7 minutes"). This PR removes the rounded estimate, as it was determined that the combination was confusing.

Finally, the addition of bullets created a spacing issue on the route cards when the user switched to Chinese. This was fixed by adding a new font size that is large enough to read in English and Spanish and small enough not to wrap in Chinese.

@aaronxsu would you be willing to take a look at the site with Chinese translations? I want to make sure there aren't any obvious mistakes or issues.


## Testing Instructions

 * Start the server and open a client profile
 * If needed, change the client's travel preferences to using transit and then return to the dock
 * Change the language to Spanish and Chinese, making sure there aren't any untranslated words and that there aren't any spacing issues on the route cards
 * Select a neighborhood, ideally with an alternative transit route listed, and switch between languages, again verifying that there aren't any spacing issues or missing translations
 * Return to "Edit Profile" and change to using a car, then check for spacing issues and missing translations


Resolves #398 & #389 
