### PR TITLE
Drop NAT Gateway

### DIFF
--- a/deployment/terraform-django/app.tf
+++ b/deployment/terraform-django/app.tf
@@ -6,7 +6,7 @@ resource "aws_security_group" "alb" {
   vpc_id = aws_vpc.default.id
 
   tags = {
-    Name        = "sg${local.short}AppLoadBalancer"
+    Name = "sg${local.short}AppLoadBalancer"
   }
 }
 
@@ -15,7 +15,7 @@ resource "aws_security_group" "app" {
   vpc_id = aws_vpc.default.id
 
   tags = {
-    Name        = "sg${local.short}AppEcsService",
+    Name = "sg${local.short}AppEcsService",
   }
 }
 
@@ -25,10 +25,10 @@ resource "aws_security_group" "app" {
 resource "aws_lb" "app" {
   name            = "alb${local.short}App"
   security_groups = [aws_security_group.alb.id]
-  subnets         = aws_subnet.public.*.id
+  subnets         = aws_subnet.main.*.id
 
   tags = {
-    Name        = "alb${local.short}App"
+    Name = "alb${local.short}App"
   }
 }
 
@@ -51,7 +51,7 @@ resource "aws_lb_target_group" "app" {
   target_type = "ip"
 
   tags = {
-    Name        = "tg${local.short}App"
+    Name = "tg${local.short}App"
   }
 }
 
@@ -123,7 +123,7 @@ resource "aws_ecs_task_definition" "app" {
   })
 
   tags = {
-    Name        = "${local.short}App",
+    Name = "${local.short}App",
   }
 }
 
@@ -141,9 +141,11 @@ resource "aws_ecs_service" "app" {
   enable_execute_command = true
   force_new_deployment   = true
 
+
   network_configuration {
-    security_groups = [aws_security_group.app.id]
-    subnets         = aws_subnet.private.*.id
+    security_groups  = [aws_security_group.app.id]
+    subnets          = aws_subnet.main.*.id
+    assign_public_ip = true
   }
 
   load_balancer {
@@ -191,7 +193,7 @@ resource "aws_ecs_task_definition" "app_cli" {
   })
 
   tags = {
-    Name        = "${local.short}AppCLI",
+    Name = "${local.short}AppCLI",
   }
 }
 

--- a/deployment/terraform-django/database.tf
+++ b/deployment/terraform-django/database.tf
@@ -4,10 +4,10 @@
 resource "aws_db_subnet_group" "default" {
   name        = var.rds_database_identifier
   description = "Private subnets for the RDS instances"
-  subnet_ids  = aws_subnet.private.*.id
+  subnet_ids  = aws_subnet.main.*.id
 
   tags = {
-    Name        = "dbsngDatabaseServer"
+    Name = "dbsngDatabaseServer"
   }
 }
 
