### PR TITLE
Fix case sensitive logins and missing emails

### DIFF
--- a/src/backend/users/admin.py
+++ b/src/backend/users/admin.py
@@ -13,6 +13,13 @@ from .models import Destination, UserProfile
 
 class LoginForm(AuthenticationForm):
     username = forms.CharField(label="Email")
+    error_messages = {"invalid_login": "Please enter a correct email and password."}
+
+    # convert entered email to lowercase
+    def clean(self):
+        self.cleaned_data["username"] = self.cleaned_data.get("username").lower()
+        cleaned_data = super(LoginForm, self).clean()
+        return cleaned_data
 
 
 # Validates that the username is a valid email on save

--- a/src/backend/users/migrations/0011_make_usernames_lowercase.py
+++ b/src/backend/users/migrations/0011_make_usernames_lowercase.py
@@ -1,0 +1,18 @@
+from django.apps import apps
+from django.db import migrations
+
+def make_username_lowercase(apps, schema_editor):
+    User = apps.get_model("auth", "User")
+    for user in User.objects.all():
+        user.username=user.username.lower()
+        user.email=user.username
+        user.save()
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('users', '0010_remove_voucher_numer_from_profile'),
+    ]
+
+    operations = [
+        migrations.RunPython(make_username_lowercase, reverse_code=migrations.RunPython.noop)
+    ]

--- a/src/backend/users/models.py
+++ b/src/backend/users/models.py
@@ -3,6 +3,14 @@ from django.contrib.gis.db import models as gis_models
 from django.contrib.gis.geos import Point
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+
+
+@receiver(pre_save, sender=User)
+def lowercase_email(sender, instance, *args, **kwargs):
+    instance.username = instance.username.lower()
+    instance.email = instance.username
 
 
 class UserProfile(models.Model):

--- a/src/backend/users/views.py
+++ b/src/backend/users/views.py
@@ -23,7 +23,7 @@ def send_login_link(request):
     Will raise an exception if User.DoesNotExist
     """
     email = request.data["username"]
-    user = User.objects.get(username=email)
+    user = User.objects.get(username__iexact=email)
     login_token = utils.get_query_string(user)
     host = request.get_host()
     protocol = "https://" if request.is_secure() else "http://"
@@ -55,7 +55,7 @@ class LoginPage(APIView):
     def post(self, request, **kwargs):
         try:
             email = request.data["username"]
-            if User.objects.get(username=email).is_active:
+            if User.objects.get(username__iexact=email).is_active:
                 # Will throw exception if cannot find the User
                 # For privacy reasons, do not send 500 error back if not found
                 send_login_link(request)


### PR DESCRIPTION
## Overview

This PR addresses problems with users not receiving login emails from either the frontend or the backend. The issues were traced back to the fact that we had set up the username field to be called email and hid the actual email field from the admin. This PR fixes the issue by:
- Adding case insensitivity to both the frontend login form and admin login so that users can enter any variation of cases and still be able to login
- Adding a migration to 1) convert all existing users' emails to lowercase and 2) copy their username to the email field
- Adding a pre-save receiver to 1) convert all existing users' emails to lowercase and 2) copy their username to the email field on the creation of new accounts.


### Checklist

- [X] Run `./scripts/format` to lint, format, and fix the application source code.


## Testing Instructions

 * If you don't have any accounts in your database with capitalized email addresses, add one from `develop` or before pulling this branch and running migrations
 * Run migrations: `./scripts/manage migrate`
 * Check that the previously capitalized email is now lowercase and that all entries now have their username twice: once in the username field and again in email
 * Create a new user from the admin with a capitalized email and verify that it converts to lowercase and copies to the email field on save
 * Log in with a capitalized version of an admin email. It should allow you to login.
 * Navigate to the frontend and login with a capitalized version of your email. It should still "send" you an email in the terminal.
 * Sign up as a new user and enter a capitalized email. Verify that it also saves as lowercase and is copied to the email field.
 

Resolves #571 & #572 
