### PR TITLE
Enable Docker Exec

### DIFF
--- a/deployment/terraform-django/app.tf
+++ b/deployment/terraform-django/app.tf
@@ -148,6 +148,7 @@ resource "aws_ecs_service" "app" {
 
   launch_type          = "FARGATE"
   platform_version     = var.fargate_platform_version
+  enable_execute_command = true
   force_new_deployment = true
 
   network_configuration {

--- a/deployment/terraform-django/dns.tf
+++ b/deployment/terraform-django/dns.tf
@@ -30,14 +30,6 @@ resource "aws_route53_zone" "external" {
   name = var.r53_public_hosted_zone
 }
 
-resource "aws_route53_record" "bastion" {
-  zone_id = aws_route53_zone.external.zone_id
-  name    = "bastion.${var.r53_public_hosted_zone}"
-  type    = "CNAME"
-  ttl     = "300"
-  records = [module.vpc.bastion_hostname]
-}
-
 resource "aws_route53_record" "site" {
   zone_id = aws_route53_zone.external.zone_id
   name    = var.r53_public_hosted_zone

--- a/deployment/terraform-django/firewall.tf
+++ b/deployment/terraform-django/firewall.tf
@@ -1,59 +1,4 @@
 #
-# Bastion security group resources
-#
-resource "aws_security_group_rule" "bastion_ssh_ingress" {
-  type        = "ingress"
-  from_port   = 22
-  to_port     = 22
-  protocol    = "tcp"
-  cidr_blocks = [var.external_access_cidr_block]
-
-  security_group_id = module.vpc.bastion_security_group_id
-}
-
-resource "aws_security_group_rule" "bastion_rds_egress" {
-  type      = "egress"
-  from_port = aws_db_instance.postgresql.port
-  to_port   = aws_db_instance.postgresql.port
-  protocol  = "tcp"
-
-  security_group_id        = module.vpc.bastion_security_group_id
-  source_security_group_id = aws_security_group.postgresql.id
-}
-
-resource "aws_security_group_rule" "bastion_ecs_egress" {
-  type      = "egress"
-  from_port = local.django_container_port
-  to_port   = local.django_container_port
-  protocol  = "tcp"
-
-  security_group_id        = module.vpc.bastion_security_group_id
-  source_security_group_id = aws_security_group.app.id
-}
-
-resource "aws_security_group_rule" "bastion_http_egress" {
-  type             = "egress"
-  from_port        = 80
-  to_port          = 80
-  protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
-  ipv6_cidr_blocks = ["::/0"]
-
-  security_group_id = module.vpc.bastion_security_group_id
-}
-
-resource "aws_security_group_rule" "bastion_https_egress" {
-  type             = "egress"
-  from_port        = 443
-  to_port          = 443
-  protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
-  ipv6_cidr_blocks = ["::/0"]
-
-  security_group_id = module.vpc.bastion_security_group_id
-}
-
-#
 # App ALB security group resources
 #
 resource "aws_security_group_rule" "alb_http_ingress" {
@@ -91,16 +36,6 @@ resource "aws_security_group_rule" "alb_ecs_egress" {
 #
 # RDS security group resources
 #
-resource "aws_security_group_rule" "rds_bastion_ingress" {
-  type      = "ingress"
-  from_port = aws_db_instance.postgresql.port
-  to_port   = aws_db_instance.postgresql.port
-  protocol  = "tcp"
-
-  security_group_id        = aws_security_group.postgresql.id
-  source_security_group_id = module.vpc.bastion_security_group_id
-}
-
 resource "aws_security_group_rule" "rds_ecs_ingress" {
   type      = "ingress"
   from_port = aws_db_instance.postgresql.port
@@ -142,14 +77,4 @@ resource "aws_security_group_rule" "ecs_alb_ingress" {
 
   security_group_id        = aws_security_group.app.id
   source_security_group_id = aws_security_group.alb.id
-}
-
-resource "aws_security_group_rule" "ecs_bastion_ingress" {
-  type      = "ingress"
-  from_port = local.django_container_port
-  to_port   = local.django_container_port
-  protocol  = "tcp"
-
-  security_group_id        = aws_security_group.app.id
-  source_security_group_id = module.vpc.bastion_security_group_id
 }

--- a/deployment/terraform-django/iam.tf
+++ b/deployment/terraform-django/iam.tf
@@ -24,6 +24,7 @@ resource "aws_iam_role" "ecs_task_execution_role" {
 resource "aws_iam_role" "ecs_task_role" {
   name               = "ecs${local.short}TaskRole"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+  managed_policy_arns = [aws_iam_policy.enable_execute_into.arn]
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
@@ -45,4 +46,25 @@ resource "aws_iam_role_policy" "scoped_email_sending" {
   name   = "ses${var.environment}ScopedEmailSendingPolicy"
   role   = aws_iam_role.ecs_task_role.name
   policy = data.aws_iam_policy_document.scoped_email_sending.json
+}
+
+resource "aws_iam_policy" "enable_execute_into" {
+  name   = "ses${var.environment}EnableExecuteInto"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = [
+            "ssmmessages:CreateControlChannel",
+            "ssmmessages:CreateDataChannel",
+            "ssmmessages:OpenControlChannel",
+            "ssmmessages:OpenDataChannel"
+       ],
+        Resource = "*"
+      },
+    ]
+  })
+
 }


### PR DESCRIPTION
## Overview
This enables the ability to exec into the running app container.

This removes access to the bastion but doesn't actually remove it
becuase that depends on reworking VPC terraform module or moving from it.

Related: #449

### Demo

$ aws ecs execute-command     --region us-east-1    --cluster ecsechostgdjangoCluster    --task <need_current_task_id>        --container django    --command "/bin/bash"    --interactive

The Session Manager plugin was installed successfully. Use the AWS CLI to start a session.


Starting session with SessionId: ecs-execute-command-0c855e0558b22fb37
root@ip-10-0-1-103:/usr/local/src/backend:

Confirm could get to psql.

### Notes

Future work:
 * Removing the bastion will actually depend on more work to separate from VPC module or update VPC to support bastion-less.
 * logging practices
 * process around using it in production (appcli, create separate task, etc?)

## Testing Instructions

1. Check local setup with https://github.com/aws-containers/amazon-ecs-exec-checker (need AWS with SSM)
2. Try demo above. 
3. For bonus connect to database.

