### PR TITLE
Fix staging basemap glyphs error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,5 +46,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fix staging deploy workflow [#613](https://github.com/azavea/echo-locator/pull/613)
+- Fix staging basemap glyphs error [#707](https://github.com/azavea/echo-locator/pull/707)
 
 ### Removed

--- a/src/frontend/src/pages/Discover/Map/baseMapStyle.json
+++ b/src/frontend/src/pages/Discover/Map/baseMapStyle.json
@@ -51,7 +51,7 @@
         }
     },
     "sprite": "https://openmaptiles.github.io/positron-gl-style/sprite",
-    "glyphs": "https://api.maptiler.com/fonts/{fontstack}/{range}.pbf?key=get_your_own_OpIi9ZULNHzrESv6T2vL",
+    "glyphs": "https://tiles.basemaps.cartocdn.com/fonts/{fontstack}/{range}.pbf",
     "layers": [
         {
             "id": "background",


### PR DESCRIPTION
## Overview

Fixes the MapTiler missing API key error on staging. This fix now unblocks basemap tiles from rendering correctly on staging. 

### Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] Run `./scripts/format` to lint, format, and fix the application source code.
- [ ] CI passes after rebase

### Demo
<img width="1446" height="988" alt="Screenshot 2025-09-09 at 5 45 01 PM" src="https://github.com/user-attachments/assets/3c1abfa3-536f-4d03-a094-c779ccaac3c5" />

### Notes

Instead of continuing with Conveyal's Mapbox API key as suggested in issue, swaps glyphs URL with open carto glyphs URL. This is consistent with our other projects that use MapLibre with an OpenMapTiles datasource.

## Testing Instructions

 * Open staging site: `https://stg.echosearch.org/`
 * Confirm map basemap loads, including place names
 * Confirm neighborhood bounds layer loads and is styled to recommendations
 * Zoom in and confirm no regressions rendering MBTA data layer in map
 * Open map attribution and confirm appropriately includes CARTO

Resolves #705 
