### PR TITLE
Update Django CSRF and cookie security settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Update docker container infra and STRTA [#604](https://github.com/azavea/echo-locator/pull/604)
 - Upgrade Postgres from version 13 to version 17 [#616](https://github.com/azavea/echo-locator/pull/616)
-- Upgrade Django from version 3.2 to 5.2 [#616](https://github.com/azavea/echo-locator/pull/616)
+- Upgrade Django from version 3.2 to 5.2 [#616](https://github.com/azavea/echo-locator/pull/616) [#622](https://github.com/azavea/echo-locator/pull/622)
 
 ### Fixed
 

--- a/src/backend/echo/settings.py
+++ b/src/backend/echo/settings.py
@@ -39,8 +39,13 @@ DEBUG = ENVIRONMENT == "Development"
 
 ALLOWED_HOSTS = []
 
+# Starting with Django 4.0, the check against
+# CSRF_TRUSTED_ORIGINS became stricter
+CSRF_TRUSTED_ORIGINS = []
+
 if "R53_PUBLIC_HOSTED_ZONE" in os.environ:
     ALLOWED_HOSTS.append(os.getenv("R53_PUBLIC_HOSTED_ZONE"))
+    CSRF_TRUSTED_ORIGINS.append(f"https://{os.getenv('R53_PUBLIC_HOSTED_ZONE')}")
 
 if ENVIRONMENT == "Development":
     ALLOWED_HOSTS.append("localhost")
@@ -217,3 +222,9 @@ if ENVIRONMENT in ["Production", "Staging"]:
     import rollbar
 
     rollbar.init(**ROLLBAR)
+
+# The cookie will be marked as “secure”
+# Browsers may ensure that the cookie is only sent
+# with an HTTPS connection.
+CSRF_COOKIE_SECURE = True
+SESSION_COOKIE_SECURE = True


### PR DESCRIPTION
## Overview

This PR:
- adds `CSRF_TRUSTED_ORIGINS` to Django settings after version upgrades and adds `R53_PUBLIC_HOSTED_ZONE` to the trusted list
- updates cookie settings based on recommended practices


### Checklist

- [ ] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] Run `./scripts/format` to lint, format, and fix the application source code.
- [ ] CI passes after rebase


### Notes

I noticed, in the admin UI, the POST endpoint to reset password succeeded, but the email doesn't send. I suspect it might have more to do with how the email backend is set up and maybe configuration needs updates on SES side as well. I am not sure. We might want to investigate a bit before opening an issue. Also not sure if this was an existing issue before the version upgrades. We could test on production and see if admin account password reset email gets sent on production or not. Plus, if resetting admin password is not something we expect to happen regularly, this might not need to be on top of the priority list.


## Testing Instructions

 * Push up `test/` branch to trigger a staging deployment
 * Log in to the staging admin site
 * Make sure it allows you to log in and perform usual admin site actions like listing objects, update an object, delete an object, create an object etc


Resolves #620 
