### PR TITLE
Fix 'bounds are not valid' console error

### DIFF
--- a/src/frontend/src/components/map.js
+++ b/src/frontend/src/components/map.js
@@ -326,7 +326,7 @@ class Map extends PureComponent<Props, State> {
     };
 
     const createMarkerWithStandardizedData = standardizeData(listingsMarker);
-    return p.routableNeighborhoods ? (
+    return p.neighborhoodBoundsExtent && p.routableNeighborhoods ? (
       <LeafletMap
         bounds={p.neighborhoodBoundsExtent}
         center={p.centerCoordinates}


### PR DESCRIPTION
## Overview

This PR fixes the 'bounds are not valid' console error that was appearing on main page start. We set the map bounds using the `neighborhoodBoundsExtent` prop, which starts off as `null` before `data.neighborhoodBounds` gets loaded with data and can update the `neighborhoodBoundsExtent` selector. It looks like the map component renders while the `neighborhoodBoundsExtent` prop is still `null` and then re-renders once data loads/prop updates—why the map/functionality still worked. We weren't getting this error before, so I'm wondering if the bundler switch (PR #457) affected the timing in which the neighborhood bounds asset loads on app start and the map component render just happens to catch it a little too early now? Either way, I just added a conditional to render if `neighborhoodBoundsExtent` isn't `null` and that seemed to do the trick.

### Checklist

- [x] Run `./scripts/format` to lint, format, and fix the application source code.

## Testing Instructions

 * `scripts/server`
 * Login as either an anonymous or verified user
 * Confirm map and neighborhood bounds display correctly without any bounds console errors
 * Select a neighborhood and confirm map bounds update without error
 * Select "back to recommendations" and confirm map bounds update back without error


Resolves #520 
