### PR TITLE
Add s3readonly and terraform version bump

### DIFF
--- a/deployment/terraform-django/iam.tf
+++ b/deployment/terraform-django/iam.tf
@@ -24,7 +24,7 @@ resource "aws_iam_role" "ecs_task_execution_role" {
 resource "aws_iam_role" "ecs_task_role" {
   name                = "ecs${local.short}TaskRole"
   assume_role_policy  = data.aws_iam_policy_document.ecs_assume_role.json
-  managed_policy_arns = [aws_iam_policy.enable_execute_into.arn]
+  managed_policy_arns = [aws_iam_policy.enable_execute_into.arn, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,7 +1,7 @@
 version: '2.1'
 services:
   terraform:
-    image: quay.io/azavea/terraform:1.0.0
+    image: quay.io/azavea/terraform:1.1.9
     volumes:
       - ./:/usr/local/src
       - $HOME/.aws:/root/.aws:ro

--- a/scripts/infra
+++ b/scripts/infra
@@ -19,6 +19,7 @@ Execute Terraform subcommands with remote state management.
 if [[ -n "${GIT_COMMIT}" ]]; then
     GIT_COMMIT="${GIT_COMMIT:0:7}"
 else
+    git config --global --add safe.directory /usr/local/src
     GIT_COMMIT="$(git rev-parse --short HEAD)"
 fi
 


### PR DESCRIPTION
## Overview

s3 read only is needed to import the users from amplify
terraform has a 1.0 promise so upgrading is easy.

### Notes

We likely should remove the S3 permissions once we have are done with migration - will add to #448

## Testing Instructions

 * Test #502 Importing Users without doing the permission add.
