### PR TITLE
Drop NAT Gateways

### DIFF
--- a/deployment/terraform-django/network.tf
+++ b/deployment/terraform-django/network.tf
@@ -23,26 +23,6 @@ resource "aws_internet_gateway" "default" {
   }
 }
 
-resource "aws_route_table" "private" {
-  count = length(var.private_subnet_cidr_blocks)
-
-  vpc_id = aws_vpc.default.id
-
-  tags = {
-    Name        = "PrivateRouteTable",
-    Project     = var.project
-    Environment = var.environment
-  }
-}
-
-resource "aws_route" "private" {
-  count = length(var.private_subnet_cidr_blocks)
-
-  route_table_id         = aws_route_table.private[count.index].id
-  destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.default[count.index].id
-}
-
 resource "aws_route_table" "public" {
   vpc_id = aws_vpc.default.id
 
@@ -88,13 +68,6 @@ resource "aws_subnet" "public" {
   }
 }
 
-resource "aws_route_table_association" "private" {
-  count = length(var.private_subnet_cidr_blocks)
-
-  subnet_id      = aws_subnet.private[count.index].id
-  route_table_id = aws_route_table.private[count.index].id
-}
-
 resource "aws_route_table_association" "public" {
   count = length(var.public_subnet_cidr_blocks)
 
@@ -102,41 +75,3 @@ resource "aws_route_table_association" "public" {
   route_table_id = aws_route_table.public.id
 }
 
-resource "aws_vpc_endpoint" "s3" {
-  vpc_id       = aws_vpc.default.id
-  service_name = "com.amazonaws.${var.aws_region}.s3"
-  route_table_ids = flatten([
-    aws_route_table.public.id,
-    aws_route_table.private.*.id
-  ])
-
-  tags = {
-    Name        = "endpointS3",
-    Project     = var.project
-    Environment = var.environment
-  }
-}
-
-#
-# NAT resources
-#
-resource "aws_eip" "nat" {
-  count = length(var.public_subnet_cidr_blocks)
-
-  vpc = true
-}
-
-resource "aws_nat_gateway" "default" {
-  depends_on = [aws_internet_gateway.default]
-
-  count = length(var.public_subnet_cidr_blocks)
-
-  allocation_id = aws_eip.nat[count.index].id
-  subnet_id     = aws_subnet.public[count.index].id
-
-  tags = {
-    Name        = "gwNAT",
-    Project     = var.project
-    Environment = var.environment
-  }
-}


### PR DESCRIPTION
Drop private routing as well
And unused aws_vpc_endpoint s3 (could see this being used in other
projects)

### Notes
I am somewhat surprised this appears to just work. My guess is the NAT gateways were actually used for the bastions primarily.
Internet access did not work from container before this - but if we need to make it work, we should just use an internet gateway (and add firewall rules if needed).

Low priority - we can do this change any time - it depends on nothing else AFAICT.

## Testing Instructions

 * Confirm everything works just as well as before.
