### PR TITLE
Fix logout error

### DIFF
--- a/src/frontend/src/components/neighborhood-details.js
+++ b/src/frontend/src/components/neighborhood-details.js
@@ -33,7 +33,7 @@ class NeighborhoodDetails extends PureComponent<Props> {
 
     this.state = {
       isFavorite:
-        props.userProfile && props.neighborhood
+        props.userProfile && props.neighborhood && props.userProfile.favorites
           ? props.userProfile.favorites.indexOf(props.neighborhood.properties.id) !== -1
           : false,
     };
@@ -46,7 +46,7 @@ class NeighborhoodDetails extends PureComponent<Props> {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.userProfile && nextProps.neighborhood) {
+    if (nextProps.userProfile && nextProps.neighborhood && nextProps.userProfile.favorites) {
       const isFavorite =
         nextProps.userProfile.favorites.indexOf(nextProps.neighborhood.properties.id) !== -1;
       this.setState({ isFavorite });

--- a/src/frontend/src/selectors/network-neighborhood-routes.js
+++ b/src/frontend/src/selectors/network-neighborhood-routes.js
@@ -16,7 +16,7 @@ export default createSelector(
   (state) => get(state, "data.userProfile"),
   (activeNetworkIndex, networks, start, neighborhoods, profile) => {
     const network = networks[activeNetworkIndex];
-    if (!neighborhoods || !neighborhoods.features || !neighborhoods.features.length || !network) {
+    if (!neighborhoods || !neighborhoods.features || !neighborhoods.features.length || !network || !profile) {
       return [];
     }
 

--- a/src/frontend/src/selectors/network-neighborhood-routes.js
+++ b/src/frontend/src/selectors/network-neighborhood-routes.js
@@ -16,7 +16,13 @@ export default createSelector(
   (state) => get(state, "data.userProfile"),
   (activeNetworkIndex, networks, start, neighborhoods, profile) => {
     const network = networks[activeNetworkIndex];
-    if (!neighborhoods || !neighborhoods.features || !neighborhoods.features.length || !network || !profile) {
+    if (
+      !neighborhoods ||
+      !neighborhoods.features ||
+      !neighborhoods.features.length ||
+      !network ||
+      !profile
+    ) {
       return [];
     }
 


### PR DESCRIPTION
## Overview

This PR addresses the logout error that appeared after fixing network routing. Now, when a logged-in `User` selects logout, they are directed back to the login/signup page. Since there is an opportunity for a `User` to be authorized to use the site, but may not have a `userProfile`, we needed to add a conditional in the networks selector to return empty if a profile doesn't exist.

### Checklist

- [x] Run `./scripts/format` to lint, format, and fix the application source code.

## Testing Instructions

 * `scripts/server`
 * `http://localhost:9966/`
 * Login, click around (or not), and then click logout
 * Confirm you are logged out and the signup/logout component displays
 * Try logging out from both the `/profile` and `/map` page


Resolves #511 
