### PR TITLE
Add script to access running Django ECS task shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add frontend component library ADR [#614](https://github.com/azavea/echo-locator/pull/614)
+- Add `./scripts/ecs-shell <env>` script [#626](https://github.com/azavea/echo-locator/pull/626)
 
 ### Changed
 

--- a/scripts/_sourced
+++ b/scripts/_sourced
@@ -19,6 +19,19 @@ check_for_help_flag() {
     fi
 }
 
+set_environment() {
+	if [[ "$1" == "stg" ]]; then
+		export ENVIRONMENT=stg
+		export AWS_REGION=us-east-1
+	elif [[ "$1" == "prd" ]]; then
+		export ENVIRONMENT=prd
+		export AWS_REGION=us-east-1
+	else
+		echo "You need to specify an environment first (stg|prod). See _sourced/set_environment for details."
+		exit 1
+	fi
+}
+
 if [[ -n "${GIT_COMMIT}" ]]; then
     export GIT_COMMIT="${GIT_COMMIT:0:16}"
 else

--- a/scripts/_sourced
+++ b/scripts/_sourced
@@ -27,7 +27,7 @@ set_environment() {
 		export ENVIRONMENT=prd
 		export AWS_REGION=us-east-1
 	else
-		echo "You need to specify an environment first (stg|prod). See _sourced/set_environment for details."
+		echo "You need to specify an environment first (stg|prd). See _sourced/set_environment for details."
 		exit 1
 	fi
 }

--- a/scripts/ecs-shell
+++ b/scripts/ecs-shell
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+USAGE_ARG_LIST="ENVIRONMENT"
+USAGE='Get a shell on an ECS Django task.'
+
+source ./scripts/_sourced
+check_for_help_flag "$@"
+set_environment "$1"
+
+CONTAINER=django
+
+CLUSTER=$(aws ecs list-clusters | grep "${ENVIRONMENT}${CONTAINER}Cluster" |
+	tr -d '"' | tr -d "," | cut -f 2- -d "/")
+
+TASKID=$(aws ecs list-tasks \
+	--cluster "${CLUSTER}" \
+	--service-name "echo${ENVIRONMENT}${CONTAINER}App" |
+	grep "arn:aws:ecs" | head -n 1 | tr -d '"' | cut -f 3- -d "/")
+
+echo "Entering taskid $TASKID on cluster $CLUSTER"
+
+aws ecs execute-command --region $AWS_REGION --cluster $CLUSTER --task $TASKID --container $CONTAINER \
+	--command "/bin/bash" --interactive


### PR DESCRIPTION
## Overview

As a part of https://github.com/azavea/echo-locator/issues/618 and some recent infra-related work, we often need to establish a connection to the running Django container on Staging or Production to perform checks etc.

This PR updates the `_sourced` script and adds a `ecs-shell <env>` script to make it handy for such a connection.


### Checklist

- [ ] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] Run `./scripts/format` to lint, format, and fix the application source code.
- [ ] CI passes after rebase

### Notes

The `infra` script will need updates now that we have a `set_environment` method in `_sourced`, so that we can parameterize the CI scripts for staging and production releases.

We should take care of it in https://github.com/azavea/echo-locator/issues/621


## Testing Instructions

 * `export AWS_PROFILE=echo-locator` (assuming this is how you named the profile`
 * `./scripts/ecs-shell stg` should get you access to the running Django container on staging
 * `./scripts/ecs-shell prd` should get you access to the running Django container on production


Resolves #618 