@@ -28,6 +28,7 @@ resource "aws_db_instance" "postgresql" {
   final_snapshot_identifier  = var.rds_final_snapshot_identifier
   skip_final_snapshot        = var.rds_skip_final_snapshot
   copy_tags_to_snapshot      = var.rds_copy_tags_to_snapshot
+  publicly_accessible        = false
   multi_az                   = var.rds_multi_az
   storage_encrypted          = var.rds_storage_encrypted
   vpc_security_group_ids     = [aws_security_group.postgresql.id]
@@ -42,7 +43,7 @@ resource "aws_security_group" "postgresql" {
   vpc_id = aws_vpc.default.id
 
   tags = {
-    Name        = "sgDatabaseServer",
+    Name = "sgDatabaseServer",
   }
 }
 

--- a/deployment/terraform-django/network.tf
+++ b/deployment/terraform-django/network.tf
@@ -7,7 +7,7 @@ resource "aws_vpc" "default" {
   enable_dns_hostnames = true
 
   tags = {
-    Name        = "vpc${local.short}",
+    Name = "vpc${local.short}",
   }
 }
 
@@ -15,33 +15,15 @@ resource "aws_internet_gateway" "default" {
   vpc_id = aws_vpc.default.id
 
   tags = {
-    Name        = "gwInternet",
+    Name = "gwInternet",
   }
-}
-
-resource "aws_route_table" "private" {
-  count = length(var.private_subnet_cidr_blocks)
-
-  vpc_id = aws_vpc.default.id
-
-  tags = {
-    Name        = "PrivateRouteTable",
-  }
-}
-
-resource "aws_route" "private" {
-  count = length(var.private_subnet_cidr_blocks)
-
-  route_table_id         = aws_route_table.private[count.index].id
-  destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.default[count.index].id
 }
 
 resource "aws_route_table" "public" {
   vpc_id = aws_vpc.default.id
 
   tags = {
-    Name        = "PublicRouteTable",
+    Name = "PublicRouteTable",
   }
 }
 
@@ -51,19 +33,7 @@ resource "aws_route" "public" {
   gateway_id             = aws_internet_gateway.default.id
 }
 
-resource "aws_subnet" "private" {
-  count = length(var.private_subnet_cidr_blocks)
-
-  vpc_id            = aws_vpc.default.id
-  cidr_block        = var.private_subnet_cidr_blocks[count.index]
-  availability_zone = var.availability_zones[count.index]
-
-  tags = {
-    Name        = "PrivateSubnet",
-  }
-}
-
-resource "aws_subnet" "public" {
+resource "aws_subnet" "main" {
   count = length(var.public_subnet_cidr_blocks)
 
   vpc_id                  = aws_vpc.default.id
@@ -72,21 +42,14 @@ resource "aws_subnet" "public" {
   map_public_ip_on_launch = true
 
   tags = {
-    Name        = "PublicSubnet",
+    Name = "MainSubnet",
   }
-}
-
-resource "aws_route_table_association" "private" {
-  count = length(var.private_subnet_cidr_blocks)
-
-  subnet_id      = aws_subnet.private[count.index].id
-  route_table_id = aws_route_table.private[count.index].id
 }
 
 resource "aws_route_table_association" "public" {
   count = length(var.public_subnet_cidr_blocks)
 
-  subnet_id      = aws_subnet.public[count.index].id
+  subnet_id      = aws_subnet.main[count.index].id
   route_table_id = aws_route_table.public.id
 }
 
@@ -95,32 +58,10 @@ resource "aws_vpc_endpoint" "s3" {
   service_name = "com.amazonaws.${var.aws_region}.s3"
   route_table_ids = flatten([
     aws_route_table.public.id,
-    aws_route_table.private.*.id
   ])
 
   tags = {
-    Name        = "endpointS3",
+    Name = "endpointS3",
   }
 }
 
-#
-# NAT resources
-#
-resource "aws_eip" "nat" {
-  count = length(var.public_subnet_cidr_blocks)
-
-  vpc = true
-}
-
-resource "aws_nat_gateway" "default" {
-  depends_on = [aws_internet_gateway.default]
-
-  count = length(var.public_subnet_cidr_blocks)
-
-  allocation_id = aws_eip.nat[count.index].id
-  subnet_id     = aws_subnet.public[count.index].id
-
-  tags = {
-    Name        = "gwNAT",
-  }
-}


### PR DESCRIPTION
We can just use a public subnet, but have RDS (or anything else) not accessible via:
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html#USER_VPC.Hiding

We do have an IPv4 address assigned to the ECS cluster tasks (it's free as long as it's running  From what I can tell we have default IP limit of 5 per AWS account and if some somehow don't get released properly we can incur charges at 0.005 an hour ($3.65 a month).  Total possible costs if things go poorly would be ~$14.60 (for 4 IPs) per month vs $65 guaranteed for NAT gateway.  

### Checklist

- [X] Run `./scripts/format` to lint, format, and fix the application source code.

## Testing Instructions

 * Ensure sign in to app and admin works
 * Rollbar works (but can test again)
