### PR TITLE
Fix adding addresses in anonymous mode

### DIFF
--- a/src/frontend/src/components/edit-profile.js
+++ b/src/frontend/src/components/edit-profile.js
@@ -231,12 +231,12 @@ class EditProfile extends PureComponent<Props> {
       purpose: DEFAULT_PROFILE_DESTINATION_TYPE,
     };
     this.setState({ destinations: [...destinations, newAddress] });
-    if (!this.state.isAnonymous) {
-      this.props.setProfile({
-        ...this.getProfileFromState(),
-        destinations: [...destinations, newAddress],
-      });
-    }
+    // Despite the name, this saves the profile to local storage in anonymous mode
+    // before calling setProfile
+    this.props.handleAuthChange({
+      ...this.getProfileFromState(),
+      destinations: [...destinations, newAddress],
+    });
   }
 
   deleteAddress(index: number, event) {


### PR DESCRIPTION
## Overview

This PR adjusts updating `userProfile` when adding destinations so that the destination fields no longer disappear when trying to add more than one in anonymous mode. In addition, I noticed that after selecting a new primary destination, sometimes the origin on the main page updated but not the "from" field in the sidebar. I created issue #525  for it ~~and resolved it here, as well~~.

### Checklist

- [x] Run `./scripts/format` to lint, format, and fix the application source code.


### Notes

- I noticed if I had more than one destination with the same type of purpose (multiple "work" destinations, for example) the "from" address on the main page sidebar would not update to the right primary address and I could not select a different destination either. The `value` for the `Select` component was set to the destination's `purpose`, which wouldn't update with multiple "work" addresses because the `value` wasn't unique between these selections. Instead, I set the `destination` obj itself to `value` to resolve this issue. UPDATE: see discussion below this was moved to a separate issue.

## Testing Instructions

 * `scripts/server`
 * Login to the site as an anonymous user
 * Confirm you can add more than one address to profile and it persists until logout


Resolves #521 
