### PR TITLE
Paramaterize magic link email 'from' domain

### DIFF
--- a/deployment/terraform-django/app.tf
+++ b/deployment/terraform-django/app.tf
@@ -116,6 +116,7 @@ resource "aws_ecs_task_definition" "app" {
     gunicorn_workers = ceil((2 * (var.fargate_app_cpu / 1024)) + 1)
 
     django_secret_key      = var.django_secret_key
+    default_from_email     = var.default_from_email
     django_log_level       = var.django_log_level
     r53_public_hosted_zone = var.r53_public_hosted_zone
 
@@ -187,6 +188,7 @@ resource "aws_ecs_task_definition" "app_cli" {
     postgres_db       = var.rds_database_name
 
     django_secret_key      = var.django_secret_key
+    default_from_email     = var.default_from_email
     django_log_level       = var.django_log_level
     r53_public_hosted_zone = var.r53_public_hosted_zone
 

--- a/deployment/terraform-django/task-definitions/app.json.tmpl
+++ b/deployment/terraform-django/task-definitions/app.json.tmpl
@@ -34,6 +34,10 @@
         "value": "${django_secret_key}"
       },
       {
+        "name": "DEFAULT_FROM_EMAIL",
+        "value": "${default_from_email}"
+      },
+      {
         "name": "DJANGO_LOG_LEVEL",
         "value": "${django_log_level}"
       },

--- a/deployment/terraform-django/task-definitions/app_cli.json.tmpl
+++ b/deployment/terraform-django/task-definitions/app_cli.json.tmpl
@@ -37,6 +37,10 @@
         "value": "${django_secret_key}"
       },
       {
+        "name": "DEFAULT_FROM_EMAIL",
+        "value": "${default_from_email}"
+      },
+      {
         "name": "DJANGO_LOG_LEVEL",
         "value": "${django_log_level}"
       },

--- a/deployment/terraform-django/variables.tf
+++ b/deployment/terraform-django/variables.tf
@@ -256,6 +256,10 @@ variable "django_secret_key" {
   type = string
 }
 
+variable "default_from_email" {
+  type = string
+}
+
 variable "django_log_level" {
   type    = string
   default = "INFO"

--- a/src/backend/users/views.py
+++ b/src/backend/users/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.gis.geos import Point
 from django.core.mail import send_mail
@@ -40,12 +41,10 @@ def send_login_link(request):
     # if one doesn't already exist
     UserProfile.objects.get_or_create(user=user)
 
-    # TODO replace with actual values parameterized based on environment
-    # issue 485 (https://github.com/azavea/echo-locator/issues/485)
     send_mail(
         "Your ECHO Login Link",
         html_message,
-        "admin@domain.com",
+        settings.DEFAULT_FROM_EMAIL,
         [email],
         fail_silently=False,
         html_message=html_message,


### PR DESCRIPTION
## Overview

This PR changes the domain from which the magic link email is sent based on the environment by setting it as an environment variable in terraform which is passed down from `terraform.tfvars` in S3.


### Checklist

- [X] Run `./scripts/format` to lint, format, and fix the application source code.


## Testing Instructions
_Because staging login isn't sending emails yet, this PR was a hard one to test (and write testing instructions for)._ 

 * Test the the default behavior is working as expected by starting your server locally and clicking sign in
 * Verify that the email it sends is coming from "noreply@stg.echosearch.org"
 * Now checkout a test branch based on this branch in order change a few things to test on staging. In `users/views.py`, add the following under except `User.DoesNotExist: pass` on lines 59-60:
```     
except Exception:
        return Response(data=settings.DEFAULT_FROM_EMAIL)
```
This will trigger with whatever error is currently happening on staging when attempting to access the `LoginPage` view, allowing us to see what value terraform is passing down without needing to see the email itself.
 * Remove the default value from `DEFAULT_FROM_EMAIL` in `settings.py` so that you can check the value is being correctly handed down from `terraform.tfvars`
 * Push your test branch up and once it has built, open your Network tab and then click sign in. No email will be sent, but your login request should display "noreply@stg.echosearch.org" as its response


Resolves #485 
