### PR TITLE
Replace docker CMDs with gunicorn config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,14 +37,6 @@ services:
     depends_on:
       database:
         condition: service_healthy
-    command:
-      - "-b :8085"
-      - "--reload"
-      - "--timeout=90"
-      - "--access-logfile=-"
-      - "--error-logfile=-"
-      - "--log-level=debug"
-      - "echo.wsgi"
     ports:
       - "8085:8085"
     cpus: 2

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -8,13 +8,3 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY ./src/backend /usr/local/src/backend
 COPY ./src/frontend/build /usr/local/src/backend/static
-
-CMD ["-b :8085", \
-    "--workers=2", \
-    "--timeout=60", \
-    "--access-logfile=-", \
-    "--access-logformat=%({X-Forwarded-For}i)s %(h)s %(l)s %(u)s %(t)s \"%(r)s\" %(s)s %(b)s \"%(f)s\" \"%(a)s\"", \
-    "--error-logfile=-", \
-    "--log-level=info", \
-    "--capture-output", \
-    "echo.wsgi"]

--- a/src/backend/gunicorn.conf.py
+++ b/src/backend/gunicorn.conf.py
@@ -1,0 +1,16 @@
+import os
+
+bind = ":8085"
+accesslog = "-"
+errorlog = "-"
+workers = 3
+loglevel = "Debug"
+
+ENVIRONMENT = os.getenv("DJANGO_ENV", "Development")
+
+if ENVIRONMENT == "Development":
+    reload = True
+else:
+    preload = True
+
+wsgi_app = "echo.wsgi"


### PR DESCRIPTION
This replaces two docker CMD lines - one was actually always overridden
with one gunicorn config file.

This also allows programmatically different config for development vs staging/production, namely:
 - development:reload enabled for reloading workers when code changes
 - prod/stg: preload enabled possibly saving memory

## Overview

The CMD in dockerfile was doing nothing, so I initially started with just removing that. But reload is not recommended in production so I wanted to vary it by that.

### Notes

Other options I considered and decided not to go with:
 - Some gunicorn settings can be set as environment variables, but this a config file seems cleaner
 - It's also possible to define some things in the gunicorn config and still run the CMD in docker, but why when it can all be in one place.

For future consideration:
It's also possible to have items like workers be generated on the fly based on the number of cpus - but we don't performance constraints for this project so not planning to optimize.

## Testing Instructions

 * Ensure works as before
 * Confirm in debug output that reload is set in development and on deployment that reload is off, and preload is on.
