### PR TITLE
Feature/kob/fix neighborhood details

### DIFF
--- a/src/backend/users/views.py
+++ b/src/backend/users/views.py
@@ -186,10 +186,10 @@ class UserProfileView(APIView):
             int(data["importanceAccessibility"])
         ]
         updated_profile.school_quality_priority = self.map_nums_to_priorities[
-            int(data["importanceAccessibility"])
+            int(data["importanceSchools"])
         ]
         updated_profile.public_safety_priority = self.map_nums_to_priorities[
-            int(data["importanceAccessibility"])
+            int(data["importanceViolentCrime"])
         ]
         updated_profile.has_voucher = data["hasVoucher"]
         updated_profile.voucher_bedrooms = data["voucherRooms"]

--- a/src/frontend/src/components/neighborhood-details.js
+++ b/src/frontend/src/components/neighborhood-details.js
@@ -187,7 +187,9 @@ class NeighborhoodDetails extends PureComponent<Props> {
           {t("NeighborhoodDetails.BedroomAbbr")} ($
           {userProfile.hasVoucher
             ? estMaxRent.toLocaleString(i18n.language)
-            : userProfile.nonVoucherBudget.toLocaleString(i18n.language)}{" "}
+            : userProfile.nonVoucherBudget
+            ? userProfile.nonVoucherBudget.toLocaleString(i18n.language)
+            : estMaxRent.toLocaleString(i18n.language)}{" "}
           {t("NeighborhoodDetails.MaxRentSearch")})
         </h6>
         <div className="neighborhood-details__links">
