### PR TITLE
WIP Add django health-check

### DIFF
--- a/deployment/terraform-django/app.tf
+++ b/deployment/terraform-django/app.tf
@@ -43,8 +43,7 @@ resource "aws_lb_target_group" "app" {
   health_check {
     healthy_threshold   = "3"
     interval            = "30"
-    # TODO GH #441: Set this to 200 after we add a health check
-    matcher             = "400"
+    matcher             = "200"
     protocol            = "HTTP"
     timeout             = "3"
     path                = "/health-check/"

--- a/src/backend/echo/settings.py
+++ b/src/backend/echo/settings.py
@@ -67,6 +67,7 @@ INSTALLED_APPS = [
     "django_extensions",
     "rest_framework",
     "rest_framework_gis",
+    "watchman",
     "api",
     "users",
 ]
@@ -167,4 +168,4 @@ STATICFILES_STORAGE = "spa.storage.SPAStaticFilesStorage"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 WATCHMAN_ERROR_CODE = 503
-WATCHMAN_CHECKS = ("watchman.checks.databases", "api.checks.gazetteercache")
+WATCHMAN_CHECKS = ("watchman.checks.databases",)

--- a/src/backend/echo/urls.py
+++ b/src/backend/echo/urls.py
@@ -16,7 +16,7 @@ Including another URLconf
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
-from django.urls import path
+from django.urls import include, path
 from echo import settings
 from users.admin import LoginForm
 
@@ -44,4 +44,5 @@ urlpatterns = [
         name="password_reset_complete",
     ),
     path("admin/", admin.site.urls),
+    path("health-check/", include("watchman.urls")),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
## Overview

This updates the `django-watchman` settings and creates a `/health-check` endpoint for django. Also updates the app resource `health_check` `matcher` to 200 in Terraform so that the instance can respond as healthy.

This is a WIP until #459 is resolved to test how health-check works on staging

### Notes

- `gazetteercache` was a custom check used in OAR that's not applicable to our `api` module, so I took it out.

## Testing Instructions

 * `scripts/server`
 * Navigate to `http://localhost:8085/health-check/` and confirm json response
 * Confirm https://stg.echosearch.org/ still works as expected
 * Login to AWS console and navigate to ECS --> ecsechostgdjangoCluster --> Tasks --> select current running task --> logs
 * Confirm `/health-check` called in the logs and responding with 200 status


Resolves #441 
