### PR TITLE
Add in missing copy and tooltip on edit profile page

### DIFF
--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -561,6 +561,23 @@ class EditProfile extends PureComponent<Props> {
     return (
       <div className='account-profile__destinations'>
         <h3 className='account-profile__label'>{t('Profile.Destinations')}</h3>
+        <span>
+          <div className='account-profile__button account-profile__button--tertiary account-profile__button--iconLeft'
+            data-tip={t('Tooltips.ProfileAddresses')}
+            data-for={`tooltip-profile-addresses`}>
+            {t('Profile.WhyAddresses')}
+          </div>
+          <ReactTooltip
+            clickable
+            html
+            effect='solid'
+            place='top'
+            isCapture
+            delayHide={TOOLTIP_HIDE_DELAY_MS}
+            className='map-sidebar__tooltip'
+            id={`tooltip-profile-addresses`}
+          />
+        </span>
         <div className='account-profile__destination-list-header'>
           <div className='account-profile__destination_field account-profile__destination_field--wide'>
             <span className='account-profile__destination-list-heading'>

--- a/taui/src/components/edit-profile.js
+++ b/taui/src/components/edit-profile.js
@@ -572,6 +572,7 @@ class EditProfile extends PureComponent<Props> {
             html
             effect='solid'
             place='top'
+            offset='{"top": -10}'
             isCapture
             delayHide={TOOLTIP_HIDE_DELAY_MS}
             className='map-sidebar__tooltip'

--- a/taui/src/locales/en/translations.js
+++ b/taui/src/locales/en/translations.js
@@ -183,9 +183,11 @@ export default {
     SaveError: 'Failed to save profile. Please try again.',
     Title: 'Profile',
     UseCommuterRail: 'I’m willing to take the express bus or commuter rail',
-    UseCommuterRailExplanation: 'The Commuter rail and express bus allow us to recommend more neighborhoods, but they usually cost more than the subway or local bus.'
+    UseCommuterRailExplanation: 'The Commuter rail and express bus allow us to recommend more neighborhoods, but they usually cost more than the subway or local bus.',
+    WhyAddresses: 'Why are we asking you this?'
   },
   Tooltips: {
+    ProfileAddresses: 'Knowing the places you visit often helps us recommend neighborhoods to you. Entering the address of your work or school allows us to recommend neighborhoods that are easy to reach by public transportation.',
     AboveAverage: 'above average',
     Average: 'about average',
     BelowAverage: 'below average',

--- a/taui/src/locales/es/translations.js
+++ b/taui/src/locales/es/translations.js
@@ -192,9 +192,11 @@ export default {
     InvalidBudget: 'Presupuesto no válido Por favor ingrese un número positivo.',
     Title: 'Perfil',
     UseCommuterRail: 'Incluye tren de cercanías y autobús expreso',
-    UseCommuterRailExplanation: 'Los resultados de búsqueda incluirán metro, autobús local, tren de cercanías y autobús expreso. El tren de cercanías y el autobús expreso harán que más comunidades sean accesibles, pero generalmente cuestan más que el servicio de metro y autobús local.'
+    UseCommuterRailExplanation: 'Los resultados de búsqueda incluirán metro, autobús local, tren de cercanías y autobús expreso. El tren de cercanías y el autobús expreso harán que más comunidades sean accesibles, pero generalmente cuestan más que el servicio de metro y autobús local.',
+    WhyAddresses: '¿Por qué me pregunta eso?'
   },
   Tooltips: {
+    ProfileAddresses: 'Si sabemos los lugares que usted visita frecuentemente, nons ayuda a recomendarle vecindarios. Ingrese la dirección de su trabajo o escuela y nos permitirá recomendarle vecindarios que son accesibles vía transportación pública.',
     AboveAverage: 'por encima del promedio',
     Average: 'el promedio',
     BelowAverage: 'por debajo del promedio',

--- a/taui/src/locales/zh/translations.js
+++ b/taui/src/locales/zh/translations.js
@@ -189,9 +189,11 @@ export default {
     InvalidBudget: 'Invalid budget. Please enter a positive number.',
     Title: '文檔',
     UseCommuterRail: '包括通勤火車和特快巴士',
-    UseCommuterRailExplanation: '搜尋結果將包括地鐵、本地巴士、通勤火車和特快巴士。通勤火車和特快巴士將可到達更多的社區，但其費用通常比地鐵和本地巴士服務要高。'
+    UseCommuterRailExplanation: '搜尋結果將包括地鐵、本地巴士、通勤火車和特快巴士。通勤火車和特快巴士將可到達更多的社區，但其費用通常比地鐵和本地巴士服務要高。',
+    WhyAddresses: '我們為何詢問你這個問題？'
   },
   Tooltips: {
+    ProfileAddresses: '得悉您常去的地點有助於我們向您推薦社區。輸入您工作或學校地址，我們就可以向您推薦乘坐公共交通容易到達的社區。',
     AboveAverage: '高於平均水平',
     Average: '相對平均水平',
     BelowAverage: '低於平均水平',


### PR DESCRIPTION
## Overview

The edit profile page was missing context on why users should put in addresses they visit frequently. This PR adds that copy, tooltip, and relevant translations.


### Demo


![Screen Shot 2022-03-31 at 10 29 58 AM](https://user-images.githubusercontent.com/77936689/161091805-6d0dfa49-127c-4d99-b8c0-ec12a7644532.png)


## Testing Instructions

 * Start the server and navigate to **http://localhost:9966/profile**
 * Verify that the copy appears under the "What places do you visit often (besides your home)?" title and that the tooltip appears when you hover over it
 * Change the language and verify that the copy and tooltip both translate as they should


Resolves #433 
