### PR TITLE
bug fix swap lat lon in user profile migration script

### DIFF
--- a/src/backend/users/management/commands/migrate_housing_seeker_data.py
+++ b/src/backend/users/management/commands/migrate_housing_seeker_data.py
@@ -391,7 +391,7 @@ class Command(BaseCommand):
             destination = Destination.objects.create(
                 profile=user_profile,
                 label=label,
-                location=Point(x=lat, y=lon),
+                location=Point(x=lon, y=lat),
                 purpose=purpose,
                 primary_destination=des[DestinationKeys.PRIMARY],
             )


### PR DESCRIPTION
## Overview

This PR adjusts the management script  `migrate_housing_seeker_data` used to import user profiles from S3. In the initial migration the latitude / longitude values for locations were swapped. This script has already been run to replace the user profiles on staging.

### Checklist

- [ ] Run `./scripts/format` to lint, format, and fix the application source code.

### Demo

![echo-issue-510-fix](https://user-images.githubusercontent.com/16727618/170502140-1d717111-6611-4a46-b7f1-0d0152d2990e.png)

### Notes


## Testing Instructions

- `./scripts/update`
- `AWS_PROFILE=<your echo profile name>./scripts/manage migrate_housing_seeker_data -b <staging profile bucket name> -p public -vkts ""`
- The above should work and should insert related staging profiles as records in your local DB. 
- Make sure it has an output of summary. User profiles with locations should be rendered on map correctly in admin.
- `AWS_PROFILE=<your echo profile name>./scripts/manage migrate_housing_seeker_data -b <production profile bucket name> -p public -vkts ""`
- The above should work and should insert related production profiles as records in your local DB
- Make sure it has an output of summary. User profiles with locations should be rendered on map correctly in admin.



Resolves https://github.com/azavea/echo-locator/issues/510
