### PR TITLE
Add bar charts: Neighborhood Criteria and Commute Time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add mobile translations subheader component [#672](https://github.com/azavea/echo-locator/pull/672)
 - Add data fixture and update scripts [#673](https://github.com/azavea/echo-locator/pull/673)
 - Add responsive menu component [#674](https://github.com/azavea/echo-locator/pull/674)
+- Add bar charts: Neighborhood Criteria and Commute Time [#675](https://github.com/azavea/echo-locator/pull/675)
 
 ### Changed
 

--- a/src/frontend/src/assets/icons/dots.svg
+++ b/src/frontend/src/assets/icons/dots.svg
@@ -1,0 +1,5 @@
+<svg width="8" height="2" viewBox="0 0 8 2" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="1" cy="1" r="1" fill="white"/>
+<circle cx="4" cy="1" r="1" fill="white"/>
+<circle cx="7" cy="1" r="1" fill="white"/>
+</svg>

--- a/src/frontend/src/components/base/Meter/Meter.styles.ts
+++ b/src/frontend/src/components/base/Meter/Meter.styles.ts
@@ -1,0 +1,22 @@
+import { tv } from "tailwind-variants";
+
+export const meterStyles = tv({
+    slots: {
+        root: "flex flex-col gap-3 w-full ",
+        labelContainer: "flex flex-col",
+        mainLabel: "text-sm text-gray-600",
+        valueLabel: "text-sm font-bold text-black",
+        track: "absolute top-1 h-1 w-full rounded-[var(--spacing-1)] bg-gray-300",
+        fill: "absolute h-[6px] rounded-[var(--spacing-1)]",
+        thumb: "absolute rounded-[var(--spacing-1)] top-[3px] h-4 w-2 -translate-y-1/2 left-[calc(50%-2px)] bg-gray-500 border border-white",
+    },
+    variants: {
+        status: {
+            low: { fill: "bg-low" },
+            belowAvg: { fill: "bg-below-avg" },
+            average: { fill: "bg-avg" },
+            aboveAvg: { fill: "bg-above-avg" },
+            high: { fill: "bg-high" },
+        },
+    },
+});

--- a/src/frontend/src/components/base/Meter/Meter.styles.ts
+++ b/src/frontend/src/components/base/Meter/Meter.styles.ts
@@ -2,10 +2,10 @@ import { tv } from "tailwind-variants";
 
 export const meterStyles = tv({
     slots: {
-        root: "flex flex-col gap-3 w-full ",
+        root: "flex flex-col gap-2 w-full ",
         labelContainer: "flex flex-col",
         mainLabel: "text-sm text-gray-600",
-        valueLabel: "text-sm font-bold text-black",
+        valueLabel: "text-sm font-bold text-black -mt-1 mb-[1px]",
         track: "absolute top-1 h-1 w-full rounded-[var(--spacing-1)] bg-gray-300",
         fill: "absolute h-[6px] rounded-[var(--spacing-1)]",
         thumb: "absolute rounded-[var(--spacing-1)] top-[3px] h-4 w-2 -translate-y-1/2 left-[calc(50%-2px)] bg-gray-500 border border-white",

--- a/src/frontend/src/components/base/Meter/Meter.styles.ts
+++ b/src/frontend/src/components/base/Meter/Meter.styles.ts
@@ -12,11 +12,11 @@ export const meterStyles = tv({
     },
     variants: {
         status: {
-            low: { fill: "bg-low" },
-            belowAvg: { fill: "bg-below-avg" },
-            average: { fill: "bg-avg" },
-            aboveAvg: { fill: "bg-above-avg" },
-            high: { fill: "bg-high" },
+            Low: { fill: "bg-low" },
+            "Below Avg": { fill: "bg-below-avg" },
+            Average: { fill: "bg-avg" },
+            "Above Avg": { fill: "bg-above-avg" },
+            High: { fill: "bg-high" },
         },
     },
 });

--- a/src/frontend/src/components/base/Meter/Meter.tsx
+++ b/src/frontend/src/components/base/Meter/Meter.tsx
@@ -6,22 +6,22 @@ import {
 
 import { meterStyles } from "./Meter.styles";
 
-type MeterStatus = "low" | "belowAvg" | "average" | "aboveAvg" | "high";
+type MeterStatus = "Low" | "Below Avg" | "Average" | "Above Avg" | "High";
 
 interface CustomMeterProps extends AriaMeterProps {
     label: string;
-    category?: string;
+    showCategory?: boolean;
 }
 
 const getStatusFromValue = (value: number): MeterStatus => {
-    if (value <= 20) return "low";
-    if (value <= 40) return "belowAvg";
-    if (value <= 60) return "average";
-    if (value <= 80) return "aboveAvg";
-    return "high";
+    if (value <= 20) return "Low";
+    if (value <= 40) return "Below Avg";
+    if (value <= 60) return "Average";
+    if (value <= 80) return "Above Avg";
+    return "High";
 };
 
-const Meter = ({ label, category, ...props }: CustomMeterProps) => {
+const Meter = ({ label, showCategory = false, ...props }: CustomMeterProps) => {
     const status = getStatusFromValue(props.value ?? 0);
     const { root, labelContainer, mainLabel, valueLabel, track, fill, thumb } =
         meterStyles({ status });
@@ -32,9 +32,9 @@ const Meter = ({ label, category, ...props }: CustomMeterProps) => {
                 <>
                     <div className={labelContainer()}>
                         <AriaLabel className={mainLabel()}>{label}</AriaLabel>
-                        {category && (
+                        {showCategory && (
                             <AriaLabel className={valueLabel()}>
-                                {category}
+                                {status}
                             </AriaLabel>
                         )}
                     </div>
@@ -42,7 +42,7 @@ const Meter = ({ label, category, ...props }: CustomMeterProps) => {
                         <div className={track()}></div>
                         <div
                             className={fill()}
-                            style={{ width: `${percentage}%` }}
+                            style={{ width: `${percentage}%`, minWidth: "6px" }}
                         />
                         <div className={thumb()} />
                     </div>

--- a/src/frontend/src/components/base/Meter/Meter.tsx
+++ b/src/frontend/src/components/base/Meter/Meter.tsx
@@ -1,0 +1,55 @@
+import {
+    Meter as AriaMeter,
+    Label as AriaLabel,
+    type MeterProps as AriaMeterProps,
+} from "react-aria-components";
+
+import { meterStyles } from "./Meter.styles";
+
+type MeterStatus = "low" | "belowAvg" | "average" | "aboveAvg" | "high";
+
+interface CustomMeterProps extends AriaMeterProps {
+    label: string;
+    category?: string;
+}
+
+const getStatusFromValue = (value: number): MeterStatus => {
+    if (value <= 20) return "low";
+    if (value <= 40) return "belowAvg";
+    if (value <= 60) return "average";
+    if (value <= 80) return "aboveAvg";
+    return "high";
+};
+
+const Meter = ({ label, category, ...props }: CustomMeterProps) => {
+    const status = getStatusFromValue(props.value ?? 0);
+    const { root, labelContainer, mainLabel, valueLabel, track, fill, thumb } =
+        meterStyles({ status });
+
+    return (
+        <AriaMeter {...props} className={root()}>
+            {({ percentage }) => (
+                <>
+                    <div className={labelContainer()}>
+                        <AriaLabel className={mainLabel()}>{label}</AriaLabel>
+                        {category && (
+                            <AriaLabel className={valueLabel()}>
+                                {category}
+                            </AriaLabel>
+                        )}
+                    </div>
+                    <div className="relative">
+                        <div className={track()}></div>
+                        <div
+                            className={fill()}
+                            style={{ width: `${percentage}%` }}
+                        />
+                        <div className={thumb()} />
+                    </div>
+                </>
+            )}
+        </AriaMeter>
+    );
+};
+
+export default Meter;

--- a/src/frontend/src/components/base/Range/Range.styles.ts
+++ b/src/frontend/src/components/base/Range/Range.styles.ts
@@ -7,6 +7,7 @@ export const rangeStyles = tv({
         mainLabel: "text-sm text-gray-600",
         rangeLabel: "text-sm font-bold text-black",
         track: "absolute top-1 h-1 w-full rounded-[var(--spacing-1)] bg-gray-300",
-        fill: "flex flex-col absolute h-[6px] rounded-[var(--spacing-1)] bg-gray-500",
+        fill: "flex flex-row justify-end absolute h-[6px] rounded-[var(--spacing-1)] bg-gray-500",
+        dots: "m-1 w-3",
     },
 });

--- a/src/frontend/src/components/base/Range/Range.styles.ts
+++ b/src/frontend/src/components/base/Range/Range.styles.ts
@@ -11,7 +11,7 @@ export const rangeStyles = tv({
     },
     variants: {
         variant: {
-            point: { fill: "rounded-full" },
+            point: {},
         },
     },
 });

--- a/src/frontend/src/components/base/Range/Range.styles.ts
+++ b/src/frontend/src/components/base/Range/Range.styles.ts
@@ -7,11 +7,6 @@ export const rangeStyles = tv({
         mainLabel: "text-sm text-gray-600",
         rangeLabel: "text-sm font-bold text-black",
         track: "absolute top-1 h-1 w-full rounded-[var(--spacing-1)] bg-gray-300",
-        fill: "absolute h-[6px] rounded-[var(--spacing-1)] bg-gray-500",
-    },
-    variants: {
-        variant: {
-            point: {},
-        },
+        fill: "flex flex-col absolute h-[6px] rounded-[var(--spacing-1)] bg-gray-500",
     },
 });

--- a/src/frontend/src/components/base/Range/Range.styles.ts
+++ b/src/frontend/src/components/base/Range/Range.styles.ts
@@ -1,0 +1,17 @@
+import { tv } from "tailwind-variants";
+
+export const rangeStyles = tv({
+    slots: {
+        root: "flex flex-col gap-3 w-full",
+        labelContainer: "flex flex-col",
+        mainLabel: "text-sm text-gray-600",
+        rangeLabel: "text-sm font-bold text-black",
+        track: "absolute top-1 h-1 w-full rounded-[var(--spacing-1)] bg-gray-300",
+        fill: "absolute h-[6px] rounded-[var(--spacing-1)] bg-gray-500",
+    },
+    variants: {
+        variant: {
+            point: { fill: "rounded-full" },
+        },
+    },
+});

--- a/src/frontend/src/components/base/Range/Range.tsx
+++ b/src/frontend/src/components/base/Range/Range.tsx
@@ -22,7 +22,7 @@ const Range = ({
     min = MIN_DEFAULT,
     max = MAX_DEFAULT,
 }: RangeDisplayProps) => {
-    const { root, labelContainer, mainLabel, rangeLabel, track, fill } =
+    const { root, labelContainer, mainLabel, rangeLabel, track, fill, dots } =
         rangeStyles();
 
     const isPoint = start === end;
@@ -54,15 +54,18 @@ const Range = ({
                                     ? "0px"
                                     : isPoint
                                       ? `calc(${startPercentage}% - 4px)`
-                                      : `${startPercentage}%`,
+                                      : end >= 120
+                                        ? `min(calc(100% - 12px), ${startPercentage}%)`
+                                        : `${startPercentage}%`,
                             width: `${widthPercentage}%`,
-                            minWidth: "6px",
+                            minWidth: end >= 120 ? "12px" : "6px",
                         }}
                     >
-                        {/* TODO: Add and style the dots icon here */}
-                        {/* {!isPoint && end >= 120 && (
-                            <DotIcon />
-                        )} */}
+                        {!isPoint && end >= 120 && (
+                            <span className={dots()}>
+                                <DotIcon />
+                            </span>
+                        )}
                     </div>
                 )}
             </div>

--- a/src/frontend/src/components/base/Range/Range.tsx
+++ b/src/frontend/src/components/base/Range/Range.tsx
@@ -1,0 +1,55 @@
+import { rangeStyles } from "./Range.styles";
+
+const MIN_DEFAULT = 0;
+const MAX_DEFAULT = 120;
+
+interface RangeDisplayProps {
+    label: string;
+    rangeText: string;
+    start: number;
+    end: number;
+    className?: string;
+    min?: number;
+    max?: number;
+}
+
+const Range = ({
+    label,
+    rangeText,
+    start,
+    end,
+    className,
+    min = MIN_DEFAULT,
+    max = MAX_DEFAULT,
+}: RangeDisplayProps) => {
+    const { root, labelContainer, mainLabel, rangeLabel, track, fill } =
+        rangeStyles();
+
+    const isPoints = start === end;
+    const totalRange = max - min;
+    const startPercentage = ((start - min) / totalRange) * 100;
+    const widthPercentage = ((end - start) / totalRange) * 100 || 8;
+
+    return (
+        <div className={root({ className })}>
+            <div className={labelContainer()}>
+                <span className={mainLabel()}>{label}</span>
+                <span className={rangeLabel()}>{rangeText}</span>
+            </div>
+            <div className="relative">
+                <div className={track()}></div>
+                <div
+                    className={isPoints ? fill({ variant: "point" }) : fill()}
+                    style={{
+                        left: isPoints
+                            ? `calc(${startPercentage}% - 4px)`
+                            : `${startPercentage}%`,
+                        width: `${widthPercentage}%`,
+                    }}
+                />
+            </div>
+        </div>
+    );
+};
+
+export default Range;

--- a/src/frontend/src/components/base/Range/Range.tsx
+++ b/src/frontend/src/components/base/Range/Range.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { rangeStyles } from "./Range.styles";
+import DotIcon from "assets/icons/dots.svg?react";
 
 const MIN_DEFAULT = 0;
 const MAX_DEFAULT = 120;

--- a/src/frontend/src/components/base/Range/Range.tsx
+++ b/src/frontend/src/components/base/Range/Range.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { rangeStyles } from "./Range.styles";
 
 const MIN_DEFAULT = 0;
@@ -5,7 +6,6 @@ const MAX_DEFAULT = 120;
 
 interface RangeDisplayProps {
     label: string;
-    rangeText: string;
     start: number;
     end: number;
     className?: string;
@@ -15,7 +15,6 @@ interface RangeDisplayProps {
 
 const Range = ({
     label,
-    rangeText,
     start,
     end,
     className,
@@ -25,10 +24,17 @@ const Range = ({
     const { root, labelContainer, mainLabel, rangeLabel, track, fill } =
         rangeStyles();
 
-    const isPoints = start === end;
+    const isPoint = start === end;
     const totalRange = max - min;
     const startPercentage = ((start - min) / totalRange) * 100;
-    const widthPercentage = ((end - start) / totalRange) * 100 || 8;
+    const widthPercentage =
+        ((Math.min(end, MAX_DEFAULT) - start) / totalRange) * 100 || 8;
+
+    const rangeText = useMemo(() => {
+        if (start >= 120) return "Over 2 hr";
+        if (isPoint) return `${start} min`;
+        return `${start}-${end} min`;
+    }, [start, end]);
 
     return (
         <div className={root({ className })}>
@@ -38,15 +44,26 @@ const Range = ({
             </div>
             <div className="relative">
                 <div className={track()}></div>
-                <div
-                    className={isPoints ? fill({ variant: "point" }) : fill()}
-                    style={{
-                        left: isPoints
-                            ? `calc(${startPercentage}% - 4px)`
-                            : `${startPercentage}%`,
-                        width: `${widthPercentage}%`,
-                    }}
-                />
+                {start < 120 && (
+                    <div
+                        className={fill()}
+                        style={{
+                            left:
+                                startPercentage === 0
+                                    ? "0px"
+                                    : isPoint
+                                      ? `calc(${startPercentage}% - 4px)`
+                                      : `${startPercentage}%`,
+                            width: `${widthPercentage}%`,
+                            minWidth: "6px",
+                        }}
+                    >
+                        {/* TODO: Add and style the dots icon here */}
+                        {/* {!isPoint && end >= 120 && (
+                            <DotIcon />
+                        )} */}
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/src/frontend/src/pages/Components.tsx
+++ b/src/frontend/src/pages/Components.tsx
@@ -8,6 +8,8 @@ import CompareFavoritesButton from "components/CompareFavoritesButton";
 import SelectLanguageButtons, {
     Languages,
 } from "components/SelectLanguageButtons";
+import Meter from "components/base/Meter/Meter";
+import Range from "components/base/Range/Range";
 
 import ArrowLeftIcon from "assets/icons/arrow-left.svg?react";
 import ArrowRightIcon from "assets/icons/arrow-right.svg?react";
@@ -227,6 +229,7 @@ const Components = () => {
                 </div>
             </section>
 
+            {/* Button group section */}
             <section className="p-8 bg-white border border-gray-200 rounded-lg shadow-sm">
                 <h2 className="text-3xl font-medium text-gray-800 mb-8 pb-4 border-b">
                     Radio Button Group
@@ -234,6 +237,71 @@ const Components = () => {
                 <div className="space-y-8">
                     <div className="flex flex-col gap-4 w-[272px]">
                         <SelectLanguageButtons language={Languages.EN} />
+                    </div>
+                </div>
+            </section>
+
+            {/* Bar chart section */}
+            <section className="p-8 bg-white border border-gray-200 rounded-lg shadow-sm">
+                <h2 className="text-3xl font-medium text-gray-800 mb-8 pb-4 border-b">
+                    Bar charts
+                </h2>
+                <div className="flex space-y-8 gap-13">
+                    <div className="flex flex-col items-center gap-8 w-13">
+                        <Meter label="Schools" value={1} />
+                        <Meter label="Schools" value={10} />
+                        <Meter label="Schools" value={25} />
+                        <Meter label="Schools" value={50} />
+                        <Meter label="Schools" value={75} />
+                        <Meter label="Schools" value={90} />
+                    </div>
+                    <div className="flex flex-col items-center gap-8 w-13">
+                        <Meter label="Schools" category="Low" value={10} />
+                        <Meter
+                            label="Schools"
+                            category="Below Avg"
+                            value={25}
+                        />
+
+                        <Meter label="Schools" category="Average" value={50} />
+                        <Meter
+                            label="Schools"
+                            category="Above Avg"
+                            value={75}
+                        />
+                        <Meter label="Schools" category="High" value={90} />
+                    </div>
+                    <div className="flex flex-col items-center gap-8 w-13">
+                        <Range
+                            label="Commute"
+                            rangeText="30-60 min"
+                            start={30}
+                            end={60}
+                        />
+                        <Range
+                            label="Commute"
+                            rangeText="0 min"
+                            start={0}
+                            end={0}
+                        />
+                        <Range
+                            label="Commute"
+                            rangeText="60 min"
+                            start={60}
+                            end={60}
+                        />
+                        <Range
+                            label="Commute"
+                            rangeText="58-60 min"
+                            start={58}
+                            end={60}
+                        />
+                        <Range
+                            label="Commute"
+                            rangeText="120 min"
+                            start={120}
+                            end={120}
+                        />
                     </div>
                 </div>
             </section>

--- a/src/frontend/src/pages/Components.tsx
+++ b/src/frontend/src/pages/Components.tsx
@@ -247,7 +247,8 @@ const Components = () => {
                     Bar charts
                 </h2>
                 <div className="flex space-y-8 gap-13">
-                    <div className="flex flex-col items-center gap-8 w-13">
+                    <div className="flex flex-col items-start gap-8 w-13">
+                        <h3 className="text-xl text-gray-800 mb-2">Criteria</h3>
                         <Meter label="Schools" value={1} />
                         <Meter label="Schools" value={10} />
                         <Meter label="Schools" value={25} />
@@ -255,53 +256,32 @@ const Components = () => {
                         <Meter label="Schools" value={75} />
                         <Meter label="Schools" value={90} />
                     </div>
-                    <div className="flex flex-col items-center gap-8 w-13">
-                        <Meter label="Schools" category="Low" value={10} />
-                        <Meter
-                            label="Schools"
-                            category="Below Avg"
-                            value={25}
-                        />
-
-                        <Meter label="Schools" category="Average" value={50} />
-                        <Meter
-                            label="Schools"
-                            category="Above Avg"
-                            value={75}
-                        />
-                        <Meter label="Schools" category="High" value={90} />
+                    <div className="flex flex-col items-start gap-8 w-13">
+                        <h3 className="text-xl text-gray-800 mb-2">Criteria</h3>
+                        <Meter label="Schools" value={10} showCategory />
+                        <Meter label="Schools" value={25} showCategory />
+                        <Meter label="Schools" value={50} showCategory />
+                        <Meter label="Schools" value={75} showCategory />
+                        <Meter label="Schools" value={90} showCategory />
                     </div>
-                    <div className="flex flex-col items-center gap-8 w-13">
-                        <Range
-                            label="Commute"
-                            rangeText="30-60 min"
-                            start={30}
-                            end={60}
-                        />
-                        <Range
-                            label="Commute"
-                            rangeText="0 min"
-                            start={0}
-                            end={0}
-                        />
-                        <Range
-                            label="Commute"
-                            rangeText="60 min"
-                            start={60}
-                            end={60}
-                        />
-                        <Range
-                            label="Commute"
-                            rangeText="58-60 min"
-                            start={58}
-                            end={60}
-                        />
-                        <Range
-                            label="Commute"
-                            rangeText="120 min"
-                            start={120}
-                            end={120}
-                        />
+                    <div className="flex flex-col items-start gap-8 w-13">
+                        <h3 className="text-xl text-gray-800 mb-2">Car</h3>
+                        <Range label="Commute" start={0} end={0} />
+                        <Range label="Commute" start={60} end={60} />
+                        <Range label="Commute" start={119} end={119} />
+                        <Range label="Commute" start={120} end={120} />
+                        <Range label="Commute" start={130} end={130} />
+                    </div>
+                    <div className="flex flex-col items-start gap-8 w-13">
+                        <h3 className="text-xl text-gray-800 mb-2">Transit</h3>
+                        <Range label="Commute" start={0} end={20} />
+                        <Range label="Commute" start={30} end={60} />
+                        <Range label="Commute" start={58} end={60} />
+                        <Range label="Commute" start={80} end={150} />
+                        <Range label="Commute" start={100} end={130} />
+                        <Range label="Commute" start={110} end={120} />
+                        <Range label="Commute" start={119} end={139} />
+                        <Range label="Commute" start={120} end={150} />
                     </div>
                 </div>
             </section>

--- a/src/frontend/src/theme.css
+++ b/src/frontend/src/theme.css
@@ -61,6 +61,13 @@
     --color-orange-900: #7c2c12;
     --color-orange-950: #431307;
 
+    /* Criteria Scale */
+    --color-low: #e55a1a;
+    --color-below-avg: #e5990c;
+    --color-avg: #7ec200;
+    --color-above-avg: #20c200;
+    --color-high: #1eb400;
+
     /* Spacing Scale (for padding, margin, width, height, gap, etc.) */
     --spacing-1: 0.125rem; /* 2px */
     --spacing-2: 0.25rem; /* 4px */


### PR DESCRIPTION
## Overview

This PR is branched out from https://github.com/azavea/echo-locator/pull/674:
- adds a customized Range component for Commute Time
- adds a customized Meter component for Neighborhood Criteria

@philippschmitt there might be styling rough edges that need your care.


### Checklist

- [ ] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] Run `./scripts/format` to lint, format, and fix the application source code.
- [ ] CI passes after rebase

### Demo

![Screenshot 2025-07-05 at 7 31 14 PM](https://github.com/user-attachments/assets/846b7042-5943-4f31-a392-747eade92fab)


## Testing Instructions

 * `./scripts/update` and `./scripts/server`
 * Go to http://localhost:9966/components and make sure the bar charts section has example uses of Range and Meter components for Neighborhood Criteria and Commute Time

Resolves #652 
Resolves #653 