@@ -207,7 +209,11 @@ class NeighborhoodDetails extends PureComponent<Props> {
             className="neighborhood-details__link"
             href={getCraigslistSearchLink(
               neighborhood.properties.id,
-              userProfile.hasVoucher ? userProfile.voucherRooms : userProfile.nonVoucherRooms,
+              userProfile.hasVoucher
+                ? userProfile.voucherRooms
+                : userProfile.nonVoucherRooms
+                ? userProfile.nonVoucherRooms
+                : 0,
               userProfile.hasVoucher ? estMaxRent : userProfile.nonVoucherBudget
             )}
             target="_blank"
@@ -232,7 +238,11 @@ class NeighborhoodDetails extends PureComponent<Props> {
             href={getGoSection8SearchLink(
               neighborhood.properties.id,
               userProfile.hasVoucher ? userProfile.voucherRooms : userProfile.nonVoucherRooms,
-              userProfile.hasVoucher ? estMaxRent : userProfile.nonVoucherBudget
+              userProfile.hasVoucher
+                ? estMaxRent
+                : userProfile.nonVoucherBudget
+                ? userProfile.nonVoucherBudget
+                : estMaxRent
             )}
             target="_blank"
             rel="noreferrer"

--- a/src/frontend/src/components/neighborhood-details.js
+++ b/src/frontend/src/components/neighborhood-details.js
@@ -111,7 +111,7 @@ class NeighborhoodDetails extends PureComponent<Props> {
   neighborhoodStats(props) {
     const { userProfile, estMaxRent } = props;
     const { t, i18n } = useTranslation();
-    const { rooms } = userProfile;
+    const rooms = userProfile.hasVoucher ? userProfile.voucherRooms : userProfile.nonVoucherRooms;
     const maxSubsidy = estMaxRent || "–––";
 
     return (
@@ -178,19 +178,26 @@ class NeighborhoodDetails extends PureComponent<Props> {
   neighborhoodLinks(props) {
     const { neighborhood, userProfile, estMaxRent } = props;
     const { t, i18n } = useTranslation();
-    const { rooms } = userProfile;
+    const rooms = userProfile.hasVoucher ? userProfile.voucherRooms : userProfile.nonVoucherRooms;
 
     return (
       <>
         <h6 className="neighborhood-details__link-heading">
           {t("NeighborhoodDetails.MainSearchToolsSearch")}: {rooms}{" "}
-          {t("NeighborhoodDetails.BedroomAbbr")} (${estMaxRent.toLocaleString(i18n.language)}{" "}
+          {t("NeighborhoodDetails.BedroomAbbr")} ($
+          {userProfile.hasVoucher
+            ? estMaxRent.toLocaleString(i18n.language)
+            : userProfile.nonVoucherBudget.toLocaleString(i18n.language)}{" "}
           {t("NeighborhoodDetails.MaxRentSearch")})
         </h6>
         <div className="neighborhood-details__links">
           <a
             className="neighborhood-details__link"
-            href={getZillowSearchLink(neighborhood.properties.id, userProfile.rooms, estMaxRent)}
+            href={getZillowSearchLink(
+              neighborhood.properties.id,
+              userProfile.hasVoucher ? userProfile.voucherRooms : userProfile.nonVoucherRooms,
+              userProfile.hasVoucher ? estMaxRent : userProfile.nonVoucherBudget
+            )}
             target="_blank"
             rel="noreferrer"
           >
@@ -200,8 +207,8 @@ class NeighborhoodDetails extends PureComponent<Props> {
             className="neighborhood-details__link"
             href={getCraigslistSearchLink(
               neighborhood.properties.id,
-              userProfile.rooms,
-              estMaxRent
+              userProfile.hasVoucher ? userProfile.voucherRooms : userProfile.nonVoucherRooms,
+              userProfile.hasVoucher ? estMaxRent : userProfile.nonVoucherBudget
             )}
             target="_blank"
             rel="noreferrer"
@@ -210,7 +217,11 @@ class NeighborhoodDetails extends PureComponent<Props> {
           </a>
           <a
             className="neighborhood-details__link"
-            href={getHotpadsSearchLink(neighborhood.properties.id, userProfile.rooms, estMaxRent)}
+            href={getHotpadsSearchLink(
+              neighborhood.properties.id,
+              userProfile.hasVoucher ? userProfile.voucherRooms : userProfile.nonVoucherRooms,
+              userProfile.hasVoucher ? estMaxRent : userProfile.nonVoucherBudget
+            )}
             target="_blank"
             rel="noreferrer"
           >
@@ -220,8 +231,8 @@ class NeighborhoodDetails extends PureComponent<Props> {
             className="neighborhood-details__link"
             href={getGoSection8SearchLink(
               neighborhood.properties.id,
-              userProfile.rooms,
-              estMaxRent
+              userProfile.hasVoucher ? userProfile.voucherRooms : userProfile.nonVoucherRooms,
+              userProfile.hasVoucher ? estMaxRent : userProfile.nonVoucherBudget
             )}
             target="_blank"
             rel="noreferrer"

--- a/src/frontend/src/components/top-bar.js
+++ b/src/frontend/src/components/top-bar.js
@@ -46,7 +46,9 @@ class TopBar extends PureComponent<Props, State> {
     const query = {
       zipcode: this.props.neighborhood.properties.id,
       budget: this.props.estMaxRent,
-      rooms: this.props.userProfile.rooms,
+      rooms: this.props.userProfile.hasVoucher
+        ? this.props.userProfile.voucherRooms
+        : this.props.userProfile.nonVoucherRooms,
     };
     switch (type) {
       case "BHA":

--- a/src/frontend/src/selectors/est-max-rent.js
+++ b/src/frontend/src/selectors/est-max-rent.js
@@ -10,13 +10,21 @@ export default createSelector(
   (userProfile, neighborhood) => {
     if (
       !userProfile ||
-      !userProfile.rooms ||
       !neighborhood ||
+      (!userProfile.voucherRooms && !userProfile.nonVoucherRooms) ||
       !neighborhood.properties ||
-      !neighborhood.properties["max_rent_" + userProfile.rooms + "br"]
+      !neighborhood.properties[
+        `max_rent_${
+          userProfile.hasVoucher ? userProfile.voucherRooms : userProfile.nonVoucherRooms
+        }br`
+      ]
     ) {
       return 0;
     }
-    return neighborhood.properties["max_rent_" + userProfile.rooms + "br"];
+    return neighborhood.properties[
+      `max_rent_${
+        userProfile.hasVoucher ? userProfile.voucherRooms : userProfile.nonVoucherRooms
+      }br`
+    ];
   }
 );


### PR DESCRIPTION
## Overview

Following the addition of the no voucher use case, the properties on `AccountProfile` that had been used to populate the neighborhood detail view, namely `rooms` and `estMaxRent`, needed to be reworked. This PR adds logic to populate `rooms` (and therefore `estMaxRent`) based on whether the user has a voucher or not. In cases when the user does not have a voucher, it also changes the external housing app searches to use the user's set budget, rather than the neighborhood's max rent.


### Checklist

- [X] Run `./scripts/format` to lint, format, and fix the application source code.

### Demo

![Screen Shot 2022-05-23 at 8 46 27 AM](https://user-images.githubusercontent.com/77936689/169823369-0dfe5c9d-c0f2-4770-81dd-3368e338e2ff.png)
When a user does not have a voucher and has set a budget, it will display the neighborhood's max rent in the "Est. Max Rent" section of the neighborhood detail view, but the user's set budget in the "Search for apartments" headline of the external search tools, as well as filling their budget into those external search tools' queries.


### Notes

This PR includes a few nested ternaries to prevent funkiness from happening if a user does not fill out a preferred number of rooms, a budget, or both. While Zillow and Hotpads' queries were smart enough to use null values, GoSection8 and Craigslist links both needed default values set, as described below:
* If a user does not have a voucher and also has not set a budget, it will display the neighborhood's max rent in the "Search for apartments" headline.
* If a user had not filled out their preferred budget and clicked on GoSection8, the link was completely broken. As a result, that query will default to using the neighborhood's max rent if no budget has been set.
* If a user had not provided a number of rooms and clicked on Craigslist, the query would fail while attempting to look for a null value of bedrooms. It will now default to 0 if no value for rooms has been provided (this is what the demo site does).

While testing this, I discovered that users will get an error from the backend if they attempt to erase their budget, a bug that has been spun out into [issue 522](https://github.com/azavea/echo-locator/issues/522). As a related note, the current behavior of not allowing a null value for budget is also true on the demo site.

While testing this, I also discovered an issue with how priorities were being saved to the backend. This PR also adds a fix for that in commit [5b4c06c](https://github.com/azavea/echo-locator/commit/5b4c06cf347d63c78377f60dc5f258171648568f).


## Testing Instructions

 * Start the server, navigate to **localhost:9966**, and log in
 * Start by verifying that changes to priorities saves as expected
 * Then select a neighborhood and verify that the details fill in as expected:
   * If your profile _does_ have a voucher, check that the "Est. Max Rent" and "Search for apartments" headlines both display your profile's set number of bedrooms and the same max rent
   * Check that if you select that you _do not_ have a voucher and also do not fill out that profile's budget, that the "Search for apartments" headline autofills with the neighborhood's max rent and that the external tools (especially GoSection8) successfully filter
   * Check that if you do not fill out your profile's number of bedrooms, that the external tools (especially Craigslist) successfully filter
   * If your profile _does not_ have a voucher, check that the "Est. Max Rent" and "Search for apartments" headlines both display your profile's set number of bedrooms, but that the "Search for apartments" headline displays your set budget, not the neighborhood's max rent
   * In both cases, check that the external search tools filter for the right number of bedrooms and rent


Resolves #513 
