### PR TITLE
Add neighborhood ranking logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add discover page component structures [#687](https://github.com/azavea/echo-locator/pull/687)
 - Bootstrap map component [#688](https://github.com/azavea/echo-locator/pull/688)
 - Migrate route and travel time logic [#693](https://github.com/azavea/echo-locator/pull/693)
+- Add neighborhood ranking logic [#694](https://github.com/azavea/echo-locator/pull/694)
 
 ### Changed
 

--- a/src/frontend/src/constants.ts
+++ b/src/frontend/src/constants.ts
@@ -63,3 +63,33 @@ export const STOP_STYLE = {
     radius: 3,
     weight: 2,
 };
+
+/*
+ * Neighborhood scoring & sorting constants
+ */
+export const MAX_TRAVEL_TIME = 120;
+// Account profile defaults for weight importance
+export const MAX_IMPORTANCE = 4;
+export const DEFAULT_ACCESSIBILITY_IMPORTANCE = 2;
+export const DEFAULT_SCHOOLS_IMPORTANCE = 1;
+export const DEFAULT_CRIME_IMPORTANCE = 1;
+
+// Place in the top results for boosted downtown results
+export const BOOST_DOWNTOWN_RESULT_PLACE = 3;
+// Include at least one downtown result in this many of the top results
+export const RESULTS_WITH_DOWNTOWN = 6;
+// Value in `town_area` column of source data for grouping zip codes in Boston
+export const BOSTON_TOWN_AREA = "Boston";
+// `town-area`s considered to be downtown, for special boosting in results
+export const DOWNTOWN_AREAS = [BOSTON_TOWN_AREA];
+
+export const MIN_QUINTILE = 1;
+export const MAX_QUINTILE = 5;
+
+// default to worst, if unknown
+export const DEFAULT_EDUCATION_QUINTILE = 5;
+export const DEFAULT_CRIME_QUINTILE = 5;
+// stored profile importance is offset by one from MAX_IMPORTANCE
+export const PROFILE_MAX_IMPORTANCE = MAX_IMPORTANCE - 1;
+/*
+ */

--- a/src/frontend/src/reducers/neighborhoods/selectors/neighborhoodsSortedWithRoutes.ts
+++ b/src/frontend/src/reducers/neighborhoods/selectors/neighborhoodsSortedWithRoutes.ts
@@ -1,0 +1,200 @@
+// @flow
+import lonlat from '@conveyal/lonlat'
+import concat from 'lodash/concat'
+import filter from 'lodash/filter'
+import findIndex from 'lodash/findIndex'
+import get from 'lodash/get'
+import includes from 'lodash/includes'
+import orderBy from 'lodash/orderBy'
+import pullAt from 'lodash/pullAt'
+
+import {
+  BOOST_DOWNTOWN_RESULT_PLACE,
+  DEFAULT_ACCESSIBILITY_IMPORTANCE,
+  DEFAULT_CRIME_IMPORTANCE,
+  DEFAULT_SCHOOLS_IMPORTANCE,
+  DOWNTOWN_AREAS,
+  MAX_IMPORTANCE,
+  RESULTS_WITH_DOWNTOWN
+} from '../constants'
+import {NeighborhoodProperties} from '../types'
+import scale from '../utils/scaling'
+import { createSelector } from '@reduxjs/toolkit'
+
+import selectNeighborhoodRoutes from "../../networks/selectors/networkNeighborhoodRoutes";
+import selectNeighborhoodTravelTimes from "./allNeighborhoodTravelTimes";
+import type { RootState } from 'store/store'
+
+
+// ~130km estimate of maximum straight-line distance drivable in area within 120 minutes
+const MAX_DISTANCE = 130000
+const MAX_TRAVEL_TIME = 120
+const MIN_QUINTILE = 1
+const MAX_QUINTILE = 5
+// stored profile importance is offset by one from MAX_IMPORTANCE
+const PROFILE_MAX_IMPORTANCE = MAX_IMPORTANCE - 1
+
+// default to worst, if unknown
+const DEFAULT_EDUCATION_QUINTILE = 5
+const DEFAULT_CRIME_QUINTILE = 5
+
+// extra constant weighting always given to travel time over the other two factors
+const EXTRA_ACCESS_WEIGHT = 2
+
+/* eslint complexity: 0 */
+export default createSelector(
+  selectNeighborhoodRoutes,
+  selectNeighborhoodTravelTimes,
+  (state: RootState) => get(state, 'neighborhoods.neighborhoods'),
+  (state: RootState) => get(state, 'networks.origin'),
+  (state: RootState) => get(state, 'userProfile'),
+  (neighborhoodRoutes, travelTimes, neighborhoods, origin, profile) => {
+    if (!neighborhoods || !profile || !neighborhoods.features || !neighborhoods.features.length ||
+      !neighborhoodRoutes || !neighborhoodRoutes.length) {
+      return []
+    }
+    const useTransit = !profile || !profile.hasVehicle
+
+    let accessibilityImportance = profile.importanceAccessibility
+      ? parseInt(profile.importanceAccessibility) - 1 : DEFAULT_ACCESSIBILITY_IMPORTANCE
+    let crimeImportance = profile.importanceViolentCrime
+      ? parseInt(profile.importanceViolentCrime) - 1 : DEFAULT_CRIME_IMPORTANCE
+    let schoolsImportance = profile.importanceSchools
+      ? parseInt(profile.importanceSchools) - 1 : DEFAULT_SCHOOLS_IMPORTANCE
+
+    // If everything is unimportant, rank all factors equally.
+    // If at least one factor has greater than the minimum importance, other factors will be
+    // instead effectively turned off by setting them to minimum importance.
+    if ((accessibilityImportance + crimeImportance + schoolsImportance) === 0) {
+      accessibilityImportance = crimeImportance = schoolsImportance = 1
+    }
+
+    if (accessibilityImportance === PROFILE_MAX_IMPORTANCE) {
+      // if set to very important, add more extra weight to travel time
+      accessibilityImportance += 1
+    }
+
+    // Alwasy give accessibility (travel time) some extra weighting
+    accessibilityImportance += EXTRA_ACCESS_WEIGHT
+
+    const totalImportance = accessibilityImportance + crimeImportance + schoolsImportance
+
+    const neighborhoodsWithRoutes = filter(neighborhoods.features.map((n, index) => {
+      let accessibilityPercent = accessibilityImportance / totalImportance
+      let crimePercent = crimeImportance / totalImportance
+      let schoolPercent = schoolsImportance / totalImportance
+
+      const properties: NeighborhoodProperties = n.properties
+      const route = neighborhoodRoutes[index]
+      const segments = useTransit ? route.routeSegments : []
+      const time = useTransit ? travelTimes[index] : distanceTime(origin, n)
+      // Routable neighborhoods outside the max travel time window will be filtered out.
+      // Smaller travel time is better; larger timeWeight is better (reverse range).
+      const timeWeight = time < MAX_TRAVEL_TIME ? scale(time, 0, MAX_TRAVEL_TIME, 1, 0) : 1
+      // Weight schools either by percentile binned into quarters if given max importance,
+      // or otherwise weight by quintile.
+      let educationWeight
+      if (schoolsImportance === PROFILE_MAX_IMPORTANCE) {
+        // "very important": instead of quintiles, group percentile ranking into quarters
+        const edPercent = properties.education_percentile
+          ? properties.education_percentile
+          : (DEFAULT_EDUCATION_QUINTILE - 1) * 20
+        let edPercentQuarter = Math.round(scale(edPercent, 0, 100, 3, 0))
+        // Treat all schools not in the top quarter as being in the bottom quarter
+        // to strongly prioritize the top quarter
+        if (edPercentQuarter > 0) {
+          edPercentQuarter = 3
+        }
+        educationWeight = scale(edPercentQuarter, 0, 3, 1, 0)
+      } else if (schoolsImportance > 0) {
+        // For "somewhat important", prioritize quintile 2 and below
+        // For "important", quintile 3 and below (lower is better)
+        const prioritizeQuintile = schoolsImportance === 1 ? 2 : 3
+        let educationQuintile = properties.education_percentile_quintile
+          ? properties.education_percentile_quintile
+          : DEFAULT_EDUCATION_QUINTILE
+        // Treat all quintiles above the maximum to prioritize as being in the worst quintile
+        if (educationQuintile > prioritizeQuintile) {
+          educationQuintile = MAX_QUINTILE
+        }
+        // Lowest education quintile is best (reverse range).
+        educationWeight = scale(educationQuintile, MIN_QUINTILE, MAX_QUINTILE, 1, 0)
+      } else {
+        educationWeight = 0 // Not important
+      }
+      let crimeWeight = 0
+      // Handle missing values (zero in spreadsheet) by re-assigning crime weight
+      // evenly to the other two factors. Also do so if crime set as unimportant.
+      if (properties.violentcrime_quintile === 0 || crimeImportance === 0) {
+        const halfCrimePercent = crimePercent / 2
+        schoolPercent += halfCrimePercent
+        accessibilityPercent += halfCrimePercent
+        crimePercent = 0
+      } else {
+        let crimeQuintile = properties.violentcrime_quintile
+          ? properties.violentcrime_quintile : DEFAULT_CRIME_QUINTILE
+        // Treat lowest two (safest) violent crime quintiles equally
+        if (crimeQuintile === 2) {
+          crimeQuintile = 1
+        }
+        if (crimeImportance === 1 && crimeQuintile < 5) {
+          // somewhat important; treat all but worst quintile the same
+          crimeQuintile = 1
+        } else if (crimeImportance === 2 && crimeQuintile < 4) {
+          // "important"; treat all but worst two quintiles the same
+          crimeQuintile = 1
+        } else if (crimeImportance === PROFILE_MAX_IMPORTANCE && crimeQuintile > 3) {
+          // "very important"; push results for worst two quintiles to bottom
+          // by reassigning weights for those quintiles to be 90% crime
+          crimePercent = 0.9
+          schoolPercent /= 10
+          accessibilityPercent /= 10
+        }
+        // Lowest crime quintile is best (reverse range).
+        crimeWeight = scale(crimeQuintile, MIN_QUINTILE, MAX_QUINTILE, 1, 0)
+      }
+
+      // Calculate weighted overall score from the percentages. Larger score is better.
+      const score = (timeWeight * accessibilityPercent) +
+        (crimeWeight * crimePercent) +
+        (educationWeight * schoolPercent)
+
+      return Object.assign({
+        score,
+        segments,
+        time,
+        timeWeight,
+        crimeWeight,
+        educationWeight
+      }, n)
+    }), n => !useTransit || (n.segments && n.segments.length && n.time < MAX_TRAVEL_TIME))
+
+    const ordered = orderBy(neighborhoodsWithRoutes, ['score'], ['desc'])
+
+    // Boost the first downtown result into the BOOST_DOWNTOWN_RESULT_PLACE
+    // if there's not already a downtown result in the top RESULTS_WITH_DOWNTOWN results.
+    const firstDowntownIndex = findIndex(ordered, n => {
+      const townArea = n.properties['town_area']
+      return townArea && includes(DOWNTOWN_AREAS, townArea)
+    })
+    if (firstDowntownIndex >= RESULTS_WITH_DOWNTOWN - 1) {
+      // extract first downtown result, removing it from `ordered` array
+      const firstDowntown = pullAt(ordered, firstDowntownIndex)
+      // splice returns the members removed from the start, mutating `ordered` in place
+      const reorderedStart = ordered.splice(0, BOOST_DOWNTOWN_RESULT_PLACE - 1)
+      return concat(reorderedStart, firstDowntown, ordered)
+    } else {
+      return ordered
+    }
+  }
+)
+
+// Estimate drive time, using straight-line distance
+const distanceTime = (origin, neighborhood) => {
+  // First get distance in meters between origin and a neighborhood point
+  const destination = lonlat.toLeaflet(neighborhood.geometry.coordinates)
+  const distance = destination.distanceTo(origin.position)
+  const normalized = distance < MAX_DISTANCE ? distance : MAX_DISTANCE
+  // Then map the distance to the travel time range
+  return scale(normalized, 0, MAX_DISTANCE, 0, MAX_TRAVEL_TIME)
+}

--- a/src/frontend/src/reducers/neighborhoods/selectors/neighborhoodsSortedWithRoutes.ts
+++ b/src/frontend/src/reducers/neighborhoods/selectors/neighborhoodsSortedWithRoutes.ts
@@ -1,200 +1,148 @@
-// @flow
-import lonlat from '@conveyal/lonlat'
-import concat from 'lodash/concat'
-import filter from 'lodash/filter'
-import findIndex from 'lodash/findIndex'
-import get from 'lodash/get'
-import includes from 'lodash/includes'
-import orderBy from 'lodash/orderBy'
-import pullAt from 'lodash/pullAt'
+// Refactored from old codebase neighborhoods-sorted-with-routes at commit 6f17e33
+
+import concat from "lodash/concat";
+import findIndex from "lodash/findIndex";
+import get from "lodash/get";
+import includes from "lodash/includes";
+import orderBy from "lodash/orderBy";
+import pullAt from "lodash/pullAt";
 
 import {
-  BOOST_DOWNTOWN_RESULT_PLACE,
-  DEFAULT_ACCESSIBILITY_IMPORTANCE,
-  DEFAULT_CRIME_IMPORTANCE,
-  DEFAULT_SCHOOLS_IMPORTANCE,
-  DOWNTOWN_AREAS,
-  MAX_IMPORTANCE,
-  RESULTS_WITH_DOWNTOWN
-} from '../constants'
-import {NeighborhoodProperties} from '../types'
-import scale from '../utils/scaling'
-import { createSelector } from '@reduxjs/toolkit'
+    BOOST_DOWNTOWN_RESULT_PLACE,
+    DOWNTOWN_AREAS,
+    MAX_TRAVEL_TIME,
+    RESULTS_WITH_DOWNTOWN,
+} from "../../../constants";
+import { createSelector } from "@reduxjs/toolkit";
+
+import type { Feature, Point } from "geojson";
+import type { NeighborhoodProperties } from "../types";
+import type { RootState } from "store/store";
 
 import selectNeighborhoodRoutes from "../../networks/selectors/networkNeighborhoodRoutes";
 import selectNeighborhoodTravelTimes from "./allNeighborhoodTravelTimes";
-import type { RootState } from 'store/store'
+import importanceCriteriaScoreWeights from "reducers/userProfile/selectors/importanceCriteriaScoreWeights";
+import { createNeighborhoodWeightedScore } from "../utils/createNeighborhoodWeightedScore";
+import { selectAllNetworksDataReady } from "src/reducers/networks/networksSlice";
 
+const getZipCodeListFromNeighborhoods = (
+    neighborhoods: Feature<Point, NeighborhoodProperties>[]
+) => neighborhoods.map(n => n.properties.id);
 
-// ~130km estimate of maximum straight-line distance drivable in area within 120 minutes
-const MAX_DISTANCE = 130000
-const MAX_TRAVEL_TIME = 120
-const MIN_QUINTILE = 1
-const MAX_QUINTILE = 5
-// stored profile importance is offset by one from MAX_IMPORTANCE
-const PROFILE_MAX_IMPORTANCE = MAX_IMPORTANCE - 1
-
-// default to worst, if unknown
-const DEFAULT_EDUCATION_QUINTILE = 5
-const DEFAULT_CRIME_QUINTILE = 5
-
-// extra constant weighting always given to travel time over the other two factors
-const EXTRA_ACCESS_WEIGHT = 2
-
-/* eslint complexity: 0 */
 export default createSelector(
-  selectNeighborhoodRoutes,
-  selectNeighborhoodTravelTimes,
-  (state: RootState) => get(state, 'neighborhoods.neighborhoods'),
-  (state: RootState) => get(state, 'networks.origin'),
-  (state: RootState) => get(state, 'userProfile'),
-  (neighborhoodRoutes, travelTimes, neighborhoods, origin, profile) => {
-    if (!neighborhoods || !profile || !neighborhoods.features || !neighborhoods.features.length ||
-      !neighborhoodRoutes || !neighborhoodRoutes.length) {
-      return []
-    }
-    const useTransit = !profile || !profile.hasVehicle
+    [
+        selectNeighborhoodRoutes,
+        selectNeighborhoodTravelTimes,
+        importanceCriteriaScoreWeights,
+        selectAllNetworksDataReady,
+        (state: RootState) => get(state, "neighborhoods.neighborhoods"),
+        (state: RootState) => get(state, "networks.activeMode"),
+    ],
+    (
+        neighborhoodRoutes,
+        travelTimes,
+        userScoreWeights,
+        networksReady,
+        neighborhoods,
+        activeNetworkMode
+    ) => {
+        const rankedLists: { recommended: string[]; tooFar: string[] } = {
+            recommended: [],
+            tooFar: [],
+        };
 
-    let accessibilityImportance = profile.importanceAccessibility
-      ? parseInt(profile.importanceAccessibility) - 1 : DEFAULT_ACCESSIBILITY_IMPORTANCE
-    let crimeImportance = profile.importanceViolentCrime
-      ? parseInt(profile.importanceViolentCrime) - 1 : DEFAULT_CRIME_IMPORTANCE
-    let schoolsImportance = profile.importanceSchools
-      ? parseInt(profile.importanceSchools) - 1 : DEFAULT_SCHOOLS_IMPORTANCE
-
-    // If everything is unimportant, rank all factors equally.
-    // If at least one factor has greater than the minimum importance, other factors will be
-    // instead effectively turned off by setting them to minimum importance.
-    if ((accessibilityImportance + crimeImportance + schoolsImportance) === 0) {
-      accessibilityImportance = crimeImportance = schoolsImportance = 1
-    }
-
-    if (accessibilityImportance === PROFILE_MAX_IMPORTANCE) {
-      // if set to very important, add more extra weight to travel time
-      accessibilityImportance += 1
-    }
-
-    // Alwasy give accessibility (travel time) some extra weighting
-    accessibilityImportance += EXTRA_ACCESS_WEIGHT
-
-    const totalImportance = accessibilityImportance + crimeImportance + schoolsImportance
-
-    const neighborhoodsWithRoutes = filter(neighborhoods.features.map((n, index) => {
-      let accessibilityPercent = accessibilityImportance / totalImportance
-      let crimePercent = crimeImportance / totalImportance
-      let schoolPercent = schoolsImportance / totalImportance
-
-      const properties: NeighborhoodProperties = n.properties
-      const route = neighborhoodRoutes[index]
-      const segments = useTransit ? route.routeSegments : []
-      const time = useTransit ? travelTimes[index] : distanceTime(origin, n)
-      // Routable neighborhoods outside the max travel time window will be filtered out.
-      // Smaller travel time is better; larger timeWeight is better (reverse range).
-      const timeWeight = time < MAX_TRAVEL_TIME ? scale(time, 0, MAX_TRAVEL_TIME, 1, 0) : 1
-      // Weight schools either by percentile binned into quarters if given max importance,
-      // or otherwise weight by quintile.
-      let educationWeight
-      if (schoolsImportance === PROFILE_MAX_IMPORTANCE) {
-        // "very important": instead of quintiles, group percentile ranking into quarters
-        const edPercent = properties.education_percentile
-          ? properties.education_percentile
-          : (DEFAULT_EDUCATION_QUINTILE - 1) * 20
-        let edPercentQuarter = Math.round(scale(edPercent, 0, 100, 3, 0))
-        // Treat all schools not in the top quarter as being in the bottom quarter
-        // to strongly prioritize the top quarter
-        if (edPercentQuarter > 0) {
-          edPercentQuarter = 3
+        if (!networksReady) {
+            return rankedLists;
         }
-        educationWeight = scale(edPercentQuarter, 0, 3, 1, 0)
-      } else if (schoolsImportance > 0) {
-        // For "somewhat important", prioritize quintile 2 and below
-        // For "important", quintile 3 and below (lower is better)
-        const prioritizeQuintile = schoolsImportance === 1 ? 2 : 3
-        let educationQuintile = properties.education_percentile_quintile
-          ? properties.education_percentile_quintile
-          : DEFAULT_EDUCATION_QUINTILE
-        // Treat all quintiles above the maximum to prioritize as being in the worst quintile
-        if (educationQuintile > prioritizeQuintile) {
-          educationQuintile = MAX_QUINTILE
+
+        const recommendedNeighborhoodsList: Feature<
+            Point,
+            NeighborhoodProperties
+        >[] = [];
+        const tooFarNeighborhoodsList: Feature<
+            Point,
+            NeighborhoodProperties
+        >[] = [];
+
+        const useTransit = activeNetworkMode !== "car";
+        neighborhoods &&
+            neighborhoods.features.forEach((n, index) => {
+                const route = neighborhoodRoutes[index];
+                const segments = useTransit ? route.segments : [];
+                const time = travelTimes[index][activeNetworkMode];
+
+                const scoreAndWeights = createNeighborhoodWeightedScore(
+                    n,
+                    userScoreWeights,
+                    time
+                );
+
+                const result = Object.assign(
+                    {
+                        segments,
+                        time,
+                        ...scoreAndWeights,
+                    },
+                    n
+                );
+
+                const isRoutable =
+                    (useTransit && segments.length) || !useTransit;
+                if (isRoutable && time < MAX_TRAVEL_TIME) {
+                    recommendedNeighborhoodsList.push(result);
+                } else {
+                    tooFarNeighborhoodsList.push(result);
+                }
+            });
+        const rankedRecommendedNeighborhoods = orderBy(
+            recommendedNeighborhoodsList,
+            ["score"],
+            ["desc"]
+        );
+        const rankedTooFarNeighborhoodsList = orderBy(
+            tooFarNeighborhoodsList,
+            ["score"],
+            ["desc"]
+        );
+
+        // Boost the first downtown result into the BOOST_DOWNTOWN_RESULT_PLACE
+        // if there's not already a downtown result in the top RESULTS_WITH_DOWNTOWN results.
+        const firstDowntownIndex = findIndex(
+            rankedRecommendedNeighborhoods,
+            n => {
+                const townArea = n.properties["town_area"];
+                return !!(townArea && includes(DOWNTOWN_AREAS, townArea));
+            }
+        );
+        if (firstDowntownIndex >= RESULTS_WITH_DOWNTOWN - 1) {
+            // extract first downtown result, removing it from `ordered` array
+            const firstDowntown = pullAt(
+                rankedRecommendedNeighborhoods,
+                firstDowntownIndex
+            );
+            // splice returns the members removed from the start, mutating `ordered` in place
+            const reorderedStart = rankedRecommendedNeighborhoods.splice(
+                0,
+                BOOST_DOWNTOWN_RESULT_PLACE - 1
+            );
+            const rankedAndBoostedRecommendedNeighborhoods = concat(
+                reorderedStart,
+                firstDowntown,
+                rankedRecommendedNeighborhoods
+            );
+            rankedLists["recommended"] = getZipCodeListFromNeighborhoods(
+                rankedAndBoostedRecommendedNeighborhoods
+            );
+        } else {
+            rankedLists["recommended"] = getZipCodeListFromNeighborhoods(
+                rankedRecommendedNeighborhoods
+            );
         }
-        // Lowest education quintile is best (reverse range).
-        educationWeight = scale(educationQuintile, MIN_QUINTILE, MAX_QUINTILE, 1, 0)
-      } else {
-        educationWeight = 0 // Not important
-      }
-      let crimeWeight = 0
-      // Handle missing values (zero in spreadsheet) by re-assigning crime weight
-      // evenly to the other two factors. Also do so if crime set as unimportant.
-      if (properties.violentcrime_quintile === 0 || crimeImportance === 0) {
-        const halfCrimePercent = crimePercent / 2
-        schoolPercent += halfCrimePercent
-        accessibilityPercent += halfCrimePercent
-        crimePercent = 0
-      } else {
-        let crimeQuintile = properties.violentcrime_quintile
-          ? properties.violentcrime_quintile : DEFAULT_CRIME_QUINTILE
-        // Treat lowest two (safest) violent crime quintiles equally
-        if (crimeQuintile === 2) {
-          crimeQuintile = 1
-        }
-        if (crimeImportance === 1 && crimeQuintile < 5) {
-          // somewhat important; treat all but worst quintile the same
-          crimeQuintile = 1
-        } else if (crimeImportance === 2 && crimeQuintile < 4) {
-          // "important"; treat all but worst two quintiles the same
-          crimeQuintile = 1
-        } else if (crimeImportance === PROFILE_MAX_IMPORTANCE && crimeQuintile > 3) {
-          // "very important"; push results for worst two quintiles to bottom
-          // by reassigning weights for those quintiles to be 90% crime
-          crimePercent = 0.9
-          schoolPercent /= 10
-          accessibilityPercent /= 10
-        }
-        // Lowest crime quintile is best (reverse range).
-        crimeWeight = scale(crimeQuintile, MIN_QUINTILE, MAX_QUINTILE, 1, 0)
-      }
 
-      // Calculate weighted overall score from the percentages. Larger score is better.
-      const score = (timeWeight * accessibilityPercent) +
-        (crimeWeight * crimePercent) +
-        (educationWeight * schoolPercent)
+        rankedLists["tooFar"] = getZipCodeListFromNeighborhoods(
+            rankedTooFarNeighborhoodsList
+        );
 
-      return Object.assign({
-        score,
-        segments,
-        time,
-        timeWeight,
-        crimeWeight,
-        educationWeight
-      }, n)
-    }), n => !useTransit || (n.segments && n.segments.length && n.time < MAX_TRAVEL_TIME))
-
-    const ordered = orderBy(neighborhoodsWithRoutes, ['score'], ['desc'])
-
-    // Boost the first downtown result into the BOOST_DOWNTOWN_RESULT_PLACE
-    // if there's not already a downtown result in the top RESULTS_WITH_DOWNTOWN results.
-    const firstDowntownIndex = findIndex(ordered, n => {
-      const townArea = n.properties['town_area']
-      return townArea && includes(DOWNTOWN_AREAS, townArea)
-    })
-    if (firstDowntownIndex >= RESULTS_WITH_DOWNTOWN - 1) {
-      // extract first downtown result, removing it from `ordered` array
-      const firstDowntown = pullAt(ordered, firstDowntownIndex)
-      // splice returns the members removed from the start, mutating `ordered` in place
-      const reorderedStart = ordered.splice(0, BOOST_DOWNTOWN_RESULT_PLACE - 1)
-      return concat(reorderedStart, firstDowntown, ordered)
-    } else {
-      return ordered
+        return rankedLists;
     }
-  }
-)
-
-// Estimate drive time, using straight-line distance
-const distanceTime = (origin, neighborhood) => {
-  // First get distance in meters between origin and a neighborhood point
-  const destination = lonlat.toLeaflet(neighborhood.geometry.coordinates)
-  const distance = destination.distanceTo(origin.position)
-  const normalized = distance < MAX_DISTANCE ? distance : MAX_DISTANCE
-  // Then map the distance to the travel time range
-  return scale(normalized, 0, MAX_DISTANCE, 0, MAX_TRAVEL_TIME)
-}
+);

--- a/src/frontend/src/reducers/neighborhoods/types.ts
+++ b/src/frontend/src/reducers/neighborhoods/types.ts
@@ -1,6 +1,6 @@
 import type { FeatureCollection, MultiPolygon, Point } from "geojson";
 
-interface NeighborhoodProperties {
+export interface NeighborhoodProperties {
     crime_percentile: number | null;
     ecc: boolean;
     education_percentile: number;

--- a/src/frontend/src/reducers/neighborhoods/utils/createNeighborhoodWeightedScore.ts
+++ b/src/frontend/src/reducers/neighborhoods/utils/createNeighborhoodWeightedScore.ts
@@ -1,0 +1,134 @@
+// Copied from old codebase neighborhoods-sorted-with-routes at commit 6f17e33
+
+import type { Feature, Point } from "geojson";
+import type { NeighborhoodProperties } from "../types";
+import type { CriteriaScoreWeights } from "src/reducers/userProfile/types";
+import {
+    DEFAULT_CRIME_QUINTILE,
+    DEFAULT_EDUCATION_QUINTILE,
+    MAX_QUINTILE,
+    MAX_TRAVEL_TIME,
+    MIN_QUINTILE,
+    PROFILE_MAX_IMPORTANCE,
+} from "src/constants";
+
+// Map value from one range to another
+const scale = (
+    num: number,
+    startMin: number,
+    startMax: number,
+    rangeMin: number,
+    rangeMax: number
+) => {
+    return (
+        ((num - startMin) * (rangeMax - rangeMin)) / (startMax - startMin) +
+        rangeMin
+    );
+};
+
+export const createNeighborhoodWeightedScore = (
+    n: Feature<Point, NeighborhoodProperties>,
+    userScoreWeights: CriteriaScoreWeights,
+    time: number
+) => {
+    const {
+        accessibilityImportance,
+        crimeImportance,
+        schoolsImportance,
+        totalImportance,
+    } = userScoreWeights;
+
+    let accessibilityPercent = accessibilityImportance / totalImportance;
+    let crimePercent = crimeImportance / totalImportance;
+    let schoolPercent = schoolsImportance / totalImportance;
+
+    const properties: NeighborhoodProperties = n.properties;
+    // Routable neighborhoods outside the max travel time window filtered into separate list.
+    // Smaller travel time is better; larger timeWeight is better (reverse range).
+    const timeWeight =
+        time < MAX_TRAVEL_TIME ? scale(time, 0, MAX_TRAVEL_TIME, 1, 0) : 1;
+    // Weight schools either by percentile binned into quarters if given max importance,
+    // or otherwise weight by quintile.
+    let educationWeight;
+    if (schoolsImportance === PROFILE_MAX_IMPORTANCE) {
+        // "very important": instead of quintiles, group percentile ranking into quarters
+        const edPercent = properties.education_percentile
+            ? properties.education_percentile
+            : (DEFAULT_EDUCATION_QUINTILE - 1) * 20;
+        let edPercentQuarter = Math.round(scale(edPercent, 0, 100, 3, 0));
+        // Treat all schools not in the top quarter as being in the bottom quarter
+        // to strongly prioritize the top quarter
+        if (edPercentQuarter > 0) {
+            edPercentQuarter = 3;
+        }
+        educationWeight = scale(edPercentQuarter, 0, 3, 1, 0);
+    } else if (schoolsImportance > 0) {
+        // For "somewhat important", prioritize quintile 2 and below
+        // For "important", quintile 3 and below (lower is better)
+        const prioritizeQuintile = schoolsImportance === 1 ? 2 : 3;
+        let educationQuintile = properties.education_percentile_quintile
+            ? properties.education_percentile_quintile
+            : DEFAULT_EDUCATION_QUINTILE;
+        // Treat all quintiles above the maximum to prioritize as being in the worst quintile
+        if (educationQuintile > prioritizeQuintile) {
+            educationQuintile = MAX_QUINTILE;
+        }
+        // Lowest education quintile is best (reverse range).
+        educationWeight = scale(
+            educationQuintile,
+            MIN_QUINTILE,
+            MAX_QUINTILE,
+            1,
+            0
+        );
+    } else {
+        educationWeight = 0; // Not important
+    }
+    let crimeWeight = 0;
+    // Handle missing values (zero in spreadsheet) by re-assigning crime weight
+    // evenly to the other two factors. Also do so if crime set as unimportant.
+    if (properties.violentcrime_quintile === 0 || crimeImportance === 0) {
+        const halfCrimePercent = crimePercent / 2;
+        schoolPercent += halfCrimePercent;
+        accessibilityPercent += halfCrimePercent;
+        crimePercent = 0;
+    } else {
+        let crimeQuintile = properties.violentcrime_quintile
+            ? properties.violentcrime_quintile
+            : DEFAULT_CRIME_QUINTILE;
+        // Treat lowest two (safest) violent crime quintiles equally
+        if (crimeQuintile === 2) {
+            crimeQuintile = 1;
+        }
+        if (crimeImportance === 1 && crimeQuintile < 5) {
+            // somewhat important; treat all but worst quintile the same
+            crimeQuintile = 1;
+        } else if (crimeImportance === 2 && crimeQuintile < 4) {
+            // "important"; treat all but worst two quintiles the same
+            crimeQuintile = 1;
+        } else if (
+            crimeImportance === PROFILE_MAX_IMPORTANCE &&
+            crimeQuintile > 3
+        ) {
+            // "very important"; push results for worst two quintiles to bottom
+            // by reassigning weights for those quintiles to be 90% crime
+            crimePercent = 0.9;
+            schoolPercent /= 10;
+            accessibilityPercent /= 10;
+        }
+        // Lowest crime quintile is best (reverse range).
+        crimeWeight = scale(crimeQuintile, MIN_QUINTILE, MAX_QUINTILE, 1, 0);
+    }
+
+    // Calculate weighted overall score from the percentages. Larger score is better.
+    const score =
+        timeWeight * accessibilityPercent +
+        crimeWeight * crimePercent +
+        educationWeight * schoolPercent;
+    return {
+        score: score,
+        timeWeight: timeWeight,
+        crimeWeight: crimeWeight,
+        educationWeight: educationWeight,
+    };
+};

--- a/src/frontend/src/reducers/userProfile/selectors/importanceCriteriaScoreWeights.ts
+++ b/src/frontend/src/reducers/userProfile/selectors/importanceCriteriaScoreWeights.ts
@@ -1,0 +1,65 @@
+// Refactored from old codebase using latest commit before introducing listings: 8ca3b94
+// Copied from neighborhoods-sorted-with-routes selector
+import get from "lodash/get";
+
+import {
+    DEFAULT_ACCESSIBILITY_IMPORTANCE,
+    DEFAULT_CRIME_IMPORTANCE,
+    DEFAULT_SCHOOLS_IMPORTANCE,
+    MAX_IMPORTANCE,
+} from "../../../constants";
+import { createSelector } from "@reduxjs/toolkit";
+import type { RootState } from "store/store";
+import type { CriteriaScoreWeights } from "../types";
+
+// stored profile importance is offset by one from MAX_IMPORTANCE
+const PROFILE_MAX_IMPORTANCE = MAX_IMPORTANCE - 1;
+// extra constant weighting always given to travel time over the other two factors
+const EXTRA_ACCESS_WEIGHT = 2;
+
+export default createSelector(
+    [(state: RootState) => get(state, "userProfile")],
+    (profile): CriteriaScoreWeights => {
+        const criteriaScoreWeights = {
+            accessibilityImportance: 0,
+            crimeImportance: 0,
+            schoolsImportance: 0,
+            totalImportance: 0,
+        };
+        let accessibilityImportance = profile.importanceAccessibility
+            ? parseInt(profile.importanceAccessibility) - 1
+            : DEFAULT_ACCESSIBILITY_IMPORTANCE;
+        let crimeImportance = profile.importanceViolentCrime
+            ? parseInt(profile.importanceViolentCrime) - 1
+            : DEFAULT_CRIME_IMPORTANCE;
+        let schoolsImportance = profile.importanceSchools
+            ? parseInt(profile.importanceSchools) - 1
+            : DEFAULT_SCHOOLS_IMPORTANCE;
+
+        // If everything is unimportant, rank all factors equally.
+        // If at least one factor has greater than the minimum importance, other factors will be
+        // instead effectively turned off by setting them to minimum importance.
+        if (
+            accessibilityImportance + crimeImportance + schoolsImportance ===
+            0
+        ) {
+            accessibilityImportance = crimeImportance = schoolsImportance = 1;
+        }
+
+        if (accessibilityImportance === PROFILE_MAX_IMPORTANCE) {
+            // if set to very important, add more extra weight to travel time
+            accessibilityImportance += 1;
+        }
+
+        // Always give accessibility (travel time) some extra weighting
+        accessibilityImportance += EXTRA_ACCESS_WEIGHT;
+
+        criteriaScoreWeights["accessibilityImportance"] =
+            accessibilityImportance;
+        criteriaScoreWeights["crimeImportance"] = crimeImportance;
+        criteriaScoreWeights["schoolsImportance"] = schoolsImportance;
+        criteriaScoreWeights["totalImportance"] =
+            accessibilityImportance + crimeImportance + schoolsImportance;
+        return criteriaScoreWeights;
+    }
+);

--- a/src/frontend/src/reducers/userProfile/types.ts
+++ b/src/frontend/src/reducers/userProfile/types.ts
@@ -1,3 +1,10 @@
+export interface CriteriaScoreWeights {
+    accessibilityImportance: number;
+    crimeImportance: number;
+    schoolsImportance: number;
+    totalImportance: number;
+}
+
 interface Destination {
     location: Location;
     primary: boolean;

--- a/src/frontend/src/reducers/userProfile/types.ts
+++ b/src/frontend/src/reducers/userProfile/types.ts
@@ -1,0 +1,16 @@
+interface Destination {
+    location: Location;
+    primary: boolean;
+    purpose: string;
+}
+
+export interface UserProfileSliceState {
+    destinations: Destination[];
+    favorites: string[];
+    hasVehicle: boolean;
+    importanceAccessibility: string;
+    importanceSchools: string;
+    importanceViolentCrime: string;
+    rooms: number;
+    useCommuterRail: boolean;
+}

--- a/src/frontend/src/reducers/userProfile/userSlice.ts
+++ b/src/frontend/src/reducers/userProfile/userSlice.ts
@@ -1,0 +1,26 @@
+import { createSlice } from "@reduxjs/toolkit";
+import type { UserProfileSliceState } from "./types";
+import {
+    DEFAULT_ACCESSIBILITY_IMPORTANCE,
+    DEFAULT_CRIME_IMPORTANCE,
+    DEFAULT_SCHOOLS_IMPORTANCE,
+} from "src/constants";
+
+const initialState: UserProfileSliceState = {
+    destinations: [],
+    favorites: [],
+    hasVehicle: false,
+    importanceAccessibility: DEFAULT_ACCESSIBILITY_IMPORTANCE.toString(),
+    importanceSchools: DEFAULT_SCHOOLS_IMPORTANCE.toString(),
+    importanceViolentCrime: DEFAULT_CRIME_IMPORTANCE.toString(),
+    rooms: 0,
+    useCommuterRail: true,
+};
+
+export const userProfileSlice = createSlice({
+    name: "userProfile",
+    initialState,
+    reducers: {},
+});
+
+export default userProfileSlice.reducer;

--- a/src/frontend/src/store/rootReducer.ts
+++ b/src/frontend/src/store/rootReducer.ts
@@ -1,10 +1,12 @@
 import { combineReducers } from "@reduxjs/toolkit";
 import neighborhoodsReducer from "reducers/neighborhoods/neighborhoodsSlice";
 import networksReducer from "reducers/networks/networksSlice";
+import userProfileReducer from "reducers/userProfile/userSlice";
 
 const rootReducer = combineReducers({
     neighborhoods: neighborhoodsReducer,
     networks: networksReducer,
+    userProfile: userProfileReducer,
 });
 
 export default rootReducer;


### PR DESCRIPTION
## Overview

Builds off of #693 and migrates the neighborhood ranking logic from the old codebase.

Adjusts the selector output so that it returns two lists (sorted, recommended neighborhood zip codes and sorted, "too far" neighborhood zip codes) for our updated UI. This output is the "true" list from which we will derive the grouped, "paginated" sorted-by-rank list in #656.

Note: I didn't touch the specifics of weighting/scores beyond moving the ranking algorithm into its own function for better clarity. This is the "core" of the app that's been refined over time with discipline-specific knowledge and iterating on it would likely be high effort that is not part of the frontend rewrite.

### Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] Run `./scripts/format` to lint, format, and fix the application source code.
- [x] CI passes after rebase

## Testing Instructions

 * Since these lists are not in state we need to print the results of the selector to the console.
       - Add the below line to the `Discover` component to call the selector: 
               `useAppSelector(neighborhoodsSortedWithRoutes);`
       - Add the following print statement to the selector right above the return to view results:
               `console.log("recommended:", rankedLists.recommended, "Too far:", rankedLists.tooFar)`
* Spin up this branch and open the console
* Alongside this window, visit the production app
     * Ensure all the user profile importance selections are set to the defaults (somewhat important commute time and not important school and safety)
     * Select the destination 700 Boylston St. and network mode "Peak"
     * View the list results in the sidebar
 * Confirm length of the recommended list is largely the same as the recommendations count on production
 * Verify the order of the neighborhood zip codes make sense between the production site and local `recommended` list.
           * If commute time is weighted highest when scoring there may be some ranking differences because route and travel times have changed in 5+ years. To test exact matches between the old codebase and new, set commute time to "not important" in production and to "1" in userProfile slice of local dev.
           * Confirm recommendations are direct match between two sites


Resolves #657 
