### PR TITLE
Create discover page component structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add initial neighborhoods redux state [#686](https://github.com/azavea/echo-locator/pull/686)
 - Add modal dialog component [#682](https://github.com/azavea/echo-locator/pull/682)
 - Add state management migrate ADR [#685](https://github.com/azavea/echo-locator/pull/685)
+- Add discover page component structures [#687](https://github.com/azavea/echo-locator/pull/687)
 
 ### Changed
 

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -7,7 +7,7 @@
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
         <link
-            href="https://fonts.googleapis.com/css2?family=Mulish:ital,wght@0,400;0,500;0,700;1,400&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Mulish:wght@400;700;800&display=swap"
             rel="stylesheet"
         />
         <title>BHA ECHO Locator</title>

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -1,46 +1,57 @@
+import { lazy, Suspense } from "react";
 import { BrowserRouter, Routes, Route } from "react-router";
 import { Navigate } from "react-router";
 
-import Root from "pages/Root";
-import Components from "pages/Components";
-import Discover from "pages/Discover";
-import Compare from "pages/Compare";
-
 import "./App.css";
-import LanguageRedirect from "components/LanguageRedirect";
+
+const Root = lazy(() => import("pages/Root"));
+const Components = lazy(() => import("pages/Components"));
+const Discover = lazy(() => import("pages/Discover/Discover"));
+const Compare = lazy(() => import("pages/Compare"));
+const LanguageRedirect = lazy(() => import("components/LanguageRedirect"));
+
+const LoadingFallback = () => <div>Loading page...</div>;
 
 const App = () => (
     <BrowserRouter>
-        <Routes>
-            {/* Redirect from the root path / to the default language page */}
-            <Route index element={<Navigate to="/en/discover" replace />} />
+        <Suspense fallback={<LoadingFallback />}>
+            <Routes>
+                {/* Redirect from the root path / to the default language page */}
+                <Route index element={<Navigate to="/en/discover" replace />} />
 
-            {/* Handle paths without a language prefix */}
-            {/* TODO: we need to update this block as we have more pages */}
-            <Route
-                path="discover"
-                element={<LanguageRedirect to="discover" />}
-            />
-            <Route path="compare" element={<LanguageRedirect to="compare" />} />
-            <Route
-                path="components"
-                element={<LanguageRedirect to="components" />}
-            />
+                {/* Handle paths without a language prefix */}
+                {/* TODO: we need to update this block as we have more pages */}
+                <Route
+                    path="discover"
+                    element={<LanguageRedirect to="discover" />}
+                />
+                <Route
+                    path="compare"
+                    element={<LanguageRedirect to="compare" />}
+                />
+                <Route
+                    path="components"
+                    element={<LanguageRedirect to="components" />}
+                />
 
-            {/* Language-specific pages */}
-            <Route path="/:lang" element={<Root />}>
-                {/* Handle /en, /es, etc. by redirecting to discover */}
-                <Route index element={<Navigate to="discover" replace />} />
+                {/* Language-specific pages */}
+                <Route path="/:lang" element={<Root />}>
+                    {/* Handle /en, /es, etc. by redirecting to discover */}
+                    <Route index element={<Navigate to="discover" replace />} />
 
-                {/* Rest of app pages */}
-                <Route path="discover" element={<Discover />} />
-                <Route path="compare" element={<Compare />} />
-                <Route path="components" element={<Components />} />
-            </Route>
+                    {/* Rest of app pages */}
+                    <Route path="discover" element={<Discover />} />
+                    <Route path="compare" element={<Compare />} />
+                    <Route path="components" element={<Components />} />
+                </Route>
 
-            {/* Catch-all */}
-            <Route path="*" element={<Navigate to="/en/discover" replace />} />
-        </Routes>
+                {/* Catch-all */}
+                <Route
+                    path="*"
+                    element={<Navigate to="/en/discover" replace />}
+                />
+            </Routes>
+        </Suspense>
     </BrowserRouter>
 );
 

--- a/src/frontend/src/components/UserProfileSubheader.tsx
+++ b/src/frontend/src/components/UserProfileSubheader.tsx
@@ -23,7 +23,8 @@ interface Props {
 }
 
 interface MobileProps extends Props {
-    display: "map" | "list";
+    display: string;
+    callback?: (key: string) => void;
 }
 
 const getModeIcon = (mode: Mode, size: Size) =>
@@ -43,6 +44,7 @@ export const UserProfileSubheaderMobile = ({
     place,
     size = "medium",
     display = "map",
+    callback,
 }: MobileProps) => {
     const [displayOption, setDisplayOption] = useState(new Set<Key>([display]));
 
@@ -56,27 +58,35 @@ export const UserProfileSubheaderMobile = ({
             return;
         }
         setDisplayOption(keys);
+        if (callback) {
+            const keyArr = [...keys];
+            if (keyArr.length && typeof keyArr[0] === "string")
+                callback(keyArr[0]);
+        }
     };
 
     return (
-        <div className="flex flex-column items-center gap-3">
+        <div className="flex flex-column items-center justify-between w-full">
             <Button
                 variant="outline"
                 size={size}
-                label="You"
                 leftIcon={<FamilyIcon className={getIconStyle(size)} />}
-            />
+            >
+                You
+            </Button>
             <Button
+                className="w-[127px] justify-start"
                 variant="outline"
                 size={size}
-                label={place}
                 leftIcon={
                     <div className="flex items-center gap-3">
                         {getModeIcon(mode, size)}
                         <ArrowFullRightIcon className="font-normal fill-gray-400 w-[10px] -ml-1" />
                     </div>
                 }
-            />
+            >
+                {place}
+            </Button>
             <ToggleButtonGroup
                 selectionMode="single"
                 selectedKeys={displayOption}
@@ -99,21 +109,23 @@ export const UserProfileSubheader = ({
     size = "medium",
 }: Props) => {
     return (
-        <div className="flex flex-col gap-3 w-[360px]">
+        <div className="flex flex-col gap-3 w-full">
             <Button
                 variant="outline"
                 size={size}
-                label="Your Profile"
                 leftIcon={<FamilyIcon className={getIconStyle(size)} />}
                 info="2br・public transit"
-            />
+            >
+                Your Profile
+            </Button>
             <Button
                 variant="outline"
                 size={size}
-                label={place}
                 leftIcon={getModeIcon(mode, size)}
                 info="122 Address St, Cambridge"
-            />
+            >
+                {place}
+            </Button>
         </div>
     );
 };

--- a/src/frontend/src/pages/Components.tsx
+++ b/src/frontend/src/pages/Components.tsx
@@ -79,7 +79,7 @@ const Components = () => {
     const { lang } = useParams<{ lang: LanguageKey | undefined }>();
 
     return (
-        <div className=" max-w-4xl mx-auto space-y-8">
+        <div className="items-center px-10 py-16 max-w-4xl mx-auto space-y-8">
             <header className="space-y-2">
                 <h1 className="text-4xl font-bold text-gray-900">Components</h1>
                 <p className="text-gray-600">
@@ -260,12 +260,14 @@ const Components = () => {
                 <div className="space-y-8">
                     <div className="flex flex-col gap-4">
                         <h3 className="text-xl text-gray-800 mb-2">Small</h3>
-                        <UserProfileSubheaderMobile
-                            size="small"
-                            mode="transit"
-                            place={Place.Work}
-                            display="map"
-                        />
+                        <div className="flex w-[375px]">
+                            <UserProfileSubheaderMobile
+                                size="small"
+                                mode="transit"
+                                place={Place.Work}
+                                display="map"
+                            />
+                        </div>
                         <UserProfileSubheader
                             size="small"
                             mode="transit"
@@ -274,12 +276,14 @@ const Components = () => {
                     </div>
                     <div className="flex flex-col gap-4">
                         <h3 className="text-xl text-gray-800 mb-2">Medium</h3>
-                        <UserProfileSubheaderMobile
-                            size="medium"
-                            mode="car"
-                            place={Place.Daycare}
-                            display="list"
-                        />
+                        <div className="flex w-[375px]">
+                            <UserProfileSubheaderMobile
+                                size="medium"
+                                mode="car"
+                                place={Place.Daycare}
+                                display="list"
+                            />
+                        </div>
                         <UserProfileSubheader
                             size="medium"
                             mode="car"
@@ -288,12 +292,14 @@ const Components = () => {
                     </div>
                     <div className="flex flex-col gap-4">
                         <h3 className="text-xl text-gray-800 mb-2">Large</h3>
-                        <UserProfileSubheaderMobile
-                            size="large"
-                            mode="car"
-                            place={Place.Doctor}
-                            display="map"
-                        />
+                        <div className="flex w-[375px]">
+                            <UserProfileSubheaderMobile
+                                size="large"
+                                mode="car"
+                                place={Place.Doctor}
+                                display="map"
+                            />
+                        </div>
                         <UserProfileSubheader
                             size="large"
                             mode="transit"

--- a/src/frontend/src/pages/Discover/Desktop.tsx
+++ b/src/frontend/src/pages/Discover/Desktop.tsx
@@ -1,0 +1,30 @@
+import { UserProfileSubheader } from "components/UserProfileSubheader";
+import { Place } from "src/enums";
+import discoverDesktopStyles from "./Discover.styles";
+import Neighborhoods from "./Neighborhoods";
+
+const DiscoverDesktop = () => {
+    const { root, sidebar, headerContainer, map } = discoverDesktopStyles({
+        isMobile: false,
+    });
+
+    return (
+        <div className={root()}>
+            <div className={sidebar()}>
+                <div className={headerContainer()}>
+                    <UserProfileSubheader
+                        size="medium"
+                        mode="transit"
+                        place={Place.Work}
+                    />
+                </div>
+                <Neighborhoods mobile={false} />
+            </div>
+
+            {/* Map */}
+            <div className={map()}>Map Content</div>
+        </div>
+    );
+};
+
+export default DiscoverDesktop;

--- a/src/frontend/src/pages/Discover/Discover.styles.ts
+++ b/src/frontend/src/pages/Discover/Discover.styles.ts
@@ -1,0 +1,37 @@
+import { tv } from "tailwind-variants";
+
+const discoverStyles = tv({
+    slots: {
+        root: "flex flex-1 min-h-0 self-stretch rounded-t-[var(--spacing-5)] bg-white",
+        sidebar:
+            "flex w-[360px] rounded-tl-[var(--spacing-5)] flex-col overflow-hidden border-r-1 border-gray-300",
+        headerContainer: "flex border-b border-gray-300 bg-white",
+        recoContainer:
+            "flex flex-1 flex-col items-start gap-6 self-stretch overflow-y-auto bg-gray-50",
+        subTitleContainer: "flex w-full flex-col gap-3 text-center",
+        subTitle: "font-xbold text-[27.65px] text-orange-700",
+        description: "text-rg text-gray-700",
+        recoList: "flex w-full flex-col gap-6",
+        recoTitleContainer: "flex flex-row items-center gap-[10px]",
+        recoTitle: "font-xbold text-[23.04px] text-black",
+        recoDescription: "text-rg text-gray-600",
+        swatch: "w-[16px] h-[16px] rounded-[var(--spacing-2)] border border-[#748C27] bg-[#BCD168]",
+        map: "flex flex-1 items-center justify-center p-6",
+    },
+    variants: {
+        isMobile: {
+            true: {
+                root: "flex-col",
+                headerContainer: "p-3",
+                recoContainer: "p-5",
+            },
+            false: {
+                root: "flex-row",
+                headerContainer: "p-6",
+                recoContainer: "p-6",
+            },
+        },
+    },
+});
+
+export default discoverStyles;

--- a/src/frontend/src/pages/Discover/Discover.styles.ts
+++ b/src/frontend/src/pages/Discover/Discover.styles.ts
@@ -9,11 +9,11 @@ const discoverStyles = tv({
         recoContainer:
             "flex flex-1 flex-col items-start gap-6 self-stretch overflow-y-auto bg-gray-50",
         subTitleContainer: "flex w-full flex-col gap-3 text-center",
-        subTitle: "font-xbold text-[27.65px] text-orange-700",
+        subTitle: "font-xbold text-3xl text-orange-700",
         description: "text-rg text-gray-700",
         recoList: "flex w-full flex-col gap-6",
         recoTitleContainer: "flex flex-row items-center gap-[10px]",
-        recoTitle: "font-xbold text-[23.04px] text-black",
+        recoTitle: "font-xbold text-2xl text-black",
         recoDescription: "text-rg text-gray-600",
         swatch: "w-[16px] h-[16px] rounded-[var(--spacing-2)] border border-[#748C27] bg-[#BCD168]",
         map: "flex flex-1 items-center justify-center p-6",

--- a/src/frontend/src/pages/Discover/Discover.tsx
+++ b/src/frontend/src/pages/Discover/Discover.tsx
@@ -1,11 +1,16 @@
 import { useEffect } from "react";
-import { useAppDispatch, useAppSelector, type RootState } from "../store/store";
+
 import { getNeighborhoodsAndBounds } from "reducers/neighborhoods/neighborhoodsThunk";
+import { useAppDispatch, useAppSelector, type RootState } from "store/store";
+import useMediaQuery from "hooks/useMediaQuery";
+import Desktop from "./Desktop";
+import Mobile from "./Mobile";
 
 const Discover = () => {
     const dispatch = useAppDispatch();
     const { loading, error, neighborhoods, neighborhoodBounds } =
         useAppSelector(({ neighborhoods }: RootState) => neighborhoods);
+    const isDesktop = useMediaQuery("(min-width: 768px)");
 
     useEffect(() => {
         // Fetch initial neighborhoods data
@@ -18,7 +23,7 @@ const Discover = () => {
         }
     }, []);
 
-    return <></>;
+    return isDesktop ? <Desktop /> : <Mobile />;
 };
 
 export default Discover;

--- a/src/frontend/src/pages/Discover/Mobile.tsx
+++ b/src/frontend/src/pages/Discover/Mobile.tsx
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+import { useSearchParams } from "react-router";
+
+import { UserProfileSubheaderMobile } from "components/UserProfileSubheader";
+import { Place } from "src/enums";
+import discoverDesktopStyles from "./Discover.styles";
+import Neighborhoods from "./Neighborhoods";
+
+const DiscoverMobile = () => {
+    const [routerParams, setRouterParams] = useSearchParams();
+    const display = routerParams.get("display");
+
+    useEffect(() => {
+        if (
+            display === null ||
+            (display && !["map", "list"].includes(display))
+        ) {
+            setRouterParams({ display: "map" });
+        }
+    }, [display]);
+
+    const onChangeMode = (newDisplay: string) => {
+        setRouterParams({ display: newDisplay });
+    };
+
+    const { root, headerContainer, map } = discoverDesktopStyles({
+        isMobile: true,
+    });
+
+    return display ? (
+        <div className={root()}>
+            <div className={headerContainer()}>
+                <UserProfileSubheaderMobile
+                    size="small"
+                    mode="transit"
+                    place={Place.Work}
+                    display={display}
+                    callback={onChangeMode}
+                />
+            </div>
+            {/* TODO: Implement Map mode neighborhood slides */}
+            {display === "map" && <div className={map()}>Map container</div>}
+            {display === "list" && <Neighborhoods mobile />}
+        </div>
+    ) : (
+        <></>
+    );
+};
+
+export default DiscoverMobile;

--- a/src/frontend/src/pages/Discover/Neighborhoods.tsx
+++ b/src/frontend/src/pages/Discover/Neighborhoods.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+
+import InputText from "components/InputText";
+import NeighborhoodCard from "components/NeighborhoodCard/NeighborhoodCard";
+import discoverStyles from "./Discover.styles";
+
+const cardFull = {
+    imageUrl:
+        "https://upload.wikimedia.org/wikipedia/commons/0/08/Washington_and_Harvard_Streets%2C_Brookline_Village_MA.jpg",
+    stats: {
+        schools: { label: "Schools", value: 25, showCategory: true },
+        safety: { label: "Safety", value: 75, showCategory: true },
+        commute: {
+            label: "Commute",
+            start: 10,
+            end: 25,
+        },
+    },
+};
+
+const Neighborhoods = ({ mobile }: { mobile: boolean }) => {
+    const [mediumTextInput, setMediumTextInput] = useState<string>("");
+    const {
+        recoContainer,
+        subTitleContainer,
+        subTitle,
+        description,
+        swatch,
+        recoList,
+        recoTitleContainer,
+        recoTitle,
+        recoDescription,
+    } = discoverStyles({ isMobile: mobile });
+
+    return (
+        <div className={recoContainer()}>
+            {/* TODO: Neighborhood search */}
+            <InputText
+                label="Text input"
+                placeholder="Search neighborhoods"
+                value={mediumTextInput}
+                onChange={setMediumTextInput}
+            />
+
+            {/* Sub-title */}
+            <div className={subTitleContainer()}>
+                <p className={subTitle()}>Discover Neighborhoods</p>
+                <p className={description()}>
+                    Recommendations are based on your profile and selected trip
+                </p>
+            </div>
+
+            {/* Recommendation list */}
+            <div className={recoList()}>
+                <div>
+                    {/* TODO: Change copy based on search result */}
+                    <div className={recoTitleContainer()}>
+                        <p className={recoTitle()}>Top 10</p>
+                        <div className={swatch()}></div>
+                    </div>
+                    <p className={recoDescription()}>
+                        Highest-ranked recommendations
+                    </p>
+                </div>
+                {/* TODO: read list of neighborhoods from prop */}
+                {new Array(10).fill(0).map((_, idx) => (
+                    <NeighborhoodCard
+                        {...cardFull}
+                        key={idx}
+                        name="Brookline"
+                        zip="02446"
+                        isTopTen
+                        hasECC
+                    />
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default Neighborhoods;

--- a/src/frontend/src/pages/Root.tsx
+++ b/src/frontend/src/pages/Root.tsx
@@ -29,12 +29,10 @@ const Root = () => {
     }, [lang, i18n, location]);
 
     return (
-        <div className="min-h-screen flex flex-col">
+        <div className="h-screen flex flex-col">
             {/* TODO: get compareCount from app store */}
             <Menu compareCount={0} languages={languageToLabel} />
-            <div className="flex flex-1 flex-col items-center self-stretch gap-6 rounded-t-[16px] bg-white px-10 py-16">
-                <Outlet />
-            </div>
+            <Outlet />
         </div>
     );
 };

--- a/src/frontend/src/theme.css
+++ b/src/frontend/src/theme.css
@@ -103,6 +103,7 @@
     /* Font Weights */
     --font-weight-normal: 400;
     --font-weight-bold: 700;
+    --font-weight-xbold: 800;
 
     /* Shadows */
     --shadow-sm:


### PR DESCRIPTION
## Overview

This PR:
- refactors the user profile header components
- creates mobile and desktop structures for the discover page using static component placeholders
- uses lazy-loading to optimize chunk sizes

Tagging @philippschmitt for styling and design cares

### Checklist

- [ ] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] Run `./scripts/format` to lint, format, and fix the application source code.
- [ ] CI passes after rebase

### Demo

Desktop list + map view
<img width="1420" height="971" alt="Screenshot 2025-08-11 at 10 04 40 AM" src="https://github.com/user-attachments/assets/5d3fa14d-36ba-479c-92a2-2340ba98ed08" />

Mobile list view
<img width="556" height="768" alt="Screenshot 2025-08-11 at 10 05 04 AM" src="https://github.com/user-attachments/assets/becac0a2-0f59-4971-a765-924fb88b6632" />


Mobile map view

<img width="579" height="749" alt="Screenshot 2025-08-11 at 10 04 53 AM" src="https://github.com/user-attachments/assets/8f99bbfe-68f1-4990-94d9-11f07cc7e23f" />



### Notes

1. Components used on the page are static to show where they are on the discover page as the scope of work here is to create page structures for both mobile and desktop
2. In mobile view, there is now a `mode` query parameter in the app URL to differentiate list or map view
3. I marked some todos in the code comments as they will be covered in other cards
4. In the designs, the search component is new, as it's not something we already created on the components page. I used the simple text input component we already have as a placeholder. The search component should be create separately as it has icons and maybe will also have typeahead (?)

On the discover page as placehoder:
<img width="356" height="82" alt="Screenshot 2025-08-11 at 10 09 41 AM" src="https://github.com/user-attachments/assets/15c492e7-0a3d-4ce5-9dd8-b3ae3684f9e0" />

In the designs:

<img width="352" height="80" alt="Screenshot 2025-08-11 at 10 10 16 AM" src="https://github.com/user-attachments/assets/0380f5e2-037e-4203-8b10-8f518b833014" />


## Testing Instructions

 * Spin up the app and go to discover page
 * Make sure the desktop view looks as expected
 * Switch to mobile view and make sure changing between map and list views work as expected with proper query param change in the app URL


Resolves https://github.com/azavea/echo-locator/issues/659
