### PR TITLE
Add formatted ranking lists to state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Migrate route and travel time logic [#693](https://github.com/azavea/echo-locator/pull/693)
 - Add neighborhood ranking logic [#694](https://github.com/azavea/echo-locator/pull/694)
 - Add initial map styling and interactions [#690](https://github.com/azavea/echo-locator/pull/690)
+- Add formatted ranking lists to state [#698](https://github.com/azavea/echo-locator/pull/698)
 
 ### Changed
 

--- a/src/frontend/src/pages/Discover/Discover.styles.ts
+++ b/src/frontend/src/pages/Discover/Discover.styles.ts
@@ -32,9 +32,9 @@ const discoverStyles = tv({
         },
         mobileListDisplay: {
             false: {
-                recoContainer: "hidden"
-            }
-        }
+                recoContainer: "hidden",
+            },
+        },
     },
 });
 

--- a/src/frontend/src/pages/Discover/Discover.tsx
+++ b/src/frontend/src/pages/Discover/Discover.tsx
@@ -1,6 +1,9 @@
 import { useEffect } from "react";
 
-import { getNeighborhoodsAndBounds } from "reducers/neighborhoods/neighborhoodsThunk";
+import {
+    getNeighborhoodsAndBounds,
+    getRankedNeighborhoodLists,
+} from "reducers/neighborhoods/neighborhoodsThunk";
 import { useAppDispatch, useAppSelector, type RootState } from "store/store";
 import useMediaQuery from "hooks/useMediaQuery";
 import Desktop from "./Desktop";
@@ -9,7 +12,10 @@ import {
     getAllTimesAndPaths,
     getNetworks,
 } from "reducers/networks/networksThunk";
-import { setOrigin } from "reducers/networks/networksSlice";
+import {
+    selectAllNetworksDataReady,
+    setOrigin,
+} from "reducers/networks/networksSlice";
 
 const Discover = () => {
     const dispatch = useAppDispatch();
@@ -75,6 +81,13 @@ const Discover = () => {
             dispatch(getAllTimesAndPaths(origin));
         }
     }, [neighborhoods, networks, origin]);
+
+    const networksDataIsReady = useAppSelector(selectAllNetworksDataReady);
+    useEffect(() => {
+        if (networksDataIsReady) {
+            dispatch(getRankedNeighborhoodLists());
+        }
+    }, [networksDataIsReady]);
     // --------------------------------------
 
     return isDesktop ? <Desktop /> : <Mobile />;

--- a/src/frontend/src/pages/Discover/Discover.tsx
+++ b/src/frontend/src/pages/Discover/Discover.tsx
@@ -31,6 +31,7 @@ const Discover = () => {
         networks,
         origin,
     } = useAppSelector(({ networks }: RootState) => networks);
+    const networksDataIsReady = useAppSelector(selectAllNetworksDataReady);
     const isDesktop = useMediaQuery("(min-width: 768px)");
 
     // TODO: Refactor below following login and user profile
@@ -82,7 +83,6 @@ const Discover = () => {
         }
     }, [neighborhoods, networks, origin]);
 
