### PR TITLE
Add is_active login conditional

### DIFF
--- a/src/backend/users/views.py
+++ b/src/backend/users/views.py
@@ -54,9 +54,11 @@ def send_login_link(request):
 class LoginPage(APIView):
     def post(self, request, **kwargs):
         try:
-            # Will throw exception if cannot find the User
-            # For privacy reasons, do not send 500 error back if not found
-            send_login_link(request)
+            email = request.data["username"]
+            if User.objects.get(username=email).is_active:
+                # Will throw exception if cannot find the User
+                # For privacy reasons, do not send 500 error back if not found
+                send_login_link(request)
         except User.DoesNotExist:
             pass
         return Response(content_type="application/json")


### PR DESCRIPTION
## Overview

This PR adds a conditional that prevents inactive users from receiving a login email.

### Checklist

- [x] Run `./scripts/format` to lint, format, and fix the application source code.

### Notes

I didn't add any messaging to display on the frontend in the event an inactive user attempts to login, as discussed in RRP. On submit, an inactive user will receive the same display message as if successful. There is currently an issue open to address this in the future #557 

## Testing Instructions

 * Create a new user either through the admin or using the frontend signup form
 * Log in as the new houseseeker user and confirm you receive an email
 * In the admin, navigate to the newly created user and uncheck the "Is active" checkbox and save
 * Attempt to log in and confirm you no longer receive an email
 * Attempt to log in as a user without an account and confirm you do not receive an email (this existed before, but confirm it still works with the new conditional)


Resolves #549 
