### PR TITLE
Update SSL cert resource creation with validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update docker container infra and STRTA [#604](https://github.com/azavea/echo-locator/pull/604)
 - Upgrade Postgres from version 13 to version 17 [#616](https://github.com/azavea/echo-locator/pull/616)
 - Upgrade Django from version 3.2 to 5.2 [#616](https://github.com/azavea/echo-locator/pull/616) [#622](https://github.com/azavea/echo-locator/pull/622)
+- Update SSL cert resource creation with validation [#623](https://github.com/azavea/echo-locator/pull/623)
 
 ### Fixed
 

--- a/deployment/terraform/certificate.tf
+++ b/deployment/terraform/certificate.tf
@@ -1,9 +1,40 @@
+# Provider hack for AWS
+# This is needed because AWS certs are only useful from us-east-1
+
+provider "aws" {
+  region = "us-east-1"
+  alias  = "us-east-1"
+}
+
 resource "aws_acm_certificate" "cert" {
-  domain_name               = var.r53_public_hosted_zone
-  subject_alternative_names = ["*.${var.r53_public_hosted_zone}"]
-  validation_method         = "DNS"
+  provider          = aws.us-east-1
+  domain_name       = var.r53_public_hosted_zone
+  validation_method = "DNS"
 
   lifecycle {
     create_before_destroy = true
   }
+}
+
+resource "aws_route53_record" "validation_app" {
+  for_each = {
+    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = aws_route53_zone.external.zone_id
+}
+
+resource "aws_acm_certificate_validation" "app" {
+  provider                = aws.us-east-1
+  certificate_arn         = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [for record in aws_route53_record.validation_app : record.fqdn]
 }


### PR DESCRIPTION
## Overview

This PR updates the SSL certificate module on the Terraform side to align with practices in recent projects
- specify provider explicitly
- add DNS validation

What's performed but not visible in the PR: I ran `terraform taint aws_acm_certificate.cert` locally pointing to the staging config bucket before letting CI do the rest of the job. It forces Terraform to replace the certificate resource entirely. This creates a brand new certificate request.

It took some trial and error to figure out what the issue was and how to fix it properly without destroying too many resources:
- The SSL cert in this app is managed by ACM and is created via Terraform. And thus we should not manually replace with new ACM certs in the console since it will mess up Terraform state, which could be more involved to handle.
- AWS should be able to automatically renew it. But somehow AWS sees it as ineligible for renewal.
- One possible reason could be that there were persistent DNS validation failures and ACM finally just gave up. It did look like the DNS validation was not done programmatically in Terraform. And there were duplicate CNAME records in both staging and production hosted zones on the Route 53 side, which I suspect were some leftovers from previous manual trial and errors, since a step of DNS validation is to add records in the corresponding hosted zones
- So instead of performing validations manually, I added some programatic validation blocks in this PR
- Also, since we want to trigger a recreate of SSL certificate, and there is actually no really resource-bound changes to trigger it, plus I did not want to manually remove it and modify Terraform state file, so I chose to run `terraform taint aws_acm_certificate.cert` to force it with the programatic validation added in the PR


### Checklist

- [ ] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] Run `./scripts/format` to lint, format, and fix the application source code.
- [ ] CI passes after rebase


## Testing Instructions

* Run the following, make sure the plan makes sense. It should not include anything significant, since the changes in this PR are already on staging through a `test` branch.
```
AWS_PROFILE=echo-locator ECHOLOCATOR_SETTINGS_BUCKET=echo-locator-stgdjango-config-us-east-1 docker compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform -c "./scripts/infra plan"
```
* Create a `test/` branch and look at CI. It should succeed with no issues.


Resolves #617 
