### PR TITLE
Get staging working again

### DIFF
--- a/deployment/terraform-django/task-definitions/app.json.tmpl
+++ b/deployment/terraform-django/task-definitions/app.json.tmpl
@@ -2,18 +2,7 @@
   {
     "name": "${name}",
     "image": "${image}",
-    "cpu": 0,
-    "command": [
-      "-b :8085",
-      "--workers=${gunicorn_workers}",
-      "--timeout=60",
-      "--access-logfile=-",
-      "--access-logformat=%({X-Forwarded-For}i)s %(h)s %(l)s %(u)s %(t)s \"%(r)s\" %(s)s %(b)s \"%(f)s\" \"%(a)s\"",
-      "--error-logfile=-",
-      "--log-level=info",
-      "--capture-output",
-      "echo.wsgi"
-    ],
+    "cpu": 1024,
     "essential": true,
     "environment": [
       {

--- a/src/backend/echo/settings.py
+++ b/src/backend/echo/settings.py
@@ -36,10 +36,13 @@ LOGLEVEL = os.getenv("DJANGO_LOG_LEVEL", "INFO")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = ENVIRONMENT == "Development"
+# TODO GH #473
+DEBUG = True
 
 ALLOWED_HOSTS = [
     "stg.echosearch.org",
     ".stg.echosearch.org",
+    "10.0.1.*",
 ]
 
 if ENVIRONMENT == "Development":


### PR DESCRIPTION
 * Enable Debug
 * Allow cpu usage for the container (was set to 0..)
 * Uses docker cmd instead of specifying our own command in terraform

This is mostly to get staging in a better state so we can eventually turn off Debug. (Although the non-debug options might be useful to keep). 

I'm not sure Staging was ever working correctly...
