### PR TITLE
Restore listings API endpoints

### DIFF
--- a/src/frontend/src/actions/listings.js
+++ b/src/frontend/src/actions/listings.js
@@ -37,8 +37,7 @@ export const setRealtorListings =
               return handleError(error, "Realtor", REALTOR_ACTION_TYPE);
             }
             try {
-              const listings = JSON.parse(response.value.body);
-              return { type: REALTOR_ACTION_TYPE, payload: { data: listings } };
+              return { type: REALTOR_ACTION_TYPE, payload: { data: response.value } };
             } catch (error) {
               return handleError(error, "Realtor", REALTOR_ACTION_TYPE);
             }
@@ -70,8 +69,7 @@ export const setBHAListings =
             if (error) {
               return handleError(error, "BHA", BHA_ACTION_TYPE);
             }
-            const listings = JSON.parse(response.value.body);
-            return fwdGeocodeBatch(listings)
+            return fwdGeocodeBatch(response.value)
               .then((data) => {
                 return { type: BHA_ACTION_TYPE, payload: { data } };
               })

--- a/src/frontend/src/constants.js
+++ b/src/frontend/src/constants.js
@@ -64,11 +64,16 @@ export const DEFAULT_SCHOOLS_IMPORTANCE = 1;
 export const DEFAULT_CRIME_IMPORTANCE = 1;
 
 // URLS
+// REALTOR_BASE_URL and BHA_BASE_URL direct to the EchoStaging API in AWS API Gateway.
+// These get-bha-listings and get-realtor-listings endpoints then trigger the get_listings and
+// get-realtor-listings lambda functions in Lambda. These functions then reformat the request
+// into a DynamoDB query, send them along to the BHAListings and RealtorListings tables via the
+// lambda-data-retriever IAM role, and format and return the response.
 export const MAPBOX_GEOCODING_URL = "https://api.mapbox.com/geocoding/v5/mapbox.places";
 export const REALTOR_BASE_URL =
-  "https://akk8p5k8o0.execute-api.us-east-1.amazonaws.com/staging/get-realtor-listings";
+  "https://z8ah1tmx4d.execute-api.us-east-1.amazonaws.com/staging/get-realtor-listings";
 export const BHA_BASE_URL =
-  "https://akk8p5k8o0.execute-api.us-east-1.amazonaws.com/staging/-get-bha-listings?";
+  "https://z8ah1tmx4d.execute-api.us-east-1.amazonaws.com/staging/get-bha-listings?";
 
 // Network colors
 export const NETWORK_COLORS = [


### PR DESCRIPTION
## Overview

This PR mostly involves changes in the AWS console, particularly in Lambda and API Gateway, but also includes two code changes: 
- Links to the new API endpoints
- Change to the type of object `setRealtorListings()` and `setBHAListings()` expect, as the new endpoints return JSON, rather a string that can be parsed to JSON


### Checklist

- [X] Run `./scripts/format` to lint, format, and fix the application source code.

### Demo

![Screen Shot 2022-09-16 at 1 55 49 PM](https://user-images.githubusercontent.com/77936689/190702649-9d854157-e79f-4711-a85a-acd72a225104.png)


### Notes

I thought about using this opportunity to replace the "staging" URLs with something that more accurately describes the endpoint's purpose, but ultimately decided to stick with the existing staging API because I figured using an existing one might minimize at least some potential work of recreating permissions and other properties on a new API. I did not remove the `/bhalistings` endpoint that existed under this API; it appears to be only partially set up, but I figured better safe than sorry.

I have not included any authorization on these endpoints because we currently don't send any authorization along. I think this was previously authorized via the Cognito user groups in a way that didn't require authorization to accompany the request, but I've removed that Authorizer from this API. These endpoints seem harmless enough to me, but let me know if that is a cause of concern and I can add an IAM requirement on them.

I tried my absolute best to touch as little code as possible; however, ultimately decided that if something needed to bend, it was better being the lambda functions. As a result, I made a few changes to those, including using `event.body` and `event.queryStringParameters` instead of trying to access the zipcode, budget, and rooms properties directly from the event as it used to be. Similarly, I added a conditional check into `get_listings` to check for rooms before just filtering against rooms and budget. If I remember correctly, this used to be supported but was removed for some reason, so I've kept the capability in if we choose to restore it in the future.

**A breakdown of how these endpoints work for future reference**
The endpoint links used within the code direct to the `EchoStaging` API in AWS API Gateway. These `get-bha-listings` and `get-realtor-listings` endpoints then trigger the `get_listings` and `get-realtor-listings` lambda functions in Lambda, respectively. These functions then reformat the request into a DynamoDB query, send them along to the `BHAListings` and `RealtorListings` tables via the `lambda-data-retriever` IAM role, and format and return the response. There are also `BHAListingsDaily`, `BHAListingsWeekly`, `RealtorListingsDaily`, and `RealtorListingsWeekly` tables; I have no idea what those are for and the lambda functions do not (and did not) make use of them. 


## Testing Instructions

Check the user experience is fixed:
 * Start the server and sign in if need be
 * Search for the Boston-Dorchester-02124 neighborhood, as this has listings from both endpoints
 * Select both of the listing checkboxes and verify that markers with relevant popups appear on the map
 
To see the work in AWS:
 * In the AWS Console, go to Lambda
 * Check the code in the `get_listings` and `get-realtor-listings` functions and double check the code under "Code source"
 * Double check that there is only one trigger listed and that it is the corresponding endpoint in API Gateway
 * Go to AWS API Gateway and select the "EchoStaging" API
 * Look through the Method Requests, Integration Requests, Integration Responses, and Method Responses of the ANY and OPTIONS method on the `get-bha-listings` and `get-realtor-listings` resources, just making sure nothing looks off
 * Select "Models" in the lefthand menu and verify the ListingsRequestSchema and ListingsResponseSchema both generally match the responses coming from the frontend and lambda functions


Resolves #585 
