### PR TITLE
Serve static files at Django root

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     volumes:
       - ./src/backend:/usr/local/src/backend
       - $HOME/.aws:/root/.aws:ro
+      - ./taui/assets:/usr/local/src/backend/static/assets
     working_dir: /usr/local/src/backend
     depends_on:
       database:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - ./src/backend:/usr/local/src/backend
       - $HOME/.aws:/root/.aws:ro
       - ./taui/assets:/usr/local/src/backend/static/assets
+      - ./taui/index.html:/usr/local/src/backend/static/index.html
     working_dir: /usr/local/src/backend
     depends_on:
       database:

--- a/src/backend/echo/settings.py
+++ b/src/backend/echo/settings.py
@@ -149,7 +149,6 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
-STATICFILES_DIRS = ((os.path.join(STATIC_ROOT, 'assets')),)
 
 # Set the django-spa static file storage:
 STATICFILES_STORAGE = 'spa.storage.SPAStaticFilesStorage'

--- a/src/backend/echo/settings.py
+++ b/src/backend/echo/settings.py
@@ -149,6 +149,7 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+STATICFILES_DIRS = ((os.path.join(STATIC_ROOT, 'assets')),)
 
 # Set the django-spa static file storage:
 STATICFILES_STORAGE = 'spa.storage.SPAStaticFilesStorage'


### PR DESCRIPTION
## Overview

We are currently using `django-spa` and a `mastarm` proxy on `start` to serve static files, however these static files were previously inaccessible to `django-spa`. This mounts the static assets created through `mastarm` to the django `/static` folder, allowing `django-spa` to find `index.html` on call to `/`.

### Notes

- The `index.html` file is not generated as part of the `mastarm` bundler and needed to be separately copied in, which is unideal. Ultimately, this serves as a temporary fix until we can move forward with a different bundler in #376.

## Testing Instructions

 * `scripts/update`
 * `scripts/server`
 * Navigate to `http://localhost:8085/` and confirm static page loads


Resolves #424 
