### PR TITLE
Adds terraform linting and reduces boilerplate around aws tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,12 @@ jobs:
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IGNORE_GITIGNORED_FILES: true
-          FILTER_REGEX_INCLUDE: src/backend/
+          FILTER_REGEX_INCLUDE: src/backend/|deployment/terraform-django/
           FILTER_REGEX_EXCLUDE: .*(migrations/*|manage.py).*
           LINTER_RULES_PATH: /
           PYTHON_BLACK_CONFIG_FILE: src/backend/pyproject.toml
           PYTHON_FLAKE8_CONFIG_FILE: src/backend/setup.cfg
+          VALIDATE_TERRAFORM_TERRASCAN: false
           VALIDATE_GITLEAKS: false
           VALIDATE_JSCPD: false
           VALIDATE_PYTHON_MYPY: false

--- a/deployment/terraform-django/alarms.tf
+++ b/deployment/terraform-django/alarms.tf
@@ -1,8 +1,3 @@
 resource "aws_sns_topic" "global" {
   name = "topic${local.short}GlobalNotifications"
-
-  tags = {
-    Project     = var.project
-    Environment = var.environment
-  }
 }

--- a/deployment/terraform-django/app.tf
+++ b/deployment/terraform-django/app.tf
@@ -7,8 +7,6 @@ resource "aws_security_group" "alb" {
 
   tags = {
     Name        = "sg${local.short}AppLoadBalancer"
-    Project     = var.project
-    Environment = var.environment
   }
 }
 
@@ -18,8 +16,6 @@ resource "aws_security_group" "app" {
 
   tags = {
     Name        = "sg${local.short}AppEcsService",
-    Project     = var.project
-    Environment = var.environment
   }
 }
 
@@ -33,8 +29,6 @@ resource "aws_lb" "app" {
 
   tags = {
     Name        = "alb${local.short}App"
-    Project     = var.project
-    Environment = var.environment
   }
 }
 
@@ -58,8 +52,6 @@ resource "aws_lb_target_group" "app" {
 
   tags = {
     Name        = "tg${local.short}App"
-    Project     = var.project
-    Environment = var.environment
   }
 }
 
@@ -132,8 +124,6 @@ resource "aws_ecs_task_definition" "app" {
 
   tags = {
     Name        = "${local.short}App",
-    Project     = var.project
-    Environment = var.environment
   }
 }
 
@@ -146,10 +136,10 @@ resource "aws_ecs_service" "app" {
   deployment_minimum_healthy_percent = var.fargate_app_deployment_min_percent
   deployment_maximum_percent         = var.fargate_app_deployment_max_percent
 
-  launch_type          = "FARGATE"
-  platform_version     = var.fargate_platform_version
+  launch_type            = "FARGATE"
+  platform_version       = var.fargate_platform_version
   enable_execute_command = true
-  force_new_deployment = true
+  force_new_deployment   = true
 
   network_configuration {
     security_groups = [aws_security_group.app.id]
@@ -202,8 +192,6 @@ resource "aws_ecs_task_definition" "app_cli" {
 
   tags = {
     Name        = "${local.short}AppCLI",
-    Project     = var.project
-    Environment = var.environment
   }
 }
 

--- a/deployment/terraform-django/cdn.tf
+++ b/deployment/terraform-django/cdn.tf
@@ -131,9 +131,4 @@ resource "aws_cloudfront_distribution" "cdn" {
     minimum_protocol_version = "TLSv1.2_2019"
     ssl_support_method       = "sni-only"
   }
-
-  tags = {
-    Project     = var.project
-    Environment = var.environment
-  }
 }

--- a/deployment/terraform-django/certificate.tf
+++ b/deployment/terraform-django/certificate.tf
@@ -3,12 +3,7 @@ resource "aws_acm_certificate" "cert" {
   subject_alternative_names = ["*.${var.r53_public_hosted_zone}"]
   validation_method         = "DNS"
 
-  tags = {
-    Project     = var.project
-    Environment = var.environment
-  }
-
   lifecycle {
-    create_before_destroy = false
+    create_before_destroy = true
   }
 }

--- a/deployment/terraform-django/config.tf
+++ b/deployment/terraform-django/config.tf
@@ -1,5 +1,11 @@
 provider "aws" {
   region = var.aws_region
+  default_tags {
+    tags = {
+      Environment = var.environment
+      Project     = var.project
+    }
+  }
 }
 
 terraform {

--- a/deployment/terraform-django/database.tf
+++ b/deployment/terraform-django/database.tf
@@ -8,8 +8,6 @@ resource "aws_db_subnet_group" "default" {
 
   tags = {
     Name        = "dbsngDatabaseServer"
-    Project     = var.project
-    Environment = var.environment
   }
 }
 
@@ -35,11 +33,6 @@ resource "aws_db_instance" "postgresql" {
   vpc_security_group_ids     = [aws_security_group.postgresql.id]
   db_subnet_group_name       = aws_db_subnet_group.default.name
   deletion_protection        = var.rds_deletion_protection
-
-  tags = {
-    Project     = var.project
-    Environment = var.environment
-  }
 }
 
 #
@@ -50,8 +43,6 @@ resource "aws_security_group" "postgresql" {
 
   tags = {
     Name        = "sgDatabaseServer",
-    Project     = var.project
-    Environment = var.environment
   }
 }
 

--- a/deployment/terraform-django/dns.tf
+++ b/deployment/terraform-django/dns.tf
@@ -8,11 +8,6 @@ resource "aws_route53_zone" "internal" {
     vpc_id     = aws_vpc.default.id
     vpc_region = var.aws_region
   }
-
-  tags = {
-    Project     = var.project
-    Environment = var.environment
-  }
 }
 
 resource "aws_route53_record" "database" {

--- a/deployment/terraform-django/network.tf
+++ b/deployment/terraform-django/network.tf
@@ -8,8 +8,6 @@ resource "aws_vpc" "default" {
 
   tags = {
     Name        = "vpc${local.short}",
-    Project     = var.project
-    Environment = var.environment
   }
 }
 
@@ -18,8 +16,6 @@ resource "aws_internet_gateway" "default" {
 
   tags = {
     Name        = "gwInternet",
-    Project     = var.project
-    Environment = var.environment
   }
 }
 
@@ -30,8 +26,6 @@ resource "aws_route_table" "private" {
 
   tags = {
     Name        = "PrivateRouteTable",
-    Project     = var.project
-    Environment = var.environment
   }
 }
 
@@ -48,8 +42,6 @@ resource "aws_route_table" "public" {
 
   tags = {
     Name        = "PublicRouteTable",
-    Project     = var.project
-    Environment = var.environment
   }
 }
 
@@ -68,8 +60,6 @@ resource "aws_subnet" "private" {
 
   tags = {
     Name        = "PrivateSubnet",
-    Project     = var.project
-    Environment = var.environment
   }
 }
 
@@ -83,8 +73,6 @@ resource "aws_subnet" "public" {
 
   tags = {
     Name        = "PublicSubnet",
-    Project     = var.project
-    Environment = var.environment
   }
 }
 
@@ -112,8 +100,6 @@ resource "aws_vpc_endpoint" "s3" {
 
   tags = {
     Name        = "endpointS3",
-    Project     = var.project
-    Environment = var.environment
   }
 }
 
@@ -136,7 +122,5 @@ resource "aws_nat_gateway" "default" {
 
   tags = {
     Name        = "gwNAT",
-    Project     = var.project
-    Environment = var.environment
   }
 }

--- a/deployment/terraform-django/storage.tf
+++ b/deployment/terraform-django/storage.tf
@@ -31,11 +31,6 @@ data "aws_iam_policy_document" "read_only_bucket_policy" {
 
 resource "aws_s3_bucket" "site" {
   bucket = local.site_bucket_name
-
-  tags = {
-    Project     = var.project,
-    Environment = var.environment
-  }
 }
 
 resource "aws_s3_bucket_cors_configuration" "site" {
@@ -57,11 +52,6 @@ resource "aws_s3_bucket_policy" "read_only_bucket" {
 
 resource "aws_s3_bucket" "logs" {
   bucket = local.logs_bucket_name
-
-  tags = {
-    Project     = var.project,
-    Environment = var.environment
-  }
 }
 
 resource "aws_s3_bucket_acl" "logs" {

--- a/scripts/test
+++ b/scripts/test
@@ -43,12 +43,13 @@ then
                 -e RUN_LOCAL=true \
                 -e VALIDATE_ALL_CODEBASE=false \
                 -e IGNORE_GITIGNORED_FILES=true \
-                -e FILTER_REGEX_INCLUDE="src/backend/" \
+                -e FILTER_REGEX_INCLUDE="src/backend/|deployment/terraform-django/" \
                 -e FILTER_REGEX_EXCLUDE=".*(migrations/*|manage.py).*" \
                 -e LINTER_RULES_PATH="/" \
                 -e PYTHON_BLACK_CONFIG_FILE="src/backend/pyproject.toml" \
                 -e PYTHON_FLAKE8_CONFIG_FILE="src/backend/setup.cfg" \
                 -e VALIDATE_GITLEAKS=false \
+                -e VALIDATE_TERRAFORM_TERRASCAN=false \
                 -e VALIDATE_JSCPD=false \
                 -e VALIDATE_PYTHON_MYPY=false \
                 -e VALIDATE_DOCKERFILE_HADOLINT=false \


### PR DESCRIPTION
Adds terraform linting and reduces boilerplate around aws tags
    
     * Terraform linting to super-linter  which caught one issue with cert lifecycle
     * Reduce boilerplate code by using default tags. Adds 9 more resources
       to having tags, while reducing lines of terraform by about 50.

### Checklist

- [x] Run `./scripts/format` to lint, format, and fix the application source code.

## Testing Instructions

 * Confirm terraform linting shows up in CI locally
 * Confirm more resources are tagged in this setup.
