### PR TITLE
Add django health-check

### DIFF
--- a/deployment/terraform-django/app.tf
+++ b/deployment/terraform-django/app.tf
@@ -43,8 +43,7 @@ resource "aws_lb_target_group" "app" {
   health_check {
     healthy_threshold   = "3"
     interval            = "30"
-    # TODO GH #441: Set this to 200 after we add a health check
-    matcher             = "400"
+    matcher             = "200"
     protocol            = "HTTP"
     timeout             = "3"
     path                = "/health-check/"

--- a/deployment/terraform-django/task-definitions/app.json.tmpl
+++ b/deployment/terraform-django/task-definitions/app.json.tmpl
@@ -2,18 +2,7 @@
   {
     "name": "${name}",
     "image": "${image}",
-    "cpu": 0,
-    "command": [
-      "-b :8085",
-      "--workers=${gunicorn_workers}",
-      "--timeout=60",
-      "--access-logfile=-",
-      "--access-logformat=%({X-Forwarded-For}i)s %(h)s %(l)s %(u)s %(t)s \"%(r)s\" %(s)s %(b)s \"%(f)s\" \"%(a)s\"",
-      "--error-logfile=-",
-      "--log-level=info",
-      "--capture-output",
-      "echo.wsgi"
-    ],
+    "cpu": 1024,
     "essential": true,
     "environment": [
       {

--- a/src/backend/echo/settings.py
+++ b/src/backend/echo/settings.py
@@ -37,8 +37,6 @@ LOGLEVEL = os.getenv("DJANGO_LOG_LEVEL", "INFO")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = ENVIRONMENT == "Development"
-# TODO GH #473
-DEBUG = True
 
 ALLOWED_HOSTS = [
     "stg.echosearch.org",

--- a/src/backend/echo/settings.py
+++ b/src/backend/echo/settings.py
@@ -70,6 +70,7 @@ INSTALLED_APPS = [
     "django_extensions",
     "rest_framework",
     "rest_framework_gis",
+    "watchman",
     "api",
     "users",
 ]
@@ -170,4 +171,4 @@ STATICFILES_STORAGE = "spa.storage.SPAStaticFilesStorage"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 WATCHMAN_ERROR_CODE = 503
-WATCHMAN_CHECKS = ("watchman.checks.databases", "api.checks.gazetteercache")
+WATCHMAN_CHECKS = ("watchman.checks.databases",)

--- a/src/backend/echo/settings.py
+++ b/src/backend/echo/settings.py
@@ -36,10 +36,13 @@ LOGLEVEL = os.getenv("DJANGO_LOG_LEVEL", "INFO")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = ENVIRONMENT == "Development"
+# TODO GH #473
+DEBUG = True
 
 ALLOWED_HOSTS = [
     "stg.echosearch.org",
     ".stg.echosearch.org",
+    "10.0.1.*",
 ]
 
 if ENVIRONMENT == "Development":

--- a/src/backend/echo/urls.py
+++ b/src/backend/echo/urls.py
@@ -16,7 +16,7 @@ Including another URLconf
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
-from django.urls import path
+from django.urls import include, path
 from echo import settings
 from users.admin import LoginForm
 
@@ -44,4 +44,5 @@ urlpatterns = [
         name="password_reset_complete",
     ),
     path("admin/", admin.site.urls),
+    path("health-check/", include("watchman.urls")),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -5,3 +5,4 @@ djangorestframework-gis==0.18
 djangorestframework==3.13.1
 django-spa==0.3.6
 django-amazon-ses==4.0.1
+requests==2.26.0


### PR DESCRIPTION
## Overview

This updates the `django-watchman` settings and creates a `/health-check` endpoint for django as well as updates the app resource `health_check` `matcher` to 200 in Terraform so that the instance can respond as healthy.

This is built off of PR #474 to bring together a multi-piece solution to resolving #459. We can't test health-check appropriately without the previous PR and the previous PR doesn't bring staging all the way to function properly without health-check and an update to allowed hosts.

### Notes

- `gazetteercache` was a custom check used in OAR that's not applicable to our `api` module, so I took it out.

## Testing Instructions

 * `scripts/server`
 * Navigate to `http://localhost:8085/health-check/` and confirm json response
 * Confirm https://stg.echosearch.org/ still works as expected
 * Login to AWS console and navigate to ECS --> ecsechostgdjangoCluster --> Tasks --> select current running task --> logs
 * Confirm `/health-check` called in the logs and responding with 200 status


Resolves #441, #459, #473
