### PR TITLE
Remove todo and add cli way to get cluster/task ids

### DIFF
--- a/deployment/README-django.md
+++ b/deployment/README-django.md
@@ -93,7 +93,7 @@ $ aws ecs list-tasks  --cluster ecsechostgdjangoCluster
 ...
 ```
 
-4. Run the following command (the task ID can be found by logging into :
+4. Run the following command:
 
 ```bash
 $ aws ecs execute-command --cluster <name-of-django-staging-cluster> --task <current-task-id> --container django --command "/bin/bash" --interactive

--- a/deployment/README-django.md
+++ b/deployment/README-django.md
@@ -48,8 +48,6 @@ project     = "echo"
 environment = "stgdjango"
 aws_region  = "us-east-1"
 
-aws_key_name = "echo-stg"
-
 r53_private_hosted_zone = "echo.internal"
 
 rds_database_identifier = stgdjango
@@ -80,13 +78,29 @@ This will attempt to apply the plan assembled in the previous step using Amazon'
 
 ### Staging
 
-1. Ensure you are setup with AWS CLI credentials.
+1. Ensure you are setup with AWS CLI credentials and have the correct profile set with `export AWS_PROFILE=echo-locator `
 2. Install the [Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) for the AWS CLI.
-3. Run the following command (the task ID can be found by logging into the AWS console and selecting the most recent running task for the ECS [django staging cluster](https://us-east-1.console.aws.amazon.com/ecs/home?region=us-east-1#/clusters/ecsechostgdjangoCluster/tasks)):
+3. Use the following commands to get the cluster name/task id or use the AWS console to select the most recent running task for the ECS [django staging cluster](https://us-east-1.console.aws.amazon.com/ecs/home?region=us-east-1#/clusters/ecsechostgdjangoCluster/tasks))
+
 ```bash
-$ aws ecs execute-command --region us-east-1 --cluster <name-of-django-staging-cluster> --task <current-task-id> --container django --command "/bin/bash" --interactive
+$ aws ecs list-clusters
+...
+......cluster/ecsechostgdjangoCluster
+...
+$ aws ecs list-tasks  --cluster ecsechostgdjangoCluster
+...
+......task/ecsechostgdjangoCluster/523612e9652b40dfae4e91e6e157c17b
+...
 ```
-4. You should see something similar to the following to initiate the start of a session:
+
+4. Run the following command (the task ID can be found by logging into :
+
+```bash
+$ aws ecs execute-command --cluster <name-of-django-staging-cluster> --task <current-task-id> --container django --command "/bin/bash" --interactive
+```
+
+5. You should see something similar to the following to initiate the start of a session:
+
 ```
 The Session Manager plugin was installed successfully. Use the AWS CLI to start a session.
 
@@ -94,8 +108,9 @@ The Session Manager plugin was installed successfully. Use the AWS CLI to start 
 Starting session with SessionId: ecs-execute-command-08e2295045096200d
 root@ip-10-0-3-195:/usr/local/src/backend#
 ```
-5. Run `python manage.py showmigrations`
-6. Confirm migrations are up to date.
-7. Run `python manage.py migrate`
-8. Run `exit` to exit the session.
-9. Monitor the log output of the current task and confirm staging functions as expected.
+
+6. Run `python manage.py showmigrations`
+7. Confirm migrations are up to date.
+8. Run `python manage.py migrate`
+9. Run `exit` to exit the session.
+10. Monitor the log output of the current task and confirm staging functions as expected.

--- a/deployment/terraform-django/storage.tf
+++ b/deployment/terraform-django/storage.tf
@@ -58,16 +58,6 @@ resource "aws_s3_bucket_policy" "read_only_bucket" {
 resource "aws_s3_bucket" "logs" {
   bucket = local.logs_bucket_name
 
-  #data "aws_cloudfront_log_delivery_canonical_user_id" "cdn" {}
-  # TODO GH #453: Ensure cloudfront logging works
-  # I guess we need to create this grant when we have an ID manually?
-  # Confirm works per https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/pull/113/files
-  #  grant {
-  #    type        = "CanonicalUser"
-  #    permissions = ["FULL_CONTROL"]
-  #    id          = data.aws_cloudfront_log_delivery_canonical_user_id.cdn.id
-  #  }
-
   tags = {
     Project     = var.project,
     Environment = var.environment


### PR DESCRIPTION
## Overview

Two unrelated bits:
 * Removes no longer needed TODO as logging appears to work
 * Add CLI way to get cluster/task ids

### Demo

Included in new docs.

## Testing Instructions

 * Try doing an exec without needing the web interface
