### PR TITLE
Update Sidebar "From" destinations Select

### DIFF
--- a/src/frontend/src/components/form.js
+++ b/src/frontend/src/components/form.js
@@ -146,6 +146,7 @@ class Form extends React.PureComponent<Props> {
         label: d.location.label,
         position: d.location.position,
         value: d.purpose,
+        purpose: d.purpose,
       };
     });
     const locationsWithLabels = locations.map((loc) => {
@@ -160,14 +161,7 @@ class Form extends React.PureComponent<Props> {
     const selectDestination = (option?: ReactSelectOption) => {
       // To make translations dynamic in Select value, reseparate label and purpose
       const loc = option && locations.find((loc) => loc.position === option.position);
-      const destinationObj = option
-        ? {
-            label: loc.label,
-            purpose: loc.purpose,
-            position: lonlat(option.position),
-            value: loc.value,
-          }
-        : null;
+      const destinationObj = option ? { ...loc, position: lonlat(option.position) } : null;
       this.setState({ destination: destinationObj });
       this.props.updateOrigin(destinationObj);
     };
@@ -200,10 +194,7 @@ class Form extends React.PureComponent<Props> {
             wrapperStyle={SELECT_WRAPPER_STYLE}
             value={{
               ...destination,
-              label:
-                t(`TripPurpose.${destination.purpose ? destination.purpose : destination.value}`) +
-                ": " +
-                destination.label,
+              label: t(`TripPurpose.${destination.purpose}`) + ": " + destination.label,
             }}
           />
         </div>

--- a/src/frontend/src/components/form.js
+++ b/src/frontend/src/components/form.js
@@ -116,6 +116,7 @@ class Form extends React.PureComponent<Props> {
       ? {
           label: destination.location.label,
           position,
+          purpose: destination.purpose,
           value: position,
         }
       : null;
@@ -127,18 +128,6 @@ class Form extends React.PureComponent<Props> {
     const network = { label: first.name, value: first.url, networkName: first.name };
     this.setState({ network });
     this.props.setActiveNetwork(network.label);
-  };
-
-  selectDestination = (option?: ReactSelectOption) => {
-    const destinationObj = option
-      ? {
-          label: option.label,
-          position: lonlat(option.position),
-          value: option.value,
-        }
-      : null;
-    this.setState({ destination: destinationObj });
-    this.props.updateOrigin(destinationObj);
   };
 
   setNetwork = (option?: ReactSelectOption) => {
@@ -168,6 +157,21 @@ class Form extends React.PureComponent<Props> {
       };
     });
     const destinationFilterOptions = createDestinationsFilter(locationsWithLabels);
+    const selectDestination = (option?: ReactSelectOption) => {
+      // To make translations dynamic in Select value, reseparate label and purpose
+      const loc = option && locations.find((loc) => loc.position === option.position);
+      const destinationObj = option
+        ? {
+            label: loc.label,
+            purpose: loc.purpose,
+            position: lonlat(option.position),
+            value: loc.value,
+          }
+        : null;
+      this.setState({ destination: destinationObj });
+      this.props.updateOrigin(destinationObj);
+    };
+
     const useNetworks = this.getProfileNetworks(this.props.networks, userProfile);
     // generate temporary, translated network labels for menu options
     const networks = useNetworks.map((n) => ({
@@ -190,11 +194,17 @@ class Form extends React.PureComponent<Props> {
             filterOptions={destinationFilterOptions}
             options={locationsWithLabels}
             optionHeight={SELECT_OPTION_HEIGHT}
-            onChange={this.selectDestination}
+            onChange={selectDestination}
             placeholder={t("Geocoding.StartPlaceholder")}
             style={SELECT_STYLE}
             wrapperStyle={SELECT_WRAPPER_STYLE}
-            value={destination}
+            value={{
+              ...destination,
+              label:
+                t(`TripPurpose.${destination.purpose ? destination.purpose : destination.value}`) +
+                ": " +
+                destination.label,
+            }}
           />
         </div>
         {!userProfile.hasVehicle && (

--- a/src/frontend/src/components/form.js
+++ b/src/frontend/src/components/form.js
@@ -116,7 +116,7 @@ class Form extends React.PureComponent<Props> {
       ? {
           label: destination.location.label,
           position,
-          value: destination.purpose,
+          value: position,
         }
       : null;
   };
@@ -161,7 +161,11 @@ class Form extends React.PureComponent<Props> {
     });
     const locationsWithLabels = locations.map((loc) => {
       // generate temporary, translated destination labels menu options
-      return { ...loc, label: t(`TripPurpose.${loc.value}`) + ": " + loc.label };
+      return {
+        ...loc,
+        label: t(`TripPurpose.${loc.value}`) + ": " + loc.label,
+        value: loc.position,
+      };
     });
     const destinationFilterOptions = createDestinationsFilter(locationsWithLabels);
     const useNetworks = this.getProfileNetworks(this.props.networks, userProfile);
@@ -190,7 +194,7 @@ class Form extends React.PureComponent<Props> {
             placeholder={t("Geocoding.StartPlaceholder")}
             style={SELECT_STYLE}
             wrapperStyle={SELECT_WRAPPER_STYLE}
-            value={destination.value}
+            value={destination}
           />
         </div>
         {!userProfile.hasVehicle && (

--- a/src/frontend/src/components/map.js
+++ b/src/frontend/src/components/map.js
@@ -391,7 +391,11 @@ class Map extends PureComponent<Props, State> {
             zIndex={getZIndex()}
           >
             <Popup>
-              <span>{p.origin.label}</span>
+              <span>
+                {p.t(`TripPurpose.${p.origin.purpose ? p.origin.purpose : p.origin.value}`) +
+                  ": " +
+                  p.origin.label}
+              </span>
             </Popup>
           </Marker>
         )}

--- a/src/frontend/src/components/map.js
+++ b/src/frontend/src/components/map.js
@@ -391,11 +391,7 @@ class Map extends PureComponent<Props, State> {
             zIndex={getZIndex()}
           >
             <Popup>
-              <span>
-                {p.t(`TripPurpose.${p.origin.purpose ? p.origin.purpose : p.origin.value}`) +
-                  ": " +
-                  p.origin.label}
-              </span>
+              <span>{p.t(`TripPurpose.${p.origin.purpose}`) + ": " + p.origin.label}</span>
             </Popup>
           </Marker>
         )}


### PR DESCRIPTION
## Overview

This PR updates the `Select` component that creates the dropdown of destinations for the "From" field on the main page sidebar. The value that displays to the user now updates to the correct primary destination, formatted as "purpose: address", and the other destination options are now able to be selected. All options are also able to be translated. In addition, the origin pop-up that displays on the map should now show a translatable "purpose: address" label.

### Checklist

- [x] Run `./scripts/format` to lint, format, and fix the application source code.

### Notes
This ended up being a trickier issue for a couple reasons:
- Once I set the option's value to a more unique identifier (`position`) the "purpose: address" formatting was lost for the value on page load, though not for the dropdown options since those values are created separately. However, if I added the formatting to the value, once an option was selected it would update to "purpose: purpose: address" since the options labels had already been formatted.
- While the destination purpose would display after selecting an option from the dropdown, the translation became static in the value and would not longer update until selecting another option. I _think_ this is because updating the `Select` value to a more unique identifier means that we're referencing the `destination` state's `label` property instead of referencing the option's `label`, the former of which has already resolved the translation into a string?

For these two reasons I ended up creating a new `purpose` property on the `destination` object so that, after an option is selected, purpose and address are re-separated from `label` so that they can be put back together again with translation and correct formatting when defining the `Select` value that displays. If `purpose` doesn't exist, it's because the `destination` state is the original object from `destinations` vs the formatted `location` options so the purpose is stored in `destination.value`.

## Testing Instructions

 * `scripts/server`
 * Login as user or anonymous
 * Create a couple destinations of the same purpose
 * Save and confirm the value that displays in the "From" field is the current primary address
 * Confirm the purpose translates
 * Confirm you can select all other destinations (and that destinations in dropdown translate as well)

Resolves #525 
