### PR TITLE
Change from latest to GIT_COMMIT

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -7,7 +7,7 @@ services:
       - $HOME/.aws:/root/.aws:ro
     environment:
       - AWS_PROFILE=echo-locator
-      - GIT_COMMIT=${GIT_COMMIT:-latest}
+      - GIT_COMMIT=${GIT_COMMIT}
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - ECHOLOCATOR_DEBUG=1
@@ -25,4 +25,4 @@ services:
     entrypoint: bash
 
   django:
-    image: "echolocator:${GIT_COMMIT:-latest}"
+    image: "echolocator:${GIT_COMMIT}"

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -19,8 +19,7 @@ ENVIRONMENT="${ECHOLOCATOR_ENVIRONMENT:-stgdjango}"
 if [[ -n "${GIT_COMMIT}" ]]; then
     GIT_COMMIT="${GIT_COMMIT:0:7}"
 else
-    # For staging we just want latest
-    GIT_COMMIT="latest"
+    GIT_COMMIT="$(git rev-parse --short HEAD)"
 fi
 
 function amazon_ecr_login() {

--- a/scripts/infra
+++ b/scripts/infra
@@ -48,6 +48,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                   -backend-config="key=terraform/state"
 
                 terraform plan \
+                  -var="image_tag=${GIT_COMMIT}" \
                   -var-file="${ECHOLOCATOR_SETTINGS_BUCKET}.tfvars" \
                   -out="${ECHOLOCATOR_SETTINGS_BUCKET}.tfplan"
                 ;;


### PR DESCRIPTION
This is a small change to stop relying on the latest docker image tag
and just have terraform use actual git commit shas.

Resolves: #476

### Demo
From ECS manager, showing django tasks

RUNNING 322268938932.dkr.ecr.us-east-1.amazonaws.com/echostgdjango:d95d488

INACTIVE RUNNING 322268938932.dkr.ecr.us-east-1.amazonaws.com/echostgdjango:5f23706

## Testing Instructions

 * See the Image SHA change like above
