### PR TITLE
Enable cloudfront -> LB -> Container

### DIFF
--- a/deployment/terraform-django/app.tf
+++ b/deployment/terraform-django/app.tf
@@ -4,19 +4,11 @@
 resource "aws_security_group" "alb" {
   name   = "sg${local.short}AppLoadBalancer"
   vpc_id = aws_vpc.default.id
-
-  tags = {
-    Name = "sg${local.short}AppLoadBalancer"
-  }
 }
 
 resource "aws_security_group" "app" {
   name   = "sg${local.short}AppEcsService"
   vpc_id = aws_vpc.default.id
-
-  tags = {
-    Name = "sg${local.short}AppEcsService",
-  }
 }
 
 #
@@ -26,10 +18,6 @@ resource "aws_lb" "app" {
   name            = "alb${local.short}App"
   security_groups = [aws_security_group.alb.id]
   subnets         = aws_subnet.main.*.id
-
-  tags = {
-    Name = "alb${local.short}App"
-  }
 }
 
 resource "aws_lb_target_group" "app" {
@@ -49,17 +37,12 @@ resource "aws_lb_target_group" "app" {
   vpc_id   = aws_vpc.default.id
 
   target_type = "ip"
-
-  tags = {
-    Name = "tg${local.short}App"
-  }
 }
 
 resource "aws_lb_listener" "app" {
   load_balancer_arn = aws_lb.app.id
-  port              = "443"
-  protocol          = "HTTPS"
-  certificate_arn   = aws_acm_certificate.cert.arn
+  port              = "80"
+  protocol          = "HTTP"
 
   default_action {
     target_group_arn = aws_lb_target_group.app.id

--- a/deployment/terraform-django/cdn.tf
+++ b/deployment/terraform-django/cdn.tf
@@ -1,20 +1,15 @@
 resource "aws_cloudfront_distribution" "cdn" {
   origin {
-    domain_name = "origin.${var.r53_public_hosted_zone}"
+    domain_name = aws_lb.app.dns_name
     origin_id   = "originAlb"
 
+    # We are doing http-only but it still requires ssl info
     custom_origin_config {
       http_port              = 80
+      origin_protocol_policy = "http-only"
       https_port             = 443
-      origin_protocol_policy = "https-only"
       origin_ssl_protocols   = ["TLSv1.2"]
-      origin_read_timeout    = 15
     }
-  }
-
-  origin {
-    domain_name = aws_s3_bucket.site.bucket_regional_domain_name
-    origin_id   = "originS3"
   }
 
   enabled         = true
@@ -23,7 +18,7 @@ resource "aws_cloudfront_distribution" "cdn" {
   comment         = "${var.project} (${var.environment})"
 
   price_class = var.cloudfront_price_class
-  aliases     = [var.r53_public_hosted_zone, "*.${var.r53_public_hosted_zone}"]
+  aliases     = [var.r53_public_hosted_zone]
 
   default_cache_behavior {
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
@@ -67,57 +62,9 @@ resource "aws_cloudfront_distribution" "cdn" {
     max_ttl                = 300
   }
 
-  ordered_cache_behavior {
-    path_pattern     = "tile/*"
-    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
-    cached_methods   = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id = "originS3"
-
-    forwarded_values {
-      query_string = false
-
-      cookies {
-        forward = "none"
-      }
-    }
-
-    compress               = true
-    viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 2592000  # 1 month
-    max_ttl                = 31536000 # 1 year
-  }
-
-
-  ordered_cache_behavior {
-    path_pattern     = "geojson/*"
-    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
-    cached_methods   = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id = "originS3"
-
-    forwarded_values {
-      query_string = false
-      headers = [
-        "Origin",
-        "Access-Control-Request-Headers",
-        "Access-Control-Request-Method"
-      ]
-
-      cookies {
-        forward = "none"
-      }
-    }
-
-    compress               = true
-    viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 2592000  # 1 month
-    max_ttl                = 31536000 # 1 year
-  }
-
   logging_config {
     include_cookies = false
-    bucket          = aws_s3_bucket.logs.bucket_domain_name
+    bucket          = "${aws_s3_bucket.logs.id}.s3.amazonaws.com"
   }
 
   restrictions {
@@ -128,7 +75,7 @@ resource "aws_cloudfront_distribution" "cdn" {
 
   viewer_certificate {
     acm_certificate_arn      = aws_acm_certificate.cert.arn
-    minimum_protocol_version = "TLSv1.2_2019"
+    minimum_protocol_version = "TLSv1.2_2021"
     ssl_support_method       = "sni-only"
   }
 }

--- a/deployment/terraform-django/dns.tf
+++ b/deployment/terraform-django/dns.tf
@@ -31,8 +31,20 @@ resource "aws_route53_record" "site" {
   type    = "A"
 
   alias {
-    name                   = aws_lb.app.dns_name
-    zone_id                = aws_lb.app.zone_id
+    name                   = aws_cloudfront_distribution.cdn.domain_name
+    zone_id                = aws_cloudfront_distribution.cdn.hosted_zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "siteV6" {
+  zone_id = aws_route53_zone.external.zone_id
+  name    = var.r53_public_hosted_zone
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.cdn.domain_name
+    zone_id                = aws_cloudfront_distribution.cdn.hosted_zone_id
     evaluate_target_health = true
   }
 }

--- a/deployment/terraform-django/firewall.tf
+++ b/deployment/terraform-django/firewall.tf
@@ -12,17 +12,6 @@ resource "aws_security_group_rule" "alb_http_ingress" {
   security_group_id = aws_security_group.alb.id
 }
 
-resource "aws_security_group_rule" "alb_https_ingress" {
-  type             = "ingress"
-  from_port        = 443
-  to_port          = 443
-  protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
-  ipv6_cidr_blocks = ["::/0"]
-
-  security_group_id = aws_security_group.alb.id
-}
-
 resource "aws_security_group_rule" "alb_ecs_egress" {
   type      = "egress"
   from_port = local.django_container_port

--- a/deployment/terraform-django/storage.tf
+++ b/deployment/terraform-django/storage.tf
@@ -1,54 +1,8 @@
 locals {
-  site_bucket_name = lower("${var.project}-${var.environment}-tiles-${var.aws_region}")
   logs_bucket_name = lower("${var.project}-${var.environment}-logs-${var.aws_region}")
 }
 
 data "aws_canonical_user_id" "current" {}
-
-#
-# S3 resources
-#
-data "aws_iam_policy_document" "read_only_bucket_policy" {
-  policy_id = "S3AnonymousReadOnlyPolicy"
-
-  statement {
-    sid = "S3ReadOnly"
-
-    effect = "Allow"
-
-    principals {
-      type        = "*"
-      identifiers = ["*"]
-    }
-
-    actions = ["s3:GetObject"]
-
-    resources = [
-      "arn:aws:s3:::${local.site_bucket_name}/*",
-    ]
-  }
-}
-
-resource "aws_s3_bucket" "site" {
-  bucket = local.site_bucket_name
-}
-
-resource "aws_s3_bucket_cors_configuration" "site" {
-  bucket = aws_s3_bucket.site.bucket
-
-  cors_rule {
-    allowed_headers = ["Authorization"]
-    allowed_methods = ["GET"]
-    allowed_origins = ["*"]
-    expose_headers  = []
-    max_age_seconds = 3000
-  }
-}
-
-resource "aws_s3_bucket_policy" "read_only_bucket" {
-  bucket = aws_s3_bucket.site.bucket
-  policy = data.aws_iam_policy_document.read_only_bucket_policy.json
-}
 
 resource "aws_s3_bucket" "logs" {
   bucket = local.logs_bucket_name


### PR DESCRIPTION
## Overview

Enable cloudfront -> LB -> Container
    
    Previously it was just LB -> Container.
    
    As part of this change:
     * Disabled HTTPS for LB, just use http-only (alternative that I've seen is use the
         same cert and have it be at origin.*, but I'm not sure what this gains us
     * Cleaned up the S3 buckets that were for a totally diferent Cloudfront setup, in this
       case we copied cdn from DistrictBuilder.
     * Dropped a few more tags that aren't useful.

### Checklist

- [x] Run `./scripts/format` to lint, format, and fix the application source code.

### Notes

Right now we don't vary the caching by anything in particular.  This might be useful to improve performance if needed.

## Testing Instructions

 * Confirm site still works as expected
 * I got a "Can't find profile directory." error in console when using a non-logged in user.  Not sure if that's related to this change or not.  Works fine with a logged in user.

Resolves #450