### PR TITLE
Fix final bugs in signup / login flow

### DIFF
--- a/src/backend/echo/settings.py
+++ b/src/backend/echo/settings.py
@@ -137,6 +137,8 @@ DATABASES = {
     }
 }
 
+# Set protocol for sent links like password reset or magic links
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # Password validation
 # https://docs.djangoproject.com/en/3.2/ref/settings/#auth-password-validators

--- a/src/frontend/src/components/edit-profile.js
+++ b/src/frontend/src/components/edit-profile.js
@@ -58,6 +58,9 @@ class EditProfile extends PureComponent<Props> {
     this.validDestinations = this.validDestinations.bind(this);
 
     const profile = props.userProfile;
+    // this makes a deep copy of the user's profile with which to restore all
+    // changed fields on cancel
+    this.initialProfile = JSON.parse(JSON.stringify(profile));
     this.state = this.getDefaultState(profile);
   }
 
@@ -127,6 +130,7 @@ class EditProfile extends PureComponent<Props> {
   cancel(event) {
     // Navigate back to the last page visited, discarding any changes.
     if (this.props.location.state && this.props.location.state.fromApp) {
+      this.props.setProfile(this.initialProfile);
       this.props.history.goBack();
     } else {
       // User navigated to this page directly

--- a/src/frontend/src/components/edit-profile.js
+++ b/src/frontend/src/components/edit-profile.js
@@ -61,17 +61,6 @@ class EditProfile extends PureComponent<Props> {
     this.state = this.getDefaultState(profile);
   }
 
-  componentWillReceiveProps(nextProps) {
-    // Listen for when profile to appear on props, because it is not present
-    // on initial load. Only load once by checking state.
-    if (!nextProps.isLoading && nextProps.userProfile) {
-      if (!nextProps.userProfile.destinations || !nextProps.userProfile.destinations.length) {
-        nextProps.userProfile.destinations = [Object.assign({}, firstAddress)];
-      }
-      this.setState(nextProps.userProfile);
-    }
-  }
-
   componentDidUpdate(prevProps, prevState) {
     if (this.state.errorMessage) {
       window.scroll(0, 0);


### PR DESCRIPTION
## Overview

This PR addresses the final issues that were preventing staging's login and signup flow from working, namely fixing the following issues:
* Magic link emails were always being sent with a "http" protocol, which resulted in broken links when clicked
* Any edits made to a user's profile were erased if they edited a destination, particularly during user sign up
* Destinations changed or added were not being restored to their previous state if users clicked "cancel"


### Checklist

- [X] Run `./scripts/format` to lint, format, and fix the application source code.


### Notes

This PR also included investigating 500 errors being sent by the server on attempting to sign in; this ended up being an issue with migrations not having been run on staging and resulted in issue #534. 

This PR also removes `componentWillReceiveProps` from the `EditProfile` component, as it was causing a very difficult to debug disconnect between component and app state when a user would edit an address. Initially, `componentWillReceiveProps` was necessary because it was possible for the component to be handed a profile that was null; however, our new login process means profile should never be empty. This seemed to leave a potential problem if profile does end up null somehow, so I wanted to add some handling for that case. In order to replicate this, I cleared local storage in my application, assuming this was the only conceivable way a user could trigger this vulnerability; however, no matter what I did, I could never get it to result in an error, as the app would just use app state to re-populate local storage. So I haven't added any error handling for that case, as it seems incredibly difficult, if not impossible, to trigger.


## Testing Instructions

 * After checking that this branch is the active one on staging, try the sign up flow:
     * Verify you receive the sign up link
     * Verify that clicking the link takes you into the app
     * Verify that any fields you fill out prior to adding your first address save as they should and are not empty if you open edit profile again
* Now check that if you edit or add an address and then click cancel, those destinations are restored to their previous state and did not save your changes


Resolves #529 
