### PR TITLE
Add email console backend for development

### DIFF
--- a/src/backend/echo/settings.py
+++ b/src/backend/echo/settings.py
@@ -43,6 +43,8 @@ if ENVIRONMENT == 'Development':
     ALLOWED_HOSTS.append('localhost')
     ALLOWED_HOSTS.append('django')
 
+    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
 # Application definition
 
 INSTALLED_APPS = [

--- a/src/backend/echo/urls.py
+++ b/src/backend/echo/urls.py
@@ -16,9 +16,30 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 from django.conf.urls.static import static
+from django.contrib.auth import views as auth_views
 
 from echo import settings
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
+    path(
+        "admin/password_reset/",
+        auth_views.PasswordResetView.as_view(),
+        name="admin_password_reset",
+    ),
+    path(
+        "admin/password_reset/done/",
+        auth_views.PasswordResetDoneView.as_view(),
+        name="password_reset_done",
+    ),
+    path(
+        "reset/<uidb64>/<token>/",
+        auth_views.PasswordResetConfirmView.as_view(),
+        name="password_reset_confirm",
+    ),
+    path(
+        "reset/done/",
+        auth_views.PasswordResetCompleteView.as_view(),
+        name="password_reset_complete",
+    ),
+    path("admin/", admin.site.urls),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
## Overview

Adds support for sending emails to the console logs in development, and enables Reset password for the Django admin (for testing purposes, but I thought we might want to leave it enabled, given that we intend for BHA users to regularly use the Django admin).


### Demo

![Screenshot 2022-04-06 141618](https://user-images.githubusercontent.com/4432106/162041774-4d516b27-5cce-4e3e-ab66-751260ff6ef2.png)
![Screenshot 2022-04-06 141628](https://user-images.githubusercontent.com/4432106/162041777-7a689596-e392-4799-86e2-388157f5e3c6.png)


## Testing Instructions

 * `scripts/server`
 * Go to the Django admin site and use the new reset password link
 * You should see an email printed to the console


Resolves #416 
