### PR TITLE
Conditionally show voucher question on profile page

### DIFF
--- a/src/frontend/src/components/edit-profile.js
+++ b/src/frontend/src/components/edit-profile.js
@@ -79,7 +79,6 @@ class EditProfile extends PureComponent<Props> {
   }
 
   getDefaultState(profile: AccountProfile) {
-    console.log("profile", profile);
     if (profile) {
       // Read profile into an object for initial component state
       return {
@@ -403,7 +402,7 @@ class EditProfile extends PureComponent<Props> {
             html
             effect="solid"
             place="top"
-            offset='{"top": -10}'
+            offset={{ top: -10 }}
             isCapture
             delayHide={TOOLTIP_HIDE_DELAY_MS}
             className="map-sidebar__tooltip"
@@ -551,8 +550,6 @@ class EditProfile extends PureComponent<Props> {
       voucherNumber,
       useCommuterRail,
     } = this.state;
-
-    console.log(isAnonymous, hasVoucher);
 
     const DestinationsList = this.destinationsList;
     const ImportanceTooltip = this.importanceTooltip;

--- a/src/frontend/src/components/edit-profile.js
+++ b/src/frontend/src/components/edit-profile.js
@@ -79,6 +79,7 @@ class EditProfile extends PureComponent<Props> {
   }
 
   getDefaultState(profile: AccountProfile) {
+    console.log("profile", profile);
     if (profile) {
       // Read profile into an object for initial component state
       return {
@@ -551,6 +552,8 @@ class EditProfile extends PureComponent<Props> {
       useCommuterRail,
     } = this.state;
 
+    console.log(isAnonymous, hasVoucher);
+
     const DestinationsList = this.destinationsList;
     const ImportanceTooltip = this.importanceTooltip;
     const ImportanceOptions = this.importanceOptions;
@@ -564,69 +567,71 @@ class EditProfile extends PureComponent<Props> {
         <div className="form-screen__main">
           <div className="account-profile">
             {!isAnonymous && (
-              <div className="account-profile__field">
-                <div className="account-profile__label">
-                  {t("Profile.ClientEmailLabel")}
-                  <br />
+              <>
+                <div className="account-profile__field">
+                  <div className="account-profile__label">
+                    {t("Profile.ClientEmailLabel")}
+                    <br />
+                  </div>
+                  <div className="account-profile__input account-profile__input--text">
+                    {clientEmail}
+                  </div>
+                  <label className="account-profile__label" htmlFor="headOfHousehold">
+                    {t("Accounts.Name")}
+                  </label>
+                  <input
+                    data-private
+                    className="account-profile__input account-profile__input--text"
+                    id="headOfHousehold"
+                    type="text"
+                    onChange={(e) => changeField("headOfHousehold", e.currentTarget.value)}
+                    defaultValue={headOfHousehold || ""}
+                    autoComplete="off"
+                  />
                 </div>
-                <div className="account-profile__input account-profile__input--text">
-                  {clientEmail}
+                <div className="account-profile__field">
+                  <div className="account-profile__label" htmlFor="voucher">
+                    {t("Profile.HasVoucher")}
+                  </div>
+                  <div className="account-profile__field-row">
+                    <div className="account-profile__field account-profile__field--inline">
+                      <input
+                        className="account-profile__input account-profile__input--checkbox"
+                        id="yesVoucher"
+                        name="voucher"
+                        type="radio"
+                        onChange={(e) => changeField("hasVoucher", e.currentTarget.checked)}
+                        defaultChecked={hasVoucher}
+                        autoComplete="off"
+                      />
+                      <label
+                        className="account-profile__label account-profile__label--secondary"
+                        htmlFor="yesVoucher"
+                      >
+                        {t("Booleans.Yes")}
+                      </label>
+                    </div>
+                    <div className="account-profile__field account-profile__field--inline">
+                      <input
+                        className="account-profile__input account-profile__input--checkbox"
+                        id="noVoucher"
+                        name="voucher"
+                        type="radio"
+                        onChange={(e) => changeField("hasVoucher", !e.currentTarget.checked)}
+                        defaultChecked={!hasVoucher}
+                        autoComplete="off"
+                      />
+                      <label
+                        className="account-profile__label account-profile__label--secondary"
+                        htmlFor="noVoucher"
+                      >
+                        {t("Booleans.No")}
+                      </label>
+                    </div>
+                  </div>
                 </div>
-                <label className="account-profile__label" htmlFor="headOfHousehold">
-                  {t("Accounts.Name")}
-                </label>
-                <input
-                  data-private
-                  className="account-profile__input account-profile__input--text"
-                  id="headOfHousehold"
-                  type="text"
-                  onChange={(e) => changeField("headOfHousehold", e.currentTarget.value)}
-                  defaultValue={headOfHousehold || ""}
-                  autoComplete="off"
-                />
-              </div>
+              </>
             )}
-            <div className="account-profile__field">
-              <div className="account-profile__label" htmlFor="voucher">
-                {t("Profile.HasVoucher")}
-              </div>
-              <div className="account-profile__field-row">
-                <div className="account-profile__field account-profile__field--inline">
-                  <input
-                    className="account-profile__input account-profile__input--checkbox"
-                    id="yesVoucher"
-                    name="voucher"
-                    type="radio"
-                    onChange={(e) => changeField("hasVoucher", e.currentTarget.checked)}
-                    defaultChecked={hasVoucher}
-                    autoComplete="off"
-                  />
-                  <label
-                    className="account-profile__label account-profile__label--secondary"
-                    htmlFor="yesVoucher"
-                  >
-                    {t("Booleans.Yes")}
-                  </label>
-                </div>
-                <div className="account-profile__field account-profile__field--inline">
-                  <input
-                    className="account-profile__input account-profile__input--checkbox"
-                    id="noVoucher"
-                    name="voucher"
-                    type="radio"
-                    onChange={(e) => changeField("hasVoucher", !e.currentTarget.checked)}
-                    defaultChecked={!hasVoucher}
-                    autoComplete="off"
-                  />
-                  <label
-                    className="account-profile__label account-profile__label--secondary"
-                    htmlFor="noVoucher"
-                  >
-                    {t("Booleans.No")}
-                  </label>
-                </div>
-              </div>
-            </div>
             {hasVoucher && (
               <div>
                 <div className="account-profile__field">


### PR DESCRIPTION
## Overview

This PR updates the `/profile` UI so that:
- it shows the "Do you have a voucher" question and selection radio buttons only when in anonymous mode
- a warning message won't show due to a styling related prop

### Checklist

- [X] Run `./scripts/format` to lint, format, and fix the application source code.

## Testing Instructions

 * On the login UI, click on "Continue without an account"
 * Make sure on the profile form, the "Do you have a voucher" question and selection radio buttons do not show up
 * Fill out the form, save, then click on "Edit profile" from top bar to go back to the profile edit page
 * Make sure the "Do you have a voucher" question and selection radio buttons do not show up
 * Log out and log in with a non-anonymous account
 * Go to the profile edit page
 * Make sure the above question shows up with the radio buttons


Closes #524 
Closes https://github.com/azavea/echo-locator/issues/519