### PR TITLE
Implement user signup

### DIFF
--- a/src/backend/echo/urls.py
+++ b/src/backend/echo/urls.py
@@ -44,6 +44,7 @@ urlpatterns = [
         auth_views.PasswordResetCompleteView.as_view(),
         name="password_reset_complete",
     ),
+    path("api/signup/", user_views.SignUpPage.as_view(), name="signup"),
     path("api/login/", user_views.LoginPage.as_view(), name="login"),
     path("api/auth/login/", user_views.ObtainToken.as_view(), name="obtain_token"),
     path("api/user/", user_views.UserProfileView.as_view(), name="user_details"),

--- a/src/backend/users/serializers.py
+++ b/src/backend/users/serializers.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Group, User
 from rest_framework import serializers
 
 from .models import Destination, UserProfile
@@ -37,3 +37,19 @@ class UserSerializer(serializers.ModelSerializer):
         model = User
         fields = ["userprofile", "username"]
         read_only_fields = ["username"]
+
+
+class HouseSeekerSignUpSerializer(serializers.ModelSerializer):
+    username = serializers.CharField(required=True, max_length=150)
+
+    class Meta:
+        model = User
+        fields = ["username"]
+
+    # Override to create User without UserProfile and add to HouseSeeker group
+    def create(self, validated_data):
+        user = User.objects.create(**validated_data)
+        houseseeker_group = Group.objects.get(name="HouseSeeker")
+        user.groups.add(houseseeker_group)
+        user.save()
+        return user

--- a/src/backend/users/serializers.py
+++ b/src/backend/users/serializers.py
@@ -40,7 +40,7 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class HouseSeekerSignUpSerializer(serializers.ModelSerializer):
-    username = serializers.CharField(required=True, max_length=150)
+    username = serializers.EmailField(required=True, max_length=150)
 
     class Meta:
         model = User

--- a/src/backend/users/serializers.py
+++ b/src/backend/users/serializers.py
@@ -46,10 +46,13 @@ class HouseSeekerSignUpSerializer(serializers.ModelSerializer):
         model = User
         fields = ["username"]
 
-    # Override to create User without UserProfile and add to HouseSeeker group
+    # Override to create User with empty UserProfile and add to HouseSeeker group
     def create(self, validated_data):
         user = User.objects.create(**validated_data)
         houseseeker_group = Group.objects.get(name="HouseSeeker")
         user.groups.add(houseseeker_group)
         user.save()
+
+        UserProfile.objects.create(user=user)
+
         return user

--- a/src/backend/users/serializers.py
+++ b/src/backend/users/serializers.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.models import Group, User
+from django.db import transaction
 from rest_framework import serializers
 
 from .models import Destination, UserProfile
@@ -47,6 +48,7 @@ class HouseSeekerSignUpSerializer(serializers.ModelSerializer):
         fields = ["username"]
 
     # Override to create User with empty UserProfile and add to HouseSeeker group
+    @transaction.atomic
     def create(self, validated_data):
         user = User.objects.create(**validated_data)
         houseseeker_group = Group.objects.get(name="HouseSeeker")

--- a/src/backend/users/tests.py
+++ b/src/backend/users/tests.py
@@ -172,7 +172,7 @@ class HouseSeekerSignUpTest(TestCase):
         self.assertContains(first_response, "created your account", status_code=200)
         self.assertContains(second_response, "already have an account", status_code=200)
 
