### PR TITLE
Remove bedrooms filter for BHA listings

### DIFF
--- a/taui/src/actions/listings.js
+++ b/taui/src/actions/listings.js
@@ -51,9 +51,10 @@ export const setBHAListings = (payload: Listing | ListingQuery) => (dispatch: Di
     dispatch({type: BHA_ACTION_TYPE, payload: payload})
   } else {
     const zipcode = payload.query.zipcode
-    const rooms = payload.query.rooms
     const budget = payload.query.budget
-    const urlWithQuery = `${BHA_BASE_URL}zipcode=${zipcode}&rooms=${rooms}&budget=${budget}`
+    // The BHA API is not currently filtering by rooms correctly
+    // As a temporary fix, we took out the bedrooms query parameter so no listings are accidentally hidden
+    const urlWithQuery = `${BHA_BASE_URL}zipcode=${zipcode}&budget=${budget}`
 
     addActionLogItem(`Set BHA listings`)
     dispatch({type: BHA_ACTION_TYPE, payload: {pending: true}})


### PR DESCRIPTION
## Overview

Currently, we fetch BHA listings by querying an API endpoint with filter parameters. However, the number of bedrooms parameter is not working and causing valid listings to be filtered out of the response. As a temporary fix, this removes the bedrooms parameter and now the listings received are only filtered by zip code and max rent.

### Notes

Setting the `rooms` query parameter to `null` is not a valid option and will return an API response of `null`. Setting the query parameter to 0 successfully returns all listings filtered by the remaining parameters, however I chose to move forward with completely removing the `rooms` parameter since we've had difficulty with this API's query requirements before and this seemed like the least risky option. If the `rooms` parameter becomes mandatory, however, using 0 is an option.


## Testing Instructions

 * Run `./scripts/server`
 * Log in and select a neighborhood (usually the 'Boston - Dorchester – 02121' neighborhood has multiple BHA listings)
 * Confirm BHA listings appear and are filtered by max rent and zip code


Resolves #418 
