### PR TITLE
Add Modal base component and use it in the top menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add user profile subheader components [#668](https://github.com/azavea/echo-locator/pull/668)
 - Add mobile translations subheader component [#672](https://github.com/azavea/echo-locator/pull/672)
 - Add data fixture and update scripts [#673](https://github.com/azavea/echo-locator/pull/673)
-- Add responsive menu component [#674](https://github.com/azavea/echo-locator/pull/674)
+- Add responsive menu component [#674](https://github.com/azavea/echo-locator/pull/674) [#682](https://github.com/azavea/echo-locator/pull/682)
 - Add bar charts: Neighborhood Criteria and Commute Time [#675](https://github.com/azavea/echo-locator/pull/675)
 - Add Neighborhood Card [#678](https://github.com/azavea/echo-locator/pull/678)
 - Add input components: Text, Number, Checkbox, Slider [#677](https://github.com/azavea/echo-locator/pull/677)
 - Add static translations support [#679](https://github.com/azavea/echo-locator/pull/679)
+- Add modal dialog component [#682](https://github.com/azavea/echo-locator/pull/682)
 
 ### Changed
 

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -32,6 +32,7 @@
         "react-router": "^7.6.2",
         "tailwind-variants": "^1.0.0",
         "tailwindcss": "^4.1.10",
+        "tailwindcss-animate": "^1.0.7",
         "tailwindcss-react-aria-components": "^2.0.0",
         "vite-plugin-svgr": "^4.3.0"
     },

--- a/src/frontend/src/components/Menu.tsx
+++ b/src/frontend/src/components/Menu.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
+import { Dialog } from "react-aria-components";
 
 import Button from "./base/Button/Button";
 import NavTab from "./base/NavTab/NavTab";
@@ -11,6 +13,8 @@ import {
 import useMediaQuery from "hooks/useMediaQuery";
 import getPathByLang from "libs/getPathByLang";
 import { Language, type LanguageKey } from "src/enums";
+import { Modal, ModalOverlay } from "./base/Modal/Modal";
+import SelectLanguageButtons from "./SelectLanguageButtons";
 
 import EchoTextLogo from "assets/icons/echo-logo-text.svg?react";
 import EchoLogo from "assets/icons/echo-logo.svg?react";
@@ -28,9 +32,15 @@ const Menu = ({ languages, compareCount }: Props) => {
     const location = useLocation();
     const { t, i18n } = useTranslation();
     const isDesktop = useMediaQuery("(min-width: 768px)");
+    const [isOpen, setIsOpen] = useState(false);
 
     const onChangeLanguage = (key: React.Key) => {
         navigate(getPathByLang(key as string, location.pathname));
+    };
+
+    const onLogout = () => {
+        // TODO: implement the logout logic
+        setIsOpen(false);
     };
 
     return (
@@ -96,13 +106,41 @@ const Menu = ({ languages, compareCount }: Props) => {
                         </Button>
                     </>
                 ) : (
-                    // TODO: Implement the hamburger menu, pending design
-                    <Button
-                        variant="ghost"
-                        leftIcon={
-                            <HamburgerIcon className="fill fill-teal-900 text-sm h-5 w-5 font-normal" />
-                        }
-                    />
+                    <>
+                        <Button
+                            variant="ghost"
+                            leftIcon={
+                                <HamburgerIcon className="fill fill-teal-900 text-sm h-5 w-5 font-normal" />
+                            }
+                            onPress={() => setIsOpen(true)}
+                        />
+                        <ModalOverlay
+                            isDismissable
+                            isOpen={isOpen}
+                            onOpenChange={setIsOpen}
+                        >
+                            <Modal isOpen={isOpen}>
+                                <Dialog>
+                                    <div className="flex flex-col p-5 align-middle">
+                                        <SelectLanguageButtons
+                                            language={lang || Language.EN}
+                                            callback={() => setIsOpen(false)}
+                                        />
+                                    </div>
+                                    <div className="w-full h-px bg-gray-300"></div>
+                                    <div className="flex flex-col p-5 align-middle">
+                                        <Button
+                                            variant="outline"
+                                            className="normal-case text-teal-800"
+                                            onPress={onLogout}
+                                        >
+                                            {t("logout")}
+                                        </Button>
+                                    </div>
+                                </Dialog>
+                            </Modal>
+                        </ModalOverlay>
+                    </>
                 )}
             </div>
         </div>

--- a/src/frontend/src/components/Menu.tsx
+++ b/src/frontend/src/components/Menu.tsx
@@ -119,8 +119,8 @@ const Menu = ({ languages, compareCount }: Props) => {
                             isOpen={isOpen}
                             onOpenChange={setIsOpen}
                         >
-                            <Modal isOpen={isOpen}>
-                                <Dialog>
+                            <Modal>
+                                <Dialog aria-label="Menu">
                                     <div className="flex flex-col p-5 align-middle">
                                         <SelectLanguageButtons
                                             language={lang || Language.EN}

--- a/src/frontend/src/components/SelectLanguageButtons.tsx
+++ b/src/frontend/src/components/SelectLanguageButtons.tsx
@@ -10,14 +10,16 @@ import { languageToLabel } from "src/constants";
 
 interface Props {
     language: LanguageKey;
+    callback?: () => void;
 }
 
-const SelectLanguageButtons = ({ language }: Props) => {
+const SelectLanguageButtons = ({ language, callback = () => {} }: Props) => {
     const navigate = useNavigate();
     const location = useLocation();
 
     const onChangeLanguage = (key: React.Key) => {
         navigate(getPathByLang(key as string, location.pathname));
+        callback();
     };
 
     return (

--- a/src/frontend/src/components/base/Modal/Modal.styles.ts
+++ b/src/frontend/src/components/base/Modal/Modal.styles.ts
@@ -4,10 +4,10 @@ export const modalOverlayStyles = tv({
     base: "fixed inset-0 z-50 bg-black/60 backdrop-blur-sm",
     variants: {
         isEntering: {
-            true: "animate-in fade-in",
+            true: "animate-in fade-in duration-300 ease-out",
         },
         isExiting: {
-            true: "animate-out fade-out",
+            true: "animate-out fade-out duration-200 ease-in",
         },
     },
 });
@@ -19,10 +19,10 @@ export const modalStyles = tv({
     ],
     variants: {
         isEntering: {
-            true: "animate-in zoom-in-95 fade-in",
+            true: "animate-in zoom-in-95 ease-out duration-300",
         },
         isExiting: {
-            true: "animate-out zoom-out-95 fade-out",
+            true: "animate-out zoom-out-95 ease-in duration-200",
         },
     },
 });

--- a/src/frontend/src/components/base/Modal/Modal.styles.ts
+++ b/src/frontend/src/components/base/Modal/Modal.styles.ts
@@ -1,0 +1,28 @@
+import { tv } from "tailwind-variants";
+
+export const modalOverlayStyles = tv({
+    base: "fixed inset-0 z-50 bg-black/60 backdrop-blur-sm",
+    variants: {
+        isEntering: {
+            true: "animate-in fade-in",
+        },
+        isExiting: {
+            true: "animate-out fade-out",
+        },
+    },
+});
+
+export const modalStyles = tv({
+    base: [
+        "fixed top-1/2 left-1/2 z-50 w-[95%] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-[var(--spacing-4)]",
+        "bg-white shadow-md",
+    ],
+    variants: {
+        isEntering: {
+            true: "animate-in zoom-in-95 fade-in",
+        },
+        isExiting: {
+            true: "animate-out zoom-out-95 fade-out",
+        },
+    },
+});

--- a/src/frontend/src/components/base/Modal/Modal.tsx
+++ b/src/frontend/src/components/base/Modal/Modal.tsx
@@ -1,0 +1,35 @@
+import {
+    Modal as AriaModal,
+    ModalOverlay as AriaModalOverlay,
+    type ModalOverlayProps as AriaModalOverlayProps,
+    type ModalOverlayProps as AriaModalProps,
+    composeRenderProps,
+} from "react-aria-components";
+import { modalOverlayStyles, modalStyles } from "./Modal.styles";
+
+export const ModalOverlay = ({
+    className,
+    ...props
+}: AriaModalOverlayProps) => (
+    <AriaModalOverlay
+        {...props}
+        className={composeRenderProps(className, (className, renderProps) =>
+            modalOverlayStyles({
+                ...renderProps,
+                className,
+            })
+        )}
+    />
+);
+
+export const Modal = ({ className, ...props }: AriaModalProps) => (
+    <AriaModal
+        {...props}
+        className={composeRenderProps(className, (className, renderProps) =>
+            modalStyles({
+                ...renderProps,
+                className,
+            })
+        )}
+    />
+);

--- a/src/frontend/src/components/base/Modal/Modal.tsx
+++ b/src/frontend/src/components/base/Modal/Modal.tsx
@@ -1,35 +1,38 @@
+import type { ComponentProps } from "react";
 import {
     Modal as AriaModal,
     ModalOverlay as AriaModalOverlay,
     type ModalOverlayProps as AriaModalOverlayProps,
-    type ModalOverlayProps as AriaModalProps,
-    composeRenderProps,
 } from "react-aria-components";
 import { modalOverlayStyles, modalStyles } from "./Modal.styles";
 
-export const ModalOverlay = ({
-    className,
-    ...props
-}: AriaModalOverlayProps) => (
+type AriaModalProps = ComponentProps<typeof AriaModal>;
+
+// TODO: the isEntering and isExiting CSS animations don't
+// work properly
+
+export const ModalOverlay = (props: AriaModalOverlayProps) => (
     <AriaModalOverlay
         {...props}
-        className={composeRenderProps(className, (className, renderProps) =>
+        className={({ isEntering, isExiting }) =>
             modalOverlayStyles({
-                ...renderProps,
-                className,
+                isEntering,
+                isExiting,
+                className: props.className as string,
             })
-        )}
+        }
     />
 );
 
-export const Modal = ({ className, ...props }: AriaModalProps) => (
+export const Modal = (props: AriaModalProps) => (
     <AriaModal
         {...props}
-        className={composeRenderProps(className, (className, renderProps) =>
+        className={({ isEntering, isExiting }) =>
             modalStyles({
-                ...renderProps,
-                className,
+                isEntering,
+                isExiting,
+                className: props.className as string,
             })
-        )}
+        }
     />
 );

--- a/src/frontend/tailwind.config.ts
+++ b/src/frontend/tailwind.config.ts
@@ -1,9 +1,10 @@
 import type { Config } from "tailwindcss";
 import reactAriaComponents from "tailwindcss-react-aria-components";
+import animatePlugin from "tailwindcss-animate";
 
 const config: Config = {
     content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
-    plugins: [reactAriaComponents()],
+    plugins: [reactAriaComponents(), animatePlugin],
 };
 
 export default config;

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -3616,6 +3616,11 @@ tailwind-variants@^1.0.0:
   dependencies:
     tailwind-merge "3.0.2"
 
+tailwindcss-animate@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz#318b692c4c42676cc9e67b19b78775742388bef4"
+  integrity sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==
+
 tailwindcss-react-aria-components@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/tailwindcss-react-aria-components/-/tailwindcss-react-aria-components-2.0.0.tgz#25d5d0a4edf5718112dda055a968f48b2a7dd29a"


### PR DESCRIPTION
## Overview

This PR is branched out from https://github.com/azavea/echo-locator/pull/679
- add base modal component
- use the modal component for the hamburger button on the top menu when in mobile view

@philippschmitt please feel free to tweak the styles

### Checklist

- [ ] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] Run `./scripts/format` to lint, format, and fix the application source code.
- [ ] CI passes after rebase

### Demo

<img width="756" height="971" alt="Screenshot 2025-07-16 at 3 22 34 PM" src="https://github.com/user-attachments/assets/c449723b-be87-44c2-88e3-642588df3946" />


## Testing Instructions

 * Spin up the app
 * Switch to mobile view
 * Click on the hamburger menu on top right. It should bring up the modal with options to select language and logout
 * Selecting language should change the language and close the modal
 * Clicking on log out currently only closes the modal, but we will hook this up with log out feature when we have it
 * Clicking somewhere outside the modal or pressing the escape key from the keyboard should close the modal with no operation
 * Test that the buttons can be tabbed to and be selected in the modal using keyboard


Resolves #676 