-    def test_user_and_no_profile_created_on_signup(self):
+    def test_user_and_empty_profile_created_on_signup(self):
         self.houseseeker.post(
             "/api/signup/",
             {"username": "testechoemail1@azavea.com"},
@@ -182,7 +182,7 @@ class HouseSeekerSignUpTest(TestCase):
         self.assertEqual(len(houseseeker_user), 1)
         self.assertEqual(houseseeker_user.first().groups.first(), self.test_houseseeker_group)
         houseseeker_user_profile = UserProfile.objects.filter(user=houseseeker_user.first())
-        self.assertIsNone(houseseeker_user_profile.first())
+        self.assertEqual(len(houseseeker_user_profile), 1)
 
     def test_signup_email_link(self):
         """

--- a/src/backend/users/tests.py
+++ b/src/backend/users/tests.py
@@ -100,9 +100,7 @@ class HouseSeekerLoginTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.houseseeker = Client()
-        user_serializer = HouseSeekerSignUpSerializer(
-            data={"username": "exists@azavea.com"}
-        )
+        user_serializer = HouseSeekerSignUpSerializer(data={"username": "exists@azavea.com"})
         user_serializer.is_valid(raise_exception=True)
         user_serializer.save()
 
@@ -131,7 +129,9 @@ class HouseSeekerLoginTest(TestCase):
             200,
             f"Expected 200, got {second_response.status_code}. {second_response.content}",
         )
-        self.assertEqual(len(mail.outbox), 1, "Fail: expected one email to be sent, not %d." % len(mail.outbox))
+        self.assertEqual(
+            len(mail.outbox), 1, "Fail: expected one email to be sent, not %d." % len(mail.outbox)
+        )
 
 
 class HouseSeekerSignUpTest(TestCase):
@@ -203,4 +203,6 @@ class HouseSeekerSignUpTest(TestCase):
             {"username": "testechoemail1@azavea.com"},
             content_type="application/json",
         )
-        self.assertEqual(len(mail.outbox), 1, "Fail: expected one email to be sent, not %d." % len(mail.outbox))
+        self.assertEqual(
+            len(mail.outbox), 1, "Fail: expected one email to be sent, not %d." % len(mail.outbox)
+        )

--- a/src/backend/users/tests.py
+++ b/src/backend/users/tests.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import Group, User
 from django.test import Client, TestCase
+from users.models import UserProfile
 
 
 class AdminSiteTest(TestCase):
@@ -87,3 +88,53 @@ class AdminSiteTest(TestCase):
             "/admin/login/?next=/admin/",
             f"Got unexpected response: {response.status_code}. {response.content}",
         )
+
+
+class HouseSeekerSignUpTest(TestCase):
+    """Check User sign up process."""
+
+    fixtures = ["group_permissions"]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.houseseeker = Client()
+        cls.test_houseseeker_group = Group.objects.get(name="HouseSeeker")
+
+    def test_signup_endpoint_response(self):
+        """
+        Test signup endpoint responds with correct login message.
+        """
+        first_response = self.houseseeker.post(
+            "/api/signup/",
+            {"username": "testechoemail@azavea.com"},
+            content_type="application/json",
+        )
+        self.assertEqual(
+            first_response.status_code,
+            200,
+            f"Expected 200, got {first_response.status_code}. {first_response.content}",
+        )
+        second_response = self.houseseeker.post(
+            "/api/signup/",
+            {"username": "testechoemail@azavea.com"},
+            content_type="application/json",
+        )
+        self.assertEqual(
+            second_response.status_code,
+            200,
+            f"Expected 200, got {second_response.status_code}. {second_response.content}",
+        )
+        self.assertContains(first_response, "created your account", status_code=200)
+        self.assertContains(second_response, "already have an account", status_code=200)
+
+    def test_user_and_no_profile_created_on_signup(self):
+        self.houseseeker.post(
+            "/api/signup/",
+            {"username": "testechoemail1@azavea.com"},
+            content_type="application/json",
+        )
+        houseseeker_user = User.objects.filter(username="testechoemail1@azavea.com")
+        self.assertEqual(len(houseseeker_user), 1)
+        self.assertEqual(houseseeker_user.first().groups.first(), self.test_houseseeker_group)
+        houseseeker_user_profile = UserProfile.objects.filter(user=houseseeker_user.first())
+        self.assertIsNone(houseseeker_user_profile.first())

--- a/src/backend/users/tests.py
+++ b/src/backend/users/tests.py
@@ -101,7 +101,7 @@ class HouseSeekerLoginTest(TestCase):
     def setUpTestData(cls):
         cls.houseseeker = Client()
         user_serializer = HouseSeekerSignUpSerializer(
-            data={"username": "testechouserexists@azavea.com"}
+            data={"username": "exists@azavea.com"}
         )
         user_serializer.is_valid(raise_exception=True)
         user_serializer.save()
@@ -113,7 +113,7 @@ class HouseSeekerLoginTest(TestCase):
         """
         first_response = self.houseseeker.post(
             "/api/login/",
-            {"email": "testechouserexists@azavea.com"},
+            {"username": "exists@azavea.com"},
             content_type="application/json",
         )
         self.assertEqual(
@@ -123,7 +123,7 @@ class HouseSeekerLoginTest(TestCase):
         )
         second_response = self.houseseeker.post(
             "/api/login/",
-            {"username": "testechouserdoesntexist@azavea.com"},
+            {"username": "doesntexist@azavea.com"},
             content_type="application/json",
         )
         self.assertEqual(
@@ -131,8 +131,7 @@ class HouseSeekerLoginTest(TestCase):
             200,
             f"Expected 200, got {second_response.status_code}. {second_response.content}",
         )
-        num_emails = len(mail.outbox)
-        self.assertEqual(num_emails, 1, "Fail: expected one email to be sent, not %d." % num_emails)
+        self.assertEqual(len(mail.outbox), 1, "Fail: expected one email to be sent, not %d." % len(mail.outbox))
 
 
 class HouseSeekerSignUpTest(TestCase):
@@ -147,19 +146,18 @@ class HouseSeekerSignUpTest(TestCase):
 
     def test_signup_email_validation(self):
         """
-        Test signup endpoint responds with 400 and login error message on invalid email.
+        Test signup endpoint responds with login error message on invalid email.
         """
         response = self.houseseeker.post(
             "/api/signup/",
             {"username": "test"},
             content_type="application/json",
         )
-        self.assertContains(response, "try again with a valid email address", status_code=400)
+        self.assertContains(response, "try again with a valid email address", status_code=200)
 
     def test_signup_endpoint_response(self):
         """
         Test signup endpoint responds with correct login message.
-        Responds with 400 and message if already have account.
         """
         first_response = self.houseseeker.post(
             "/api/signup/",
@@ -178,11 +176,11 @@ class HouseSeekerSignUpTest(TestCase):
         )
         self.assertEqual(
             second_response.status_code,
-            400,
-            f"Expected 400, got {second_response.status_code}. {second_response.content}",
+            200,
+            f"Expected 200, got {second_response.status_code}. {second_response.content}",
         )
         self.assertContains(first_response, "complete your account", status_code=200)
-        self.assertContains(second_response, "already have an account", status_code=400)
+        self.assertContains(second_response, "already have an account", status_code=200)
 
     def test_user_and_empty_profile_created_on_signup(self):
         self.houseseeker.post(
@@ -198,12 +196,11 @@ class HouseSeekerSignUpTest(TestCase):
 
     def test_signup_email_link(self):
         """
-        Test email is sent on User sign up and link in email responds with 200.
+        Test email is sent on User sign up.
         """
         self.houseseeker.post(
             "/api/signup/",
             {"username": "testechoemail1@azavea.com"},
             content_type="application/json",
         )
-        num_emails = len(mail.outbox)
-        self.assertEqual(num_emails, 1, "Fail: expected one email to be sent, not %d." % num_emails)
+        self.assertEqual(len(mail.outbox), 1, "Fail: expected one email to be sent, not %d." % len(mail.outbox))

--- a/src/backend/users/tests.py
+++ b/src/backend/users/tests.py
@@ -169,7 +169,7 @@ class HouseSeekerSignUpTest(TestCase):
             200,
             f"Expected 200, got {second_response.status_code}. {second_response.content}",
         )
-        self.assertContains(first_response, "created your account", status_code=200)
+        self.assertContains(first_response, "complete your account", status_code=200)
         self.assertContains(second_response, "already have an account", status_code=200)
 
     def test_user_and_empty_profile_created_on_signup(self):

--- a/src/backend/users/tests.py
+++ b/src/backend/users/tests.py
@@ -145,9 +145,21 @@ class HouseSeekerSignUpTest(TestCase):
         cls.houseseeker = Client()
         cls.test_houseseeker_group = Group.objects.get(name="HouseSeeker")
 
+    def test_signup_email_validation(self):
+        """
+        Test signup endpoint responds with 400 and login error message on invalid email.
+        """
+        response = self.houseseeker.post(
+            "/api/signup/",
+            {"username": "test"},
+            content_type="application/json",
+        )
+        self.assertContains(response, "try again with a valid email address", status_code=400)
+
     def test_signup_endpoint_response(self):
         """
         Test signup endpoint responds with correct login message.
+        Responds with 400 and message if already have account.
         """
         first_response = self.houseseeker.post(
             "/api/signup/",
@@ -166,11 +178,11 @@ class HouseSeekerSignUpTest(TestCase):
         )
         self.assertEqual(
             second_response.status_code,
-            200,
-            f"Expected 200, got {second_response.status_code}. {second_response.content}",
+            400,
+            f"Expected 400, got {second_response.status_code}. {second_response.content}",
         )
         self.assertContains(first_response, "complete your account", status_code=200)
-        self.assertContains(second_response, "already have an account", status_code=200)
+        self.assertContains(second_response, "already have an account", status_code=400)
 
     def test_user_and_empty_profile_created_on_signup(self):
         self.houseseeker.post(

--- a/src/backend/users/views.py
+++ b/src/backend/users/views.py
@@ -140,10 +140,6 @@ class UserProfileView(APIView):
         user = User.objects.get(username=request.user)
         serializer = UserSerializer(user)
 
-        # On initial sign up a UserProfile will be empty
-        if serializer.data["userprofile"] is None:
-            return Response({"unverifiedUserProfile": True})
-
         content = self.repackage_for_frontend(serializer.data)
 
         return Response(content)

--- a/src/backend/users/views.py
+++ b/src/backend/users/views.py
@@ -20,8 +20,7 @@ def send_login_link(request):
     Send email with passwordless login link to User on Login/Sign Up.
     Will raise an exception if User.DoesNotExist
     """
-    # Request.data key could be "username" or "email", so turn into list to be safe
-    email = list(request.data.values())[0]
+    email = request.data["username"]
     user = User.objects.get(username=email)
     login_token = utils.get_query_string(user)
     host = request.get_host()

--- a/src/backend/users/views.py
+++ b/src/backend/users/views.py
@@ -35,6 +35,10 @@ def send_login_link(request):
         login_link
     )
 
+    # Confirm User has default empty profile to access site
+    # if one doesn't already exist
+    UserProfile.objects.get_or_create(user=user)
+
     # TODO replace with actual values parameterized based on environment
     # issue 485 (https://github.com/azavea/echo-locator/issues/485)
     send_mail(

--- a/src/backend/users/views.py
+++ b/src/backend/users/views.py
@@ -5,6 +5,7 @@ from django.db.utils import IntegrityError
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from rest_framework.authtoken.models import Token
+from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -213,7 +214,9 @@ class SignUpPage(APIView):
         except Exception as e:
             if type(e) == IntegrityError:
                 signup_message = "It looks like we already have an account with that email. Sign in by clicking the link below!"
+            if type(e) == ValidationError:
+                signup_message = "Please try again with a valid email address."
             if type(e) == Exception:
                 signup_message = "Something went wrong. Please try again."
-            pass
+            return Response(data=signup_message, status=400, content_type="application/json")
         return Response(data=signup_message, content_type="application/json")

--- a/src/backend/users/views.py
+++ b/src/backend/users/views.py
@@ -10,7 +10,7 @@ from rest_framework.views import APIView
 from sesame import utils
 
 from .models import Destination, UserProfile
-from .serializers import UserSerializer
+from .serializers import HouseSeekerSignUpSerializer, UserSerializer
 
 
 class LoginPage(APIView):
@@ -183,3 +183,17 @@ class UserProfileView(APIView):
         serializer = UserSerializer(User.objects.get(username=request.user))
         content = self.repackage_for_frontend(serializer.data)
         return Response(content)
+
+
+class SignUpPage(APIView):
+    def post(self, request, **kwargs):
+        try:
+            user_serializer = HouseSeekerSignUpSerializer(data=request.data)
+            user_serializer.is_valid(raise_exception=True)
+            user_serializer.save()
+
+            signup_message = "Ok we created your account."
+            pass
+        except Exception:
+            signup_message = "It looks like we already have an account with that email. Sign in by clicking the link below!"
+        return Response(data=signup_message, content_type="application/json")

--- a/src/backend/users/views.py
+++ b/src/backend/users/views.py
@@ -204,11 +204,10 @@ class SignUpPage(APIView):
     def post(self, request, **kwargs):
         signup_message = "Thank you! You'll receive an email shortly with a link to complete your account. Click the link to create your profile and get started with ECHO."
         try:
-            with transaction.atomic():
-                user_serializer = HouseSeekerSignUpSerializer(data=request.data)
-                user_serializer.is_valid(raise_exception=True)
-                user_serializer.save()
-                send_login_link(request)
+            user_serializer = HouseSeekerSignUpSerializer(data=request.data)
+            user_serializer.is_valid(raise_exception=True)
+            user_serializer.save()
+            send_login_link(request)
         except IntegrityError:
             signup_message = "It looks like we already have an account with that email. Sign in by clicking the link below!"
         except ValidationError:

--- a/src/backend/users/views.py
+++ b/src/backend/users/views.py
@@ -141,7 +141,7 @@ class UserProfileView(APIView):
 
         # On initial sign up a UserProfile will be empty
         if serializer.data["userprofile"] is None:
-            return Response({"unverified_user_profile": True})
+            return Response({"unverifiedUserProfile": True})
 
         content = self.repackage_for_frontend(serializer.data)
 
@@ -204,7 +204,7 @@ class UserProfileView(APIView):
 
 class SignUpPage(APIView):
     def post(self, request, **kwargs):
-        signup_message = "Ok we created your account."
+        signup_message = "Thank you! You'll receive an email shortly with a link to complete your account. Click the link to create your profile and get started with ECHO."
         try:
             user_serializer = HouseSeekerSignUpSerializer(data=request.data)
             user_serializer.is_valid(raise_exception=True)

--- a/src/backend/users/views.py
+++ b/src/backend/users/views.py
@@ -139,6 +139,10 @@ class UserProfileView(APIView):
         user = User.objects.get(username=request.user)
         serializer = UserSerializer(user)
 
+        # On initial sign up a UserProfile will be empty
+        if serializer.data["userprofile"] is None:
+            return Response({"unverified_user_profile": True})
+
         content = self.repackage_for_frontend(serializer.data)
 
         return Response(content)

--- a/src/frontend/src/actions/profile.js
+++ b/src/frontend/src/actions/profile.js
@@ -57,7 +57,7 @@ export const sendSignUpLink = (email) => (dispatch, getState) => {
     })
     .catch((error) => {
       console.error("Error creating user profile", error);
-      dispatch({ type: "set login message", payload: "SignIn.ErrorCreatingProfile" });
+      dispatch({ type: "set login message", payload: error.response.data });
     });
 };
 

--- a/src/frontend/src/actions/profile.js
+++ b/src/frontend/src/actions/profile.js
@@ -46,6 +46,21 @@ export const saveProfile = (profile, authToken) => (dispatch, getState) => {
   });
 };
 
+export const sendSignUpLink = (email) => (dispatch, getState) => {
+  addActionLogItem(`Sending signup link to ${email}`);
+  axios
+    .post("/api/signup/", {
+      username: email,
+    })
+    .then((response) => {
+      dispatch({ type: "set login message", payload: response.data });
+    })
+    .catch((error) => {
+      console.error("Error creating user profile", error);
+      dispatch({ type: "set login message", payload: "SignIn.ErrorCreatingProfile" });
+    });
+};
+
 export const sendLoginLink = (email) => (dispatch, getState) => {
   addActionLogItem(`Sending login link to ${email}`);
   axios.post("/api/login/", { email });

--- a/src/frontend/src/actions/profile.js
+++ b/src/frontend/src/actions/profile.js
@@ -57,7 +57,7 @@ export const sendSignUpLink = (email) => (dispatch, getState) => {
     })
     .catch((error) => {
       console.error("Error creating user profile", error);
-      dispatch({ type: "set login message", payload: error.response.data });
+      dispatch({ type: "set login message", payload: "SignIn.SignUpError" });
     });
 };
 

--- a/src/frontend/src/actions/profile.js
+++ b/src/frontend/src/actions/profile.js
@@ -63,7 +63,7 @@ export const sendSignUpLink = (email) => (dispatch, getState) => {
 
 export const sendLoginLink = (email) => (dispatch, getState) => {
   addActionLogItem(`Sending login link to ${email}`);
-  axios.post("/api/login/", { email });
+  axios.post("/api/login/", { username: email });
   dispatch({ type: "set login message", payload: "SignIn.LoginLinkSent" });
 };
 

--- a/src/frontend/src/components/application.js
+++ b/src/frontend/src/components/application.js
@@ -85,6 +85,7 @@ type Props = {
   routableNeighborhoods: any,
   saveProfile: (Function) => void,
   sendLoginLink: (Function) => void,
+  sendSignUpLink: (Function) => void,
   setActiveListing: (Function) => void,
   setActiveNeighborhood: (Function) => void,
   setAuthToken: (Function) => void,

--- a/src/frontend/src/components/authenticator.js
+++ b/src/frontend/src/components/authenticator.js
@@ -37,7 +37,6 @@ export default function Authenticator(Comp) {
           destinations: [],
           hasVehicle: false,
           headOfHousehold: ANONYMOUS_USERNAME,
-          key: ANONYMOUS_USERNAME,
           rooms: 0,
           voucherNumber: ANONYMOUS_USERNAME,
         };

--- a/src/frontend/src/components/custom-sign-in.js
+++ b/src/frontend/src/components/custom-sign-in.js
@@ -25,10 +25,16 @@ const SignInHeaderTranslated = withTranslation()(SignInHeader);
 class CustomSignIn extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { value: "" };
+    this.state = { value: "", newUser: false };
 
+    this.handleToggle = this.handleToggle.bind(this);
     this.handleChange = this.handleChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  handleToggle(e) {
+    const toggle = !e.target.className.includes("login");
+    this.setState({ newUser: toggle });
   }
 
   handleChange(e) {
@@ -37,7 +43,9 @@ class CustomSignIn extends React.Component {
 
   handleSubmit(e) {
     e.preventDefault();
-    this.props.sendLoginLink(this.state.value);
+    this.state.newUser
+      ? this.props.sendSignUpLink(this.state.value)
+      : this.props.sendLoginLink(this.state.value);
   }
 
   render() {
@@ -54,10 +62,24 @@ class CustomSignIn extends React.Component {
               </label>
             </fieldset>
             <button type="submit" className="auth-main__button auth-main__button--primary">
-              {t("Header.SignIn")}
+              {this.state.newUser ? t("Header.SignUp") : t("Header.SignIn")}
             </button>
             <div className="auth-main__success-message">{t(this.props.data.loginMessage)}</div>
           </form>
+          {this.state.newUser ? (
+            <div className="auth-main__new-user-toggle">
+              {`${t("SignIn.SwitchToLoginExplanation")} `}
+              <span className="login link" onClick={this.handleToggle}>
+                {t("SignIn.SwitchToLogin")}
+              </span>
+            </div>
+          ) : (
+            <div className="auth-main__new-user-toggle">
+              <span className="signup link" onClick={this.handleToggle}>
+                {t("SignIn.SwitchToSignup")}
+              </span>
+            </div>
+          )}
           <div className="auth-main__anonymous-login">
             {`${t("SignIn.AnonymousExplanation")} `}
             <Link

--- a/src/frontend/src/components/edit-profile.js
+++ b/src/frontend/src/components/edit-profile.js
@@ -79,7 +79,7 @@ class EditProfile extends PureComponent<Props> {
   }
 
   getDefaultState(profile: AccountProfile) {
-    if (profile) {
+    if (profile && !profile.unverified_user_profile) {
       // Read profile into an object for initial component state
       return {
         clientEmail: profile.clientEmail,

--- a/src/frontend/src/components/edit-profile.js
+++ b/src/frontend/src/components/edit-profile.js
@@ -67,7 +67,7 @@ class EditProfile extends PureComponent<Props> {
     if (
       !nextProps.isLoading &&
       nextProps.userProfile &&
-      !this.state.userProfile.unverified_user_profile
+      !nextProps.userProfile.unverifiedUserProfile
     ) {
       if (!nextProps.userProfile.destinations || !nextProps.userProfile.destinations.length) {
         nextProps.userProfile.destinations = [Object.assign({}, firstAddress)];
@@ -83,7 +83,7 @@ class EditProfile extends PureComponent<Props> {
   }
 
   getDefaultState(profile: AccountProfile) {
-    if (profile && !profile.unverified_user_profile) {
+    if (profile && !profile.unverifiedUserProfile) {
       // Read profile into an object for initial component state
       return {
         clientEmail: profile.clientEmail,
@@ -134,7 +134,7 @@ class EditProfile extends PureComponent<Props> {
         voucherNumber: "",
         componentError: null,
         errorMessage: "",
-        isAnonymous: !(profile && profile.unverified_user_profile),
+        isAnonymous: !(profile && profile.unverifiedUserProfile),
       };
     }
   }

--- a/src/frontend/src/components/edit-profile.js
+++ b/src/frontend/src/components/edit-profile.js
@@ -64,7 +64,11 @@ class EditProfile extends PureComponent<Props> {
   componentWillReceiveProps(nextProps) {
     // Listen for when profile to appear on props, because it is not present
     // on initial load. Only load once by checking state.
-    if (!nextProps.isLoading && nextProps.userProfile && !this.state.key) {
+    if (
+      !nextProps.isLoading &&
+      nextProps.userProfile &&
+      !this.state.userProfile.unverified_user_profile
+    ) {
       if (!nextProps.userProfile.destinations || !nextProps.userProfile.destinations.length) {
         nextProps.userProfile.destinations = [Object.assign({}, firstAddress)];
       }
@@ -103,15 +107,14 @@ class EditProfile extends PureComponent<Props> {
         importanceViolentCrime: profile.importanceViolentCrime
           ? profile.importanceViolentCrime
           : DEFAULT_CRIME_IMPORTANCE,
-        key: profile.key,
         hasVoucher: profile.hasVoucher,
         nonVoucherBudget: profile.nonVoucherBudget,
         nonVoucherRooms: profile.nonVoucherRooms,
         voucherRooms: profile.voucherRooms,
-        voucherNumber: profile.voucherNumber,
+        voucherNumber: profile.voucherNumber ? profile.voucherNumber : "",
         componentError: null,
         errorMessage: "",
-        isAnonymous: profile.key === ANONYMOUS_USERNAME,
+        isAnonymous: profile.voucherNumber === ANONYMOUS_USERNAME,
       };
     } else {
       // Use defaults for new profile
@@ -124,7 +127,6 @@ class EditProfile extends PureComponent<Props> {
         importanceAccessibility: DEFAULT_ACCESSIBILITY_IMPORTANCE,
         importanceSchools: DEFAULT_SCHOOLS_IMPORTANCE,
         importanceViolentCrime: DEFAULT_CRIME_IMPORTANCE,
-        key: "",
         hasVoucher: false,
         nonVoucherBudget: null,
         nonVoucherRooms: 0,
@@ -163,7 +165,6 @@ class EditProfile extends PureComponent<Props> {
       importanceAccessibility,
       importanceSchools,
       importanceViolentCrime,
-      key,
       hasVoucher,
       nonVoucherBudget,
       nonVoucherRooms,
@@ -182,7 +183,6 @@ class EditProfile extends PureComponent<Props> {
       importanceAccessibility,
       importanceSchools,
       importanceViolentCrime,
-      key,
       hasVoucher,
       nonVoucherBudget,
       nonVoucherRooms,

--- a/src/frontend/src/components/edit-profile.js
+++ b/src/frontend/src/components/edit-profile.js
@@ -64,11 +64,7 @@ class EditProfile extends PureComponent<Props> {
   componentWillReceiveProps(nextProps) {
     // Listen for when profile to appear on props, because it is not present
     // on initial load. Only load once by checking state.
-    if (
-      !nextProps.isLoading &&
-      nextProps.userProfile &&
-      !nextProps.userProfile.unverifiedUserProfile
-    ) {
+    if (!nextProps.isLoading && nextProps.userProfile) {
       if (!nextProps.userProfile.destinations || !nextProps.userProfile.destinations.length) {
         nextProps.userProfile.destinations = [Object.assign({}, firstAddress)];
       }
@@ -83,7 +79,7 @@ class EditProfile extends PureComponent<Props> {
   }
 
   getDefaultState(profile: AccountProfile) {
-    if (profile && !profile.unverifiedUserProfile) {
+    if (profile) {
       // Read profile into an object for initial component state
       return {
         clientEmail: profile.clientEmail,
@@ -134,7 +130,7 @@ class EditProfile extends PureComponent<Props> {
         voucherNumber: "",
         componentError: null,
         errorMessage: "",
-        isAnonymous: !(profile && profile.unverifiedUserProfile),
+        isAnonymous: !profile,
       };
     }
   }

--- a/src/frontend/src/components/edit-profile.js
+++ b/src/frontend/src/components/edit-profile.js
@@ -134,7 +134,7 @@ class EditProfile extends PureComponent<Props> {
         voucherNumber: "",
         componentError: null,
         errorMessage: "",
-        isAnonymous: true,
+        isAnonymous: !(profile && profile.unverified_user_profile),
       };
     }
   }

--- a/src/frontend/src/locales/en/translations.js
+++ b/src/frontend/src/locales/en/translations.js
@@ -139,7 +139,7 @@ export default {
     SwitchToLoginExplanation: "Already have an account?",
     SwitchToLogin: "Sign in here.",
     SwitchToSignup: "Create an account here.",
-    SignUpError: "Something went wrong. Please try again."
+    SignUpError: "Something went wrong. Please try again.",
   },
   Header: {
     New: "New search",

--- a/src/frontend/src/locales/en/translations.js
+++ b/src/frontend/src/locales/en/translations.js
@@ -136,6 +136,10 @@ export default {
       "Username or password was incorrect. Both usernames and passwords are case-sensitive.",
     LoginLinkSent: "Thank you! Please check your email for a link to sign into ECHO.",
     NoProfileFound: "You do not have a user profile. Please create one and try again.",
+    ErrorCreatingProfile: "Something went wrong. Please try again.",
+    SwitchToLoginExplanation: "Already have an account?",
+    SwitchToLogin: "Sign in here.",
+    SwitchToSignup: "Create an account here.",
   },
   Header: {
     New: "New search",
@@ -143,6 +147,7 @@ export default {
     Logout: "Logout",
     SignIn: "Sign in",
     SignOut: "Sign out",
+    SignUp: "Create Account",
   },
   Accounts: {
     Create: "Create new profile",

--- a/src/frontend/src/locales/en/translations.js
+++ b/src/frontend/src/locales/en/translations.js
@@ -136,7 +136,6 @@ export default {
       "Username or password was incorrect. Both usernames and passwords are case-sensitive.",
     LoginLinkSent: "Thank you! Please check your email for a link to sign into ECHO.",
     NoProfileFound: "You do not have a user profile. Please create one and try again.",
-    ErrorCreatingProfile: "Something went wrong. Please try again.",
     SwitchToLoginExplanation: "Already have an account?",
     SwitchToLogin: "Sign in here.",
     SwitchToSignup: "Create an account here.",

--- a/src/frontend/src/locales/en/translations.js
+++ b/src/frontend/src/locales/en/translations.js
@@ -139,6 +139,7 @@ export default {
     SwitchToLoginExplanation: "Already have an account?",
     SwitchToLogin: "Sign in here.",
     SwitchToSignup: "Create an account here.",
+    SignUpError: "Something went wrong. Please try again."
   },
   Header: {
     New: "New search",

--- a/src/frontend/src/sass/06_components/_auth-main.scss
+++ b/src/frontend/src/sass/06_components/_auth-main.scss
@@ -34,14 +34,19 @@
     text-align: center;
   }
 
-  &__anonymous-login {
+  &__anonymous-login, &__new-user-toggle {
   padding: 0;
   font-size: 1.4rem;
   line-height: 1.5;
   text-align: center;
 
-    a {
+    a, .link {
         color: $primary;
+    }
+
+    .link {
+        color: $primary;
+        cursor: pointer;
     }
   }
 }

--- a/src/frontend/src/types.js
+++ b/src/frontend/src/types.js
@@ -66,12 +66,12 @@ export type AccountProfile = {
   importanceAccessibility: number,
   importanceSchools: number,
   importanceViolentCrime: number,
-  key: string,
   nonVoucherBudget: number,
   nonVoucherRooms: number,
   useCommuterRail: boolean,
   voucherNumber: string,
   voucherRooms: number,
+  voucherNumber?: string
 } | {
   unverified_user_profile: boolean
 }

--- a/src/frontend/src/types.js
+++ b/src/frontend/src/types.js
@@ -73,7 +73,7 @@ export type AccountProfile = {
   voucherRooms: number,
   voucherNumber?: string
 } | {
-  unverified_user_profile: boolean
+  unverifiedUserProfile?: boolean | undefined
 }
 
 /**

--- a/src/frontend/src/types.js
+++ b/src/frontend/src/types.js
@@ -69,10 +69,9 @@ export type AccountProfile = {
   nonVoucherBudget: number,
   nonVoucherRooms: number,
   useCommuterRail: boolean,
-  voucherNumber: string,
+  voucherNumber?: string,
   voucherRooms: number,
-  voucherNumber?: string
-}
+};
 
 /**
  * Neighborhood GeoJSON properties.

--- a/src/frontend/src/types.js
+++ b/src/frontend/src/types.js
@@ -72,7 +72,9 @@ export type AccountProfile = {
   useCommuterRail: boolean,
   voucherNumber: string,
   voucherRooms: number,
-};
+} | {
+  unverified_user_profile: boolean
+}
 
 /**
  * Neighborhood GeoJSON properties.

--- a/src/frontend/src/types.js
+++ b/src/frontend/src/types.js
@@ -72,8 +72,6 @@ export type AccountProfile = {
   voucherNumber: string,
   voucherRooms: number,
   voucherNumber?: string
-} | {
-  unverifiedUserProfile?: boolean | undefined
 }
 
 /**


### PR DESCRIPTION
## Overview

This PR allows for users to sign up for an account with their email address and, on form submit, receive an emailed link to create a profile and sign in. Below the surface, when a user clicks the “create account” button: their email is validated, a new `User` is created, the new `User` is added to the `HouseSeeker` group, and an empty related `UserProfile` is created before sending the email. Appropriate frontend changes were made, including:
- Adding a clickable prompt on the “sign in” page to create an account (and from the “sign up” page a prompt to toggle back to “sign in”). It should be noted that these are not two separate pages/components, but just toggles between appropriate text/actions.
- Updated `loginMessage` payloads to walk through the signup process or give context to any signup errors.

### Notes

- One tricky part of this PR was figuring out how to let a new `User` create their initial `UserProfile`, even though the authorization to reach the `EditProfile` component relies on the presence of a `UserProfile`. The way I chose to get around this, while also differentiating `Users` who have attempted to sign up but haven't actually clicked the email link or who haven't create a `UserProfile`, was to ~~create an intermediary `AccountProfile` type: `{unverifiedUserProfile: boolean}`. Responding with this object from the backend and setting it as the profile seemed simpler than creating a field on the `UserProfile` model and allows `profile !== undefined` while also differentiating between a complete `UserProfile` and `isAnonymous`~~ create an empty `UserProfile` on signup. This allows `profile !== undefined` to pass authentication and will populate/view a default `EditProfile` component as if `isAnonymous` without actually being `isAnonymous`.
- I made a couple adjustments to the `AccountProfile` type as well as some of the conditionals in `EditProfile` to better fit when a new `User` _has_ a profile, but doesn't actually have anything in it to validate. This is namely getting rid of the `key` property since this is a leftover of our Amplify/S3 profile process (I couldn't find any active purpose to it) as well as making `voucherNumber` optional. These changes were also made as part of the open PR #497 so I tried to stay as close as possible to those changes to avoid any conflicts.
- Full account creation depends on the ability to edit a `UserProfile`. However, since there’s an open PR #497 for editing `UserProfile` from the frontend I decided not to touch any of the functionality. This PR simply creates an empty `UserProfile` for new `Users` and, once we have the ability to save edits to `UserProfile`, the absence of the `unverifiedUserProfile` property will signify account creation is "complete".
- I left the email body copy the same as login since it seemed broad enough to cover signup as well. Any extra signup context is included as part of the `loginMessage` after submitting email.

## Testing Instructions

 * `scripts/update` 
 * `scripts/manage test users.tests` to confirm tests function
 * `scripts/server`
 * Navigate to `localhost:9966/`
 * Click the "create an account" text to toggle to the signup form
 * Try and submit an invalid email and confirm account creation fails and error response message appears
 * Try and submit a valid email and confirm email link prints in the console
 * Try and submit the same email again and confirm duplicate account creation fails
 * Navigate to the email link and confirm it loads `/profile` page, and all fields are present but empty
 * Confirm you can't navigate beyond `/profile` without setting required fields
 * Create a new `User` through the admin, and don't create a related `UserProfile`. Login with the new `User` email and confirm still authorized to navigate to the `/profile` page.


Resolves #465 
