### PR TITLE
Add Django admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,27 @@ This project uses [`scripts-to-rule-them-all`](https://github.com/azavea/archite
 | `test`      | Run linters and tests                                      |
 | `update`    | Update project, assemble, run migrations                   |
 
+#### Creating a staff user account
+
+From the project directory, run:
+```
+./scripts/manage createsuperuser
+```
+Fill out the prompts for a username, email, and password.
 
 ### Logging In
 
-Once it is running, log in using staging credentials. From there, you can make a Client ID by
+Run: 
+```
+./scripts/server
+```
+
+#### Site
+Navigate to http://localhost:9966 and log in using staging credentials. From there, you can make a Client ID by
 entering and searching for a random 6-8 digit number, then making a new profile.
+
+#### Admin
+Navigate to http://localhost:8085/admin and login with your credentials created through the `createsuperuser` command above.
 
 ## Data
 

--- a/src/backend/echo/urls.py
+++ b/src/backend/echo/urls.py
@@ -19,4 +19,6 @@ from django.conf.urls.static import static
 
 from echo import settings
 
-urlpatterns = static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+urlpatterns = [
+    path('admin/', admin.site.urls),
+] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
## Overview

Creates an `/admin` site accessible to users with `staff` or `superuser` attributes. Also updates the `README.md` to walk users through setting up a superuser account and logging in.

### Notes
I’ve noticed that the `/admin` site navigation is really slow. The request for `admin/auth/users` for example took ~1 min and navigation back to `/admin` took ~1 min as well. It doesn’t appear consistent and I set up the `django-debug-toolbar` locally to explore further but didn’t find anything particularly insightful (how/which template files and sql queries made seemed normal), so I’m leaving it for now unless it becomes a problem down the road.
Browser timing info from toolbar:
<img width="1249" alt="Screen Shot 2022-03-31 at 10 58 12 AM" src="https://user-images.githubusercontent.com/36374797/161113950-a29311bb-d85e-44ff-bb60-e4475344ed8c.png">


## Testing Instructions

 * Follow the instructions in the `README.md` to create a user account
 * Run ` ./scripts/server`
 * Navigate to http://localhost:8085/admin and login with new credentials
 * Confirm login and `Groups` and `Users` models exists 

Resolves #426 
