### PR TITLE
Set up email support via Amazon SES in deployed env

### DIFF
--- a/deployment/terraform-django/dns.tf
+++ b/deployment/terraform-django/dns.tf
@@ -49,3 +49,21 @@ resource "aws_route53_record" "site" {
     evaluate_target_health = true
   }
 }
+
+resource "aws_route53_record" "ses_verification" {
+  zone_id = aws_route53_zone.external.zone_id
+  name    = "_amazonses.${var.r53_public_hosted_zone}"
+  type    = "TXT"
+  ttl     = "300"
+  records = [aws_ses_domain_identity.app.verification_token]
+}
+
+resource "aws_route53_record" "ses_dkim" {
+  count = 3
+
+  zone_id = aws_route53_zone.external.zone_id
+  name    = "${aws_ses_domain_dkim.app.dkim_tokens[count.index]}._domainkey.${var.r53_public_hosted_zone}"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["${aws_ses_domain_dkim.app.dkim_tokens[count.index]}.dkim.amazonses.com"]
+}

--- a/deployment/terraform-django/email.tf
+++ b/deployment/terraform-django/email.tf
@@ -1,0 +1,24 @@
+#
+# SES resources
+#
+resource "aws_ses_domain_identity" "app" {
+  domain = var.r53_public_hosted_zone
+}
+
+resource "aws_ses_domain_dkim" "app" {
+  domain = aws_ses_domain_identity.app.domain
+}
+
+resource "aws_ses_identity_notification_topic" "app_bounce" {
+  topic_arn                = aws_sns_topic.global.arn
+  notification_type        = "Bounce"
+  identity                 = aws_ses_domain_identity.app.domain
+  include_original_headers = false
+}
+
+resource "aws_ses_identity_notification_topic" "app_complaint" {
+  topic_arn                = aws_sns_topic.global.arn
+  notification_type        = "Complaint"
+  identity                 = aws_ses_domain_identity.app.domain
+  include_original_headers = false
+}

--- a/deployment/terraform-django/iam.tf
+++ b/deployment/terraform-django/iam.tf
@@ -30,3 +30,19 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
   role       = aws_iam_role.ecs_task_execution_role.name
   policy_arn = var.aws_ecs_task_execution_role_policy_arn
 }
+
+data "aws_iam_policy_document" "scoped_email_sending" {
+  statement {
+    effect = "Allow"
+
+    actions = ["ses:SendEmail", "ses:SendRawEmail"]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "scoped_email_sending" {
+  name   = "ses${var.environment}ScopedEmailSendingPolicy"
+  role   = aws_iam_role.ecs_task_role.name
+  policy = data.aws_iam_policy_document.scoped_email_sending.json
+}

--- a/src/backend/echo/settings.py
+++ b/src/backend/echo/settings.py
@@ -48,6 +48,10 @@ if ENVIRONMENT == "Development":
     ALLOWED_HOSTS.append("127.0.0.1")
 
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+else:
+    EMAIL_BACKEND = "django_amazon_ses.EmailBackend"
+
+DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "noreply@stg.echosearch.org")
 
 # Application definition
 

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -4,3 +4,4 @@ django-watchman==1.3.0
 djangorestframework-gis==0.18
 djangorestframework==3.13.1
 django-spa==0.3.6
+django-amazon-ses==4.0.1


### PR DESCRIPTION
## Overview

This configures our Django app to send emails through AWS via [django-amazon-ses](https://github.com/azavea/django-amazon-ses) in staging/production environment. Debugging and development environments should still log to the console vs email. 

- [x] Right now our staging site throws a 500 server error on `/admin/`. To allow testing SES emails, the last commit sends an email on `/test-email/` page load. Once confirming the emails send on staging, this commit will be undone.
- [x] In order to send emails to houseseeker/counselor email addresses we will need to be removed from the SES sandbox, opened in [Issue 460](https://github.com/azavea/echo-locator/issues/460).

### Notes

- This was effectively a copy of the [email support set up of Treetective](https://github.com/azavea/treetective/pull/318), commit [c8b7806](https://github.com/azavea/treetective/commit/c8b7806fef027030460d69ec75ba564c8013954e). Changes include: 
  - getting rid of the `default_from_email` variable in terraform and related tasks. Since we hardcode the `DEFAULT_FROM_EMAIL` variable in Django `settings.py` it didn't seem necessary to test that the "from" address matches within the iam policy. If this conditional is worth keeping, I can bring it back and we will also need to update the appropriate `/terraform/terraform.tfvars` on S3 to include a `default_from_email` variable.
  - We configure our DKIM records for Route 53 in Terraform using a hardcoded `count` variable. I initially had it set up with the `for_each` meta-argument [as done in Treetective](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html). However, I was running into issues in `scripts/infra plan` as the `dkim_tokens` attribute isn't created until `apply` so Terraform wasn't sure how many records to create before then in `plan`. I think the ideal would be to set an initial `count` and then use the `-target` resource to update it in `apply`, but I couldn't get this to work and ultimately decided to follow the earlier Treetective setup.

## Demo
<img width="653" alt="Screen Shot 2022-04-26 at 4 48 23 PM" src="https://user-images.githubusercontent.com/36374797/165392365-07d6552d-2a10-40be-8614-85b60449400e.png">


## Testing Instructions

 * `scripts/server`
 * Navigate to `http://localhost:8085/test-email/` and confirm email message prints in the console
 * Navigate to `https://stg.echosearch.org/test-email/` (until #459 is resolved this won't display as expected—but that's ok, just calling the url will prompt the email to send for now.)
 * Login to AWS Console, navigate to Amazon SES, and scroll down to the "Sends" graph on the dashboard ("The count of successful send requests.")
 * Confirm an email has been sent through SES (You may need to refresh for the graph to populate)


Resolves #430 