### PR TITLE
Include destination coordinates in API

### DIFF
--- a/src/backend/users/serializers.py
+++ b/src/backend/users/serializers.py
@@ -8,7 +8,7 @@ from .models import Destination, UserProfile
 class DestinationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Destination
-        fields = ["profile", "label", "purpose", "primary_destination"]
+        fields = ["profile", "location", "label", "purpose", "primary_destination"]
 
 
 class UserProfileSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
## Overview

Previously we were using placeholders for destination locations; this replaces the placeholders with values from the database.

### Checklist

- [x] Run `./scripts/format` to lint, format, and fix the application source code.

### Demo

<img width="1106" alt="Screen Shot 2022-05-19 at 15 30 10" src="https://user-images.githubusercontent.com/447977/169387502-00607132-b058-49f2-909c-3009e08d2257.png">
<img width="1506" alt="Screen Shot 2022-05-19 at 15 30 20" src="https://user-images.githubusercontent.com/447977/169387515-ed5974f9-dd33-4a69-bcd3-1b76af3b5c8e.png">


## Testing Instructions

 * Open up an existing profile and edit some locations so that they get re-geocoded (geocoding doesn't happen unless you type in the address box, so if locations have the default coordinates they'll keep them until they are changed).
 * Save the profile. Use the network inspector to view the request and confirm that the request / response payloads show the same values for `lat` and `lon` for each destination (i.e. no coordinates are getting switched between request and response).
 * View the map and choose different locations. Confirm that the start marker moves around on the map, and if you want, drop one of the addresses into another mapping service like Google Maps and confirm that we agree with them on where it is.

Resolves #486 