-    const networksDataIsReady = useAppSelector(selectAllNetworksDataReady);
     useEffect(() => {
         if (networksDataIsReady) {
             dispatch(getRankedNeighborhoodLists());

--- a/src/frontend/src/pages/Discover/Mobile.tsx
+++ b/src/frontend/src/pages/Discover/Mobile.tsx
@@ -40,8 +40,8 @@ const DiscoverMobile = () => {
                 />
             </div>
             {/* TODO: Implement Map mode neighborhood slides */}
-            <Map mapDisplay={display === "map"}/>
-            <Neighborhoods mobile listDisplay={display === "list"}/>
+            <Map mapDisplay={display === "map"} />
+            <Neighborhoods mobile listDisplay={display === "list"} />
         </div>
     ) : (
         <></>

--- a/src/frontend/src/reducers/neighborhoods/neighborhoodsSlice.ts
+++ b/src/frontend/src/reducers/neighborhoods/neighborhoodsSlice.ts
@@ -1,8 +1,12 @@
-import { createSlice } from "@reduxjs/toolkit";
-import type { NeighborhoodsSliceState } from "./types";
+import { createSelector, createSlice } from "@reduxjs/toolkit";
+import type {
+    NeighborhoodsSliceState,
+    RankedNeighborhoodsLists,
+} from "./types";
 import { getNeighborhoodsAndBounds } from "./neighborhoodsThunk";
 import allNeighborhoodTravelTimes from "./selectors/allNeighborhoodTravelTimes";
 import drawNeighborhoodRoute from "./selectors/drawNeighborhoodRoute";
+import type { RootState } from "src/store/store";
 
 const initialState: NeighborhoodsSliceState = {
     neighborhoods: null,
@@ -10,6 +14,12 @@ const initialState: NeighborhoodsSliceState = {
     activeNeighborhood: null,
     loading: false,
     error: null,
+    rankedNeighborhoodsLists: {
+        topTen: [],
+        groupedTopTen: [],
+        groupedRecommended: [],
+        groupedTooFar: [],
+    },
 };
 
 export const neighborhoodSlice = createSlice({
@@ -21,6 +31,12 @@ export const neighborhoodSlice = createSlice({
             { payload: neighborhood }: { payload: string | null }
         ) => {
             state.activeNeighborhood = neighborhood;
+        },
+        setRankedNeighborhoodLists: (
+            state,
+            { payload: lists }: { payload: RankedNeighborhoodsLists }
+        ) => {
+            state.rankedNeighborhoodsLists = lists;
         },
     },
     extraReducers: builder => {
@@ -42,9 +58,23 @@ export const neighborhoodSlice = createSlice({
     },
 });
 
-export const { setActiveNeighborhood } = neighborhoodSlice.actions;
+export const { setActiveNeighborhood, setRankedNeighborhoodLists } =
+    neighborhoodSlice.actions;
 
 export { allNeighborhoodTravelTimes as selectNeighborhoodTravelTimes };
 export { drawNeighborhoodRoute as selectNeighborhoodRouteGeoJson };
+
+export const selectNeighborhoodNameByZipcode = createSelector(
+    [(state: RootState) => state.neighborhoods.neighborhoods],
+    neighborhoods =>
+        neighborhoods &&
+        neighborhoods.features.reduce(
+            (zipMap, f) => {
+                zipMap[f.properties.id] = f.properties.town;
+                return zipMap;
+            },
+            {} as { [key: string]: string }
+        )
+);
 
 export default neighborhoodSlice.reducer;

--- a/src/frontend/src/reducers/neighborhoods/neighborhoodsThunk.ts
+++ b/src/frontend/src/reducers/neighborhoods/neighborhoodsThunk.ts
@@ -3,6 +3,14 @@ import {
     fetchNeighborhoods,
     fetchNeighborhoodBounds,
 } from "../../api/neighborhoods";
+import {
+    selectNeighborhoodNameByZipcode,
+    setRankedNeighborhoodLists,
+} from "./neighborhoodsSlice";
+import { type AppDispatch, type RootState } from "store/store";
+import neighborhoodsSortedWithRoutes from "./selectors/neighborhoodsSortedWithRoutes";
+import type { RankedNeighborhoodsLists } from "./types";
+import groupRankingsByLikeNeigborhoodName from "./utils/groupRankingListsByName";
 
 export const getNeighborhoodsAndBounds = createAsyncThunk(
     "neighborhoods/getNeighborhoodsAndBounds",
@@ -19,3 +27,44 @@ export const getNeighborhoodsAndBounds = createAsyncThunk(
         return { neighborhoods, neighborhoodBounds };
     }
 );
+
+export const getRankedNeighborhoodLists =
+    () => (dispatch: AppDispatch, getState: () => RootState) => {
+        const state = getState() as RootState;
+
+        const groupedNeighborhoodsLists: RankedNeighborhoodsLists = {
+            topTen: [],
+            groupedTopTen: [],
+            groupedRecommended: [],
+            groupedTooFar: [],
+        };
+
+        const neighborhoodsList = neighborhoodsSortedWithRoutes(state);
+        const neighborhoodNameByZipcode =
+            selectNeighborhoodNameByZipcode(state);
+
+        groupedNeighborhoodsLists.topTen = neighborhoodsList.recommended.slice(
+            0,
+            10
+        );
+
+        if (neighborhoodNameByZipcode) {
+            groupedNeighborhoodsLists.groupedTopTen =
+                groupRankingsByLikeNeigborhoodName(
+                    groupedNeighborhoodsLists.topTen,
+                    neighborhoodNameByZipcode
+                );
+            groupedNeighborhoodsLists.groupedTooFar =
+                groupRankingsByLikeNeigborhoodName(
+                    neighborhoodsList.tooFar,
+                    neighborhoodNameByZipcode
+                );
+            groupedNeighborhoodsLists.groupedRecommended =
+                groupRankingsByLikeNeigborhoodName(
+                    neighborhoodsList.recommended.slice(10),
+                    neighborhoodNameByZipcode
+                );
+        }
+
+        dispatch(setRankedNeighborhoodLists(groupedNeighborhoodsLists));
+    };

--- a/src/frontend/src/reducers/neighborhoods/types.ts
+++ b/src/frontend/src/reducers/neighborhoods/types.ts
@@ -44,10 +44,18 @@ export type NeighborhoodBounds = FeatureCollection<
     NeighborhoodBoundsProperties
 >;
 
+export interface RankedNeighborhoodsLists {
+    topTen: string[];
+    groupedTopTen: (string | string[])[];
+    groupedRecommended: (string | string[])[];
+    groupedTooFar: (string | string[])[];
+}
+
 export interface NeighborhoodsSliceState {
     neighborhoods: Neighborhoods | null;
     neighborhoodBounds: NeighborhoodBounds | null;
     activeNeighborhood: string | null;
     loading: boolean;
     error: string | null;
+    rankedNeighborhoodsLists: RankedNeighborhoodsLists;
 }

--- a/src/frontend/src/reducers/neighborhoods/utils/groupRankingListsByName.ts
+++ b/src/frontend/src/reducers/neighborhoods/utils/groupRankingListsByName.ts
@@ -1,0 +1,47 @@
+const LIKE_NAME_INDEX_LIMIT = 50;
+
+// Group neighborhoods with the same name if close together in ranking
+// Group separately between "top ten" and remaining list
+const groupRankingListsByLikeNeigborhoodName = (
+    list: string[],
+    neighborhoodNameByZipcode: { [zip: string]: string }
+): (string | string[])[] => {
+    const groupedList: (string | string[])[] = [];
+    const alreadyGroupedIndexes: Set<number> = new Set();
+
+    list.forEach((zip, i) => {
+        if (alreadyGroupedIndexes.has(i)) {
+            return;
+        }
+
+        const name =
+            neighborhoodNameByZipcode && neighborhoodNameByZipcode[zip];
+        const group = [zip];
+        alreadyGroupedIndexes.add(i);
+
+        const likeNameIndexMax = Math.min(
+            i + LIKE_NAME_INDEX_LIMIT + 1,
+            list.length
+        );
+
+        for (let j = i + 1; j < likeNameIndexMax; j++) {
+            if (i === j || alreadyGroupedIndexes.has(j)) return;
+
+            const compareZip = list[j];
+            const compareName =
+                neighborhoodNameByZipcode &&
+                neighborhoodNameByZipcode[compareZip];
+
+            if (compareName === name) {
+                group.push(compareZip);
+                alreadyGroupedIndexes.add(j);
+            }
+        }
+
+        groupedList.push(group.length > 1 ? group : group[0]);
+    });
+
+    return groupedList;
+};
+
+export default groupRankingListsByLikeNeigborhoodName;


### PR DESCRIPTION
## Overview

Brings the derived ranked neighborhoods into state and formats lists for both map and list view. Redux state now has a "true", ungrouped top ten list to use for the map top ten tour as well as three grouped lists for the list view: top ten, recommended, and too far. The groupings within each list were created by traversing neighborhoods list and, for the first instance of a unique neighborhood name, finding all neighborhood matches close in ranking with a matching name and creating a group of those ids at the initial index.

I defined "close in ranking" as <= a difference of 50 indexes. This number is mostly from visually inspecting the grouped lists  at different values of index proximities. The max difference of 50 felt like it captured all matching name neighborhoods within a reasonable chunk of the total list (~240 neighborhoods) while also not creating a false sense of rank inflation

### Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] Run `./scripts/format` to lint, format, and fix the application source code.
- [x] CI passes after rebase

### Demo
<img width="1034" height="281" alt="Screenshot 2025-08-27 at 10 30 05 AM" src="https://github.com/user-attachments/assets/6dff0334-6efa-4636-bfce-a0be9e72851d" />
<img width="671" height="443" alt="Screenshot 2025-08-27 at 10 29 52 AM" src="https://github.com/user-attachments/assets/cb2c2f76-fd31-45e1-8b40-b1bc8902691a" />


## Testing Instructions

 * `scripts/server`
 * open up discover page in browser and open dev tools to see console
 * Confirm 4 separate lists of grouped neighborhoods lists are in state 
 * Open up production app and set values to defaults, set origin to 700 Boylston st, and mode to Peak
 * Compare ranked list in production to the ranked list in this branch's state and confirm these are aligned
 * Confirm groupings of zipcodes all have the same neighborhood name and there are no name matches close together in lists
      * I found this easiest by temporarily switching to push the neighborhood name to state list vs the zipcode, done with the following diff:
```diff
      diff --git a/src/frontend/src/reducers/neighborhoods/neighborhoodsThunk.ts b/src/frontend/src/reducers/neighborhoods/neighborhoodsThunk.ts
index f7f6b78..1907a68 100644
--- a/src/frontend/src/reducers/neighborhoods/neighborhoodsThunk.ts
+++ b/src/frontend/src/reducers/neighborhoods/neighborhoodsThunk.ts
@@ -65,7 +65,7 @@ export const getRankedNeighborhoodLists =
                 }
 
                 const name = nameByZipcodeMap && nameByZipcodeMap[zip];
-                const group = [zip];
+                const group = [name];
                 alreadyGroupedIndexes.push(i);
 
                 list.forEach((compareId, j) => {
@@ -77,7 +77,7 @@ export const getRankedNeighborhoodLists =
                     const inProximityToFirstTownName = Math.abs(j - i) <= 50;
 
                     if (compareName === name && inProximityToFirstTownName) {
-                        group.push(compareId);
+                        group.push(compareName);
                         alreadyGroupedIndexes.push(j);
                     }
                 });

```


Resolves #656 
