### PR TITLE
Fix staging deploy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     # Run GH Super-Linter against code base
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: cat .github/super-linter.env >> $GITHUB_ENV
       - name: Lint Code Base
         uses: github/super-linter@v4
@@ -25,14 +25,14 @@ jobs:
     env:
       DOCKER_BUILDKIT: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Set staging bucket if on develop or test, otherwise it won't be set
       # which is fine for a test build
       - run: echo "ECHOLOCATOR_SETTINGS_BUCKET=echo-locator-stgdjango-config-us-east-1" >> $GITHUB_ENV
         if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/test/')
 
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v4
         if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/test/')
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -48,7 +48,7 @@ jobs:
         if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/test/')
 
       - run: |
-          docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform -c "
+          docker compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform -c "
             unset AWS_PROFILE
             ./scripts/infra plan
             ./scripts/infra apply

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fix staging deploy workflow [#613](https://github.com/azavea/echo-locator/pull/613)
+
 ### Removed

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -10,6 +10,7 @@ services:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - ECHOLOCATOR_DEBUG=1
+      - SAFE_DIR_FOR_CI=1
       - ECHOLOCATOR_SETTINGS_BUCKET=${ECHOLOCATOR_SETTINGS_BUCKET:-echo-locator-stgdjango-config-us-east-1}
       - ECHOLOCATOR_SITE_BUCKET=${ECHOLOCATOR_SITE_BUCKET:-echo-locator-staging-site-us-east-1}
     working_dir: /usr/local/src

--- a/scripts/_sourced
+++ b/scripts/_sourced
@@ -22,10 +22,8 @@ check_for_help_flag() {
 if [[ -n "${GIT_COMMIT}" ]]; then
     export GIT_COMMIT="${GIT_COMMIT:0:16}"
 else
+    if [[ -n "${SAFE_DIR_FOR_CI}" ]]; then
+        git config --global --add safe.directory /usr/local/src
+    fi
     export GIT_COMMIT="$(git rev-parse --short=16 HEAD)"
 fi
-
-# TODO #597:
-# Update STRTA to use set_environment method defined here 
-# and standardize as much as possible given current
-# deployed resources' naming conventions

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -5,12 +5,6 @@ USAGE="Build application for staging or a release."
 source ./scripts/_sourced
 check_for_help_flag "$@"
 
-if [[ -n "${GIT_COMMIT}" ]]; then
-    GIT_COMMIT="${GIT_COMMIT:0:7}"
-else
-    GIT_COMMIT="$(git rev-parse --short HEAD)"
-fi
-
 echo "Running update script"
 REACT_APP_GIT_COMMIT="${GIT_COMMIT}" \
     ./scripts/update

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -7,12 +7,6 @@ check_for_help_flag "$@"
 
 ENVIRONMENT="${ECHOLOCATOR_ENVIRONMENT:-stgdjango}"
 
-if [[ -n "${GIT_COMMIT}" ]]; then
-    GIT_COMMIT="${GIT_COMMIT:0:7}"
-else
-    GIT_COMMIT="$(git rev-parse --short HEAD)"
-fi
-
 function amazon_ecr_login() {
     # Retrieves a temporary authorization token that can be used to access
     # Amazon ECR, along with the registry URL.

--- a/scripts/infra
+++ b/scripts/infra
@@ -6,13 +6,6 @@ USAGE="Execute Terraform subcommands with remote state management."
 source ./scripts/_sourced
 check_for_help_flag "$@"
 
-if [[ -n "${GIT_COMMIT}" ]]; then
-    GIT_COMMIT="${GIT_COMMIT:0:7}"
-else
-    git config --global --add safe.directory /usr/local/src
-    GIT_COMMIT="$(git rev-parse --short HEAD)"
-fi
-
 TERRAFORM_DIR="${DIR}/../deployment/terraform"
     echo
     echo "Attempting to deploy application version [${GIT_COMMIT}]..."


### PR DESCRIPTION
## Overview

Staging deploy build initially breaking due to invalid Github AWS credentials. To resolve:
1. Limited the permission scope of `echolocator-dev` AWS user, used for CI and infra, to `Developer` permissions group
2. Created new access key for `echolocator-dev`, stored in 1password entry 'ECHO GitHub User AWS Access', and updated Github secrets values

Also addresses breaking docker compose syntax and adds small action upgrades used in GA workflow. 

### Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] Run `./scripts/format` to lint, format, and fix the application source code.
- [x] CI passes after rebase

### Demo

Successful test build and deploy to staging in branch build: https://github.com/azavea/echo-locator/actions/runs/14043579749


## Testing Instructions

 * Confirm build of test branch successful
 * Confirm no issues deploying to staging
      * we don't have a version.txt file, so hard to test without any new development work but can confirm staging at least up by interacting with https://stg.echosearch.org/


Resolves #597 
