### PR TITLE
Add mobile translations subheader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add a styled Button component [#667](https://github.com/azavea/echo-locator/pull/667)
 - Add a styled Button Group component [#668](https://github.com/azavea/echo-locator/pull/668)
 - Add user profile subheader components [#668](https://github.com/azavea/echo-locator/pull/668)
+- Add mobile translations subheader component [#672](https://github.com/azavea/echo-locator/pull/672)
 
 ### Changed
 

--- a/src/frontend/src/components/SelectLanguageButtons.tsx
+++ b/src/frontend/src/components/SelectLanguageButtons.tsx
@@ -27,12 +27,13 @@ const SelectLanguageButtons = ({ language }: Props) => {
 
     return (
         <RadioButtonGroup
+            aria-label="Select a language"
             value={selectedLanguage}
             onChange={setSelectedLanguage}
         >
-            <RadioButton value={Languages.EN} label="English" />
-            <RadioButton value={Languages.ES} label="Español" />
-            <RadioButton value={Languages.ZH} label="中文" />
+            <RadioButton value={Languages.EN}>English</RadioButton>
+            <RadioButton value={Languages.ES}>Español</RadioButton>
+            <RadioButton value={Languages.ZH}>中文</RadioButton>
         </RadioButtonGroup>
     );
 };

--- a/src/frontend/src/components/SelectLanguageButtons.tsx
+++ b/src/frontend/src/components/SelectLanguageButtons.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+
+import {
+    RadioButton,
+    RadioButtonGroup,
+} from "./base/RadioButtonGroup/RadioButtonGroup";
+
+export const Languages = {
+    EN: "en",
+    ES: "es",
+    ZH: "zh",
+};
+
+type LanguageKeys = (typeof Languages)[keyof typeof Languages];
+
+interface Props {
+    language: LanguageKeys;
+}
+
+const SelectLanguageButtons = ({ language }: Props) => {
+    const [selectedLanguage, setSelectedLanguage] =
+        useState<LanguageKeys>(language);
+
+    useEffect(() => {
+        setSelectedLanguage(language);
+    }, [language]);
+
+    return (
+        <RadioButtonGroup
+            value={selectedLanguage}
+            onChange={setSelectedLanguage}
+        >
+            <RadioButton value={Languages.EN} label="English" />
+            <RadioButton value={Languages.ES} label="Español" />
+            <RadioButton value={Languages.ZH} label="中文" />
+        </RadioButtonGroup>
+    );
+};
+
+export default SelectLanguageButtons;

--- a/src/frontend/src/components/base/ButtonGroup/ButtonGroup.tsx
+++ b/src/frontend/src/components/base/ButtonGroup/ButtonGroup.tsx
@@ -3,7 +3,7 @@ import {
     Button as AriaButton,
     type GroupProps as AriaGroupProps,
     type ButtonProps as AriaButtonProps,
-    composeRenderProps as composeButtonGroupRenderProps,
+    composeRenderProps,
 } from "react-aria-components";
 import { type VariantProps } from "tailwind-variants";
 
@@ -20,7 +20,7 @@ export interface GroupedButtonProps
 const ButtonGroup = (props: AriaGroupProps) => (
     <AriaGroup
         {...props}
-        className={composeButtonGroupRenderProps(
+        className={composeRenderProps(
             props.className,
             (className, renderProps) =>
                 buttonGroupStyles({ ...renderProps, className })
@@ -39,15 +39,13 @@ const GroupedButton = ({
 }: GroupedButtonProps) => (
     <AriaButton
         {...props}
-        className={composeButtonGroupRenderProps(
-            className,
-            (className, renderProps) =>
-                groupedButtonStyles({
-                    ...renderProps,
-                    variant,
-                    size,
-                    className,
-                })
+        className={composeRenderProps(className, (className, renderProps) =>
+            groupedButtonStyles({
+                ...renderProps,
+                variant,
+                size,
+                className,
+            })
         )}
     >
         {leftIcon}

--- a/src/frontend/src/components/base/RadioButtonGroup/RadioButtonGroup.styles.ts
+++ b/src/frontend/src/components/base/RadioButtonGroup/RadioButtonGroup.styles.ts
@@ -1,0 +1,20 @@
+import { tv } from "tailwind-variants";
+
+export const radioButtonGroupStyles = tv({
+    base: "flex gap-3",
+});
+
+export const radioButtonStyles = tv({
+    base: [
+        "flex items-center justify-center rounded-[var(--spacing-4)] border px-4 py-2 h-[34px] gap-3 self-stretch flex-1",
+        "text-gray-800 text-sm font-bold transition-colors border",
+        "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-muted-blue-400 focus-visible:ring-offset-2",
+        "pressed:scale-[0.98]",
+    ],
+    variants: {
+        isSelected: {
+            true: "border-gray-500",
+            false: "border-gray-300 hover:border-gray-500",
+        },
+    },
+});

--- a/src/frontend/src/components/base/RadioButtonGroup/RadioButtonGroup.styles.ts
+++ b/src/frontend/src/components/base/RadioButtonGroup/RadioButtonGroup.styles.ts
@@ -14,7 +14,7 @@ export const radioButtonStyles = tv({
     ],
     variants: {
         isSelected: {
-            true: "border-gray-500",
+            true: "border-gray-300 bg-gray-100 text-gray-900",
             false: "border-gray-300 hover:border-gray-500",
         },
         isFocusVisible: {

--- a/src/frontend/src/components/base/RadioButtonGroup/RadioButtonGroup.styles.ts
+++ b/src/frontend/src/components/base/RadioButtonGroup/RadioButtonGroup.styles.ts
@@ -1,20 +1,24 @@
 import { tv } from "tailwind-variants";
 
 export const radioButtonGroupStyles = tv({
-    base: "flex gap-3",
+    base: ["flex gap-3"],
 });
 
 export const radioButtonStyles = tv({
     base: [
         "flex items-center justify-center rounded-[var(--spacing-4)] border px-4 py-2 h-[34px] gap-3 self-stretch flex-1",
         "text-gray-800 text-sm font-bold transition-colors border",
-        "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-muted-blue-400 focus-visible:ring-offset-2",
+        "cursor-pointer",
         "pressed:scale-[0.98]",
+        "outline-none",
     ],
     variants: {
         isSelected: {
             true: "border-gray-500",
             false: "border-gray-300 hover:border-gray-500",
+        },
+        isFocusVisible: {
+            true: "ring-2 ring-muted-blue-600 ring-offset-2",
         },
     },
 });

--- a/src/frontend/src/components/base/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/src/frontend/src/components/base/RadioButtonGroup/RadioButtonGroup.tsx
@@ -5,18 +5,11 @@ import {
     type RadioProps as AriaRadioProps,
     composeRenderProps,
 } from "react-aria-components";
-import { type VariantProps } from "tailwind-variants";
 
 import {
     radioButtonGroupStyles,
     radioButtonStyles,
 } from "./RadioButtonGroup.styles";
-
-export interface RadioButtonProps
-    extends AriaRadioProps,
-        VariantProps<typeof radioButtonStyles> {
-    label?: string;
-}
 
 export const RadioButtonGroup = (props: AriaRadioGroupProps) => (
     <AriaRadioGroup
@@ -29,20 +22,14 @@ export const RadioButtonGroup = (props: AriaRadioGroupProps) => (
     />
 );
 
-export const RadioButton = ({
-    className,
-    label,
-    ...props
-}: RadioButtonProps) => (
+export const RadioButton = ({ className, ...props }: AriaRadioProps) => (
     <AriaRadio
         {...props}
-        className={({ isSelected }) =>
+        className={composeRenderProps(className, (className, renderProps) =>
             radioButtonStyles({
-                isSelected,
-                className: className as string,
+                ...renderProps,
+                className,
             })
-        }
-    >
-        {label && <span>{label}</span>}
-    </AriaRadio>
+        )}
+    />
 );

--- a/src/frontend/src/components/base/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/src/frontend/src/components/base/RadioButtonGroup/RadioButtonGroup.tsx
@@ -1,0 +1,48 @@
+import {
+    RadioGroup as AriaRadioGroup,
+    Radio as AriaRadio,
+    type RadioGroupProps as AriaRadioGroupProps,
+    type RadioProps as AriaRadioProps,
+    composeRenderProps,
+} from "react-aria-components";
+import { type VariantProps } from "tailwind-variants";
+
+import {
+    radioButtonGroupStyles,
+    radioButtonStyles,
+} from "./RadioButtonGroup.styles";
+
+export interface RadioButtonProps
+    extends AriaRadioProps,
+        VariantProps<typeof radioButtonStyles> {
+    label?: string;
+}
+
+export const RadioButtonGroup = (props: AriaRadioGroupProps) => (
+    <AriaRadioGroup
+        {...props}
+        className={composeRenderProps(
+            props.className,
+            (className, renderProps) =>
+                radioButtonGroupStyles({ ...renderProps, className })
+        )}
+    />
+);
+
+export const RadioButton = ({
+    className,
+    label,
+    ...props
+}: RadioButtonProps) => (
+    <AriaRadio
+        {...props}
+        className={({ isSelected }) =>
+            radioButtonStyles({
+                isSelected,
+                className: className as string,
+            })
+        }
+    >
+        {label && <span>{label}</span>}
+    </AriaRadio>
+);

--- a/src/frontend/src/pages/Components.tsx
+++ b/src/frontend/src/pages/Components.tsx
@@ -5,6 +5,9 @@ import {
     UserProfileSubheaderMobile,
 } from "components/UserProfileSubheader";
 import CompareFavoritesButton from "components/CompareFavoritesButton";
+import SelectLanguageButtons, {
+    Languages,
+} from "components/SelectLanguageButtons";
 
 import ArrowLeftIcon from "assets/icons/arrow-left.svg?react";
 import ArrowRightIcon from "assets/icons/arrow-right.svg?react";
@@ -251,6 +254,17 @@ const Components = () => {
                                 mode="transit"
                                 place={Places.Doctor}
                             />
+                        </div>
+                    </div>
+                </section>
+
+                <section className="p-8 bg-white border border-gray-200 rounded-lg shadow-sm">
+                    <h2 className="text-3xl font-medium text-gray-800 mb-8 pb-4 border-b">
+                        Radio Button Group
+                    </h2>
+                    <div className="space-y-8">
+                        <div className="flex flex-col gap-4 w-[272px]">
+                            <SelectLanguageButtons language={Languages.EN} />
                         </div>
                     </div>
                 </section>


### PR DESCRIPTION
## Overview

This PR builds on top of [`RadioGroup`](https://react-spectrum.adobe.com/react-aria/RadioGroup.html) from React Aria and creates the translations subheader component.

I ended up using `RadioGroup` rather than the button group, because there should always be one option selected, which makes a radio group semantically closer to the use case.


Tagging @philippschmitt for styling improvements.

### Checklist

- [ ] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] Run `./scripts/format` to lint, format, and fix the application source code.
- [ ] CI passes after rebase

### Demo


![Screenshot 2025-07-01 at 6 28 59 PM](https://github.com/user-attachments/assets/8a3d2e65-73dc-42ee-a25d-4f0a93ee8da0)



## Testing Instructions

 * `./scripts/update` and `./scripts/server`
 * Go to http://localhost:9966/components
 * Click on the buttons in the "Radio Button Group" section, and make sure the clicked option's button border is outlined


Resolves https://github.com/azavea/echo-locator/issues/649
