### PR TITLE
Fix 500 error when user clicks expired link

### DIFF
--- a/src/backend/users/views.py
+++ b/src/backend/users/views.py
@@ -31,7 +31,7 @@ def send_login_link(request):
 
     html_message = """
     <p>Hi there,</p>
-    <p>Thanks for using ECHO! Here is your <a href="{}">link to login</a>. </p>
+    <p>Thanks for using ECHO! Here is your <a href="{}">link to login</a>. This link is valid for 1 hour.</p>
     <p>BHA</p>
     """.format(
         login_link
@@ -67,8 +67,12 @@ class LoginPage(APIView):
 class ObtainToken(APIView):
     def get(self, request, **kwargs):
         user = utils.get_user(request)
-        token, created = Token.objects.get_or_create(user=user)
         response = HttpResponseRedirect("/")
+        # If the token has expired or is otherwise invalid just send them back to the homepage,
+        # where they'll see the login screen again.
+        if user is None:
+            return response
+        token, created = Token.objects.get_or_create(user=user)
         # set authentication cookie with max_age 30 days
         response.set_cookie("auth_token", token.key, max_age=60 * 60 * 24 * 30)
         return response


### PR DESCRIPTION
## Overview

Redirects the user back to the login page if they click on an expired link, rather than throwing a 500 error.

Also updates the email text to explain that login links only last for
one hour.

### Checklist

- [ ] Run `./scripts/format` to lint, format, and fix the application source code.

### Demo

N/A

### Notes

Ideally, we'd explain to the user that their link had expired within the application when they try to use an expired link, but I think this is sufficient for a quick fix.

## Testing Instructions

 * On `develop`, update `settings.py` and change the `SESAME_MAX_AGE` parameter to something small, like `60`, so that links expire quickly for testing.
 * Start `./scripts/server` and enter your email on the login screen.
 * Wait long enough for the token to expire, then use the email link from the console. The email text should specify that the link will expire in one hour (though that will be false, in this case).
 * You should see a 500 error.
 * Check out this branch and try to log in again, with either the old expired email or a new one.
 * You shouldn't see a 500 error; instead, you should simply be redirected back to the login screen.


Resolves #580 