### PR TITLE
Upgrade Django image to latest

### DIFF
--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -1,24 +1,15 @@
-FROM quay.io/azavea/django:3.2-python3.9-slim
+FROM quay.io/azavea/django:3.2-python3.10-slim
 
 RUN mkdir -p /usr/local/src/backend
 WORKDIR /usr/local/src/backend
 
 COPY requirements.txt /usr/local/src/backend/
-RUN set -ex \
-    && buildDeps=" \
-    build-essential \
-    " \
-    && deps=" \
-    postgresql-client-13 \
-    " \
-    && apt-get update && apt-get install -y $buildDeps $deps --no-install-recommends \
-    && pip install --no-cache-dir -r requirements.txt \
-    && apt-get purge -y --auto-remove $buildDeps
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . /usr/local/src/backend
 
 CMD ["-b :8085", \
-    "--workers=1", \
+    "--workers=2", \
     "--timeout=60", \
     "--access-logfile=-", \
     "--access-logformat=%({X-Forwarded-For}i)s %(h)s %(l)s %(u)s %(t)s \"%(r)s\" %(s)s %(b)s \"%(f)s\" \"%(a)s\"", \


### PR DESCRIPTION
 - removes items that are installed already per new image (psql 13)
 - bumps workers to 2 to be more like what production/staging would look like

## Testing Instructions

 * Just check the admin site still works at localhost:8085/admin/

