### PR TITLE
Fix polygon corruption on slow internet

### DIFF
--- a/src/frontend/src/actions/network.js
+++ b/src/frontend/src/actions/network.js
@@ -1,6 +1,7 @@
 // @flow
 import lonlat from "@conveyal/lonlat";
 import fetch, { fetchMultiple } from "@conveyal/woonerf/fetch";
+import { isEmpty } from "lodash";
 
 import { retrieveConfig, storeConfig } from "../config";
 import { ACCESSIBILITY_IS_LOADING, ACCESSIBILITY_IS_EMPTY, TAUI_CONFIG_KEY } from "../constants";
@@ -168,14 +169,22 @@ export const fetchAllTimesAndPathsForIndex =
   };
 
 export const fetchAllTimesAndPathsForCoordinate =
+  // if these times and paths are fetched before neighborhoodBounds exists, polygon
+  // corruption will occur
   (coordinate: LonLat) => (dispatch: Dispatch, getState: any) => {
     const state = getState();
-    const currentZoom = state.map.zoom;
-    dispatch(
-      state.data.networks.map((network) =>
-        fetchTimesAndPathsForNetworkAtCoordinate(network, coordinate, currentZoom)
-      )
-    );
+    if (!isEmpty(state.data.neighborhoodBounds)) {
+      const currentZoom = state.map.zoom;
+      dispatch(
+        state.data.networks.map((network) =>
+          fetchTimesAndPathsForNetworkAtCoordinate(network, coordinate, currentZoom)
+        )
+      );
+    } else {
+      setTimeout(() => {
+        dispatch(fetchAllTimesAndPathsForCoordinate(coordinate));
+      }, 500);
+    }
   };
 
 const fetchTimesAndPathsForNetworkAtCoordinate = (network, coordinate, currentZoom) => {


### PR DESCRIPTION
## Overview

Polygons were generating in a way that looked corrupted under slow internet conditions due to the update of transit networks before neighborhood bounds state had been updated. This PR conditionally adds a pause and recursive check to the generation of the networks, specifically where networks are assigned paths and times for the given origin point, so that they are not generated before `neighborhoodBounds` state exists.

### Checklist

- [X] Run `./scripts/format` to lint, format, and fix the application source code.

### Demo

The same map generated on 2G-speed internet before and then after this fix.

_Before_
![Screen Shot 2022-07-28 at 2 56 19 PM](https://user-images.githubusercontent.com/77936689/181616606-b3a2c43c-a783-4687-a859-7729571e6e05.png)

_After_
![Screen Shot 2022-07-28 at 2 57 24 PM](https://user-images.githubusercontent.com/77936689/181616636-e7debf71-d301-4aad-9b92-1a828891a248.png)


## Testing Instructions

 * Start the server, navigate to **localhost:9966**, and log in
 * In the network tab, click "No throttling" and set the internet to something much slower (I made my own custom internet profile that downloads at 1 Mbit/s and uploads at 20 kbit/s)
 * Refresh the page and wait for it to load. Once it loads, the map should look normal
 * Log out and log in again using the same tab with the slow internet connection. Again, the loaded map should look normal.


Resolves #574 
