### PR TITLE
Refactor user authentication APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Parameterize and update URLs to analysis files [#627](https://github.com/azavea/echo-locator/pull/627)
 - Edit neighborhood data & images for new UI [#695](https://github.com/azavea/echo-locator/pull/695)
 - Refactor networks data state to support place comparisons [#699](https://github.com/azavea/echo-locator/pull/699)
+- Refactor user authentication APIs [#718](https://github.com/azavea/echo-locator/pull/718)
 
 ### Fixed
 

--- a/src/backend/api/views.py
+++ b/src/backend/api/views.py
@@ -1,3 +1,4 @@
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -6,6 +7,8 @@ from .serializers import NeighborhoodBoundsSerializer, NeighborhoodSerializer
 
 
 class ListNeighborhoods(APIView):
+    permission_classes = [IsAuthenticated]
+
     def get(self, request):
         neighborhoods = Neighborhood.objects.all()
         serializer = NeighborhoodSerializer(neighborhoods, many=True)
@@ -13,6 +16,8 @@ class ListNeighborhoods(APIView):
 
 
 class ListNeighborhoodBounds(APIView):
+    permission_classes = [IsAuthenticated]
+
     def get(self, request):
         neighborhoods = Neighborhood.objects.all()
         serializer = NeighborhoodBoundsSerializer(neighborhoods, many=True)

--- a/src/backend/echo/urls.py
+++ b/src/backend/echo/urls.py
@@ -45,11 +45,10 @@ urlpatterns = [
         auth_views.PasswordResetCompleteView.as_view(),
         name="password_reset_complete",
     ),
-    path("api/signup/", user_views.SignUpPage.as_view(), name="signup"),
-    path("api/login/", user_views.LoginPage.as_view(), name="login"),
+    path("api/login/", user_views.UnifiedLoginView.as_view(), name="login"),
+    path("api/logout/", user_views.DeleteToken.as_view(), name="delete_token"),
     path("api/auth/login/", user_views.ObtainToken.as_view(), name="obtain_token"),
     path("api/user/", user_views.UserProfileView.as_view(), name="user_details"),
-    path("api/logout/", user_views.DeleteToken.as_view(), name="delete_token"),
     path("api/neighborhoods/", api_views.ListNeighborhoods.as_view(), name="list_neighborhoods"),
     path(
         "api/neighborhood-bounds/",

--- a/src/backend/users/serializers.py
+++ b/src/backend/users/serializers.py
@@ -1,5 +1,4 @@
-from django.contrib.auth.models import Group, User
-from django.db import transaction
+from django.contrib.auth.models import User
 from rest_framework import serializers
 
 from .models import Destination, UserProfile
@@ -46,15 +45,3 @@ class HouseSeekerSignUpSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ["username"]
-
-    # Override to create User with empty UserProfile and add to HouseSeeker group
-    @transaction.atomic
-    def create(self, validated_data):
-        user = User.objects.create(**validated_data)
-        houseseeker_group = Group.objects.get(name="HouseSeeker")
-        user.groups.add(houseseeker_group)
-        user.save()
-
-        UserProfile.objects.create(user=user)
-
-        return user

--- a/src/backend/users/tests.py
+++ b/src/backend/users/tests.py
@@ -130,7 +130,7 @@ class HouseSeekerLoginTest(TestCase):
             f"Expected 200, got {second_response.status_code}. {second_response.content}",
         )
         self.assertEqual(
-            len(mail.outbox), 1, "Fail: expected one email to be sent, not %d." % len(mail.outbox)
+            len(mail.outbox), 2, "Fail: expected two emails to be sent, not %d." % len(mail.outbox)
         )
 
 
@@ -149,18 +149,18 @@ class HouseSeekerSignUpTest(TestCase):
         Test signup endpoint responds with login error message on invalid email.
         """
         response = self.houseseeker.post(
-            "/api/signup/",
+            "/api/login/",
             {"username": "test"},
             content_type="application/json",
         )
-        self.assertContains(response, "try again with a valid email address", status_code=200)
+        self.assertContains(response, "Enter a valid email address", status_code=400)
 
     def test_signup_endpoint_response(self):
         """
         Test signup endpoint responds with correct login message.
         """
         first_response = self.houseseeker.post(
-            "/api/signup/",
+            "/api/login/",
             {"username": "testechoemail@azavea.com"},
             content_type="application/json",
         )
@@ -169,22 +169,15 @@ class HouseSeekerSignUpTest(TestCase):
             200,
             f"Expected 200, got {first_response.status_code}. {first_response.content}",
         )
-        second_response = self.houseseeker.post(
-            "/api/signup/",
-            {"username": "testechoemail@azavea.com"},
-            content_type="application/json",
+        self.assertContains(
+            first_response,
+            "If an account with this email exists or was just created, you will receive a login link shortly.",
+            status_code=200,
         )
-        self.assertEqual(
-            second_response.status_code,
-            200,
-            f"Expected 200, got {second_response.status_code}. {second_response.content}",
-        )
-        self.assertContains(first_response, "complete your account", status_code=200)
-        self.assertContains(second_response, "already have an account", status_code=200)
 
     def test_user_and_empty_profile_created_on_signup(self):
         self.houseseeker.post(
-            "/api/signup/",
+            "/api/login/",
             {"username": "testechoemail1@azavea.com"},
             content_type="application/json",
         )
@@ -199,7 +192,7 @@ class HouseSeekerSignUpTest(TestCase):
         Test email is sent on User sign up.
         """
         self.houseseeker.post(
-            "/api/signup/",
+            "/api/login/",
             {"username": "testechoemail1@azavea.com"},
             content_type="application/json",
         )

--- a/src/backend/users/views.py
+++ b/src/backend/users/views.py
@@ -1,13 +1,9 @@
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Group, User
 from django.contrib.gis.geos import Point
 from django.core.mail import send_mail
 from django.db import transaction
-from django.db.utils import IntegrityError
-from django.http import HttpResponseRedirect
-from django.urls import reverse
 from rest_framework.authtoken.models import Token
-from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -27,7 +23,7 @@ def send_login_link(request):
     login_token = utils.get_query_string(user)
     host = request.get_host()
     protocol = "https://" if request.is_secure() else "http://"
-    login_link = protocol + host + reverse("obtain_token") + login_token
+    login_link = f"{protocol}{host}/login/callback{login_token}"
 
     html_message = """
     <p>Hi there,</p>
@@ -51,41 +47,64 @@ def send_login_link(request):
     )
 
 
-class LoginPage(APIView):
+class UnifiedLoginView(APIView):
+    """
+    Handles both login and registration.
+    If the user exists, it sends a login link.
+    If the user does not exist, it creates the user first, then sends the link.
+    """
+
     def post(self, request, **kwargs):
-        try:
-            email = request.data["username"]
-            if User.objects.get(username__iexact=email).is_active:
-                # Will throw exception if cannot find the User
-                # For privacy reasons, do not send 500 error back if not found
-                send_login_link(request)
-        except User.DoesNotExist:
-            pass
-        return Response(content_type="application/json")
+        # Use a serializer to validate the email format
+        serializer = HouseSeekerSignUpSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        email = serializer.validated_data["username"].lower()
+
+        # get_or_create handles the core logic for new and existing users
+        user, created = User.objects.get_or_create(username=email)
+
+        if created:
+            # If a new user was created, perform any first-time setup
+            # This logic is moved from the old serializer's .create() method
+            user.email = email
+            user.save()
+            UserProfile.objects.create(user=user)
+            # Add them to a group
+            house_seeker_group = Group.objects.get(name="HouseSeeker")
+            user.groups.add(house_seeker_group)
+
+        # Send the magic link email to both new and existing users
+        send_login_link(request)
+
+        # Always return a consistent, positive message for security
+        message = "If an account with this email exists or was just created, you will receive a login link shortly."
+        return Response({"message": message})
 
 
 class ObtainToken(APIView):
     def get(self, request, **kwargs):
         user = utils.get_user(request)
-        response = HttpResponseRedirect("/")
-        # If the token has expired or is otherwise invalid just send them back to the homepage,
-        # where they'll see the login screen again.
+
+        # If the token is invalid or expired, get_user returns None
         if user is None:
-            return response
-        token, created = Token.objects.get_or_create(user=user)
-        # set authentication cookie with max_age 30 days
-        response.set_cookie("auth_token", token.key, max_age=60 * 60 * 24 * 30)
-        return response
+            return Response({"error": "Invalid or expired login link."}, status=401)
+
+        # Get or create the DRF token for the user
+        token, _ = Token.objects.get_or_create(user=user)
+
+        # Return the token key in a JSON response
+        return Response({"token": token.key})
 
 
 class DeleteToken(APIView):
     permission_classes = (IsAuthenticated,)
 
     def post(self, request, **kwargs):
-        response = Response(status=200)
-        response.delete_cookie("auth_token")
+        # Delete the token from the database.
         Token.objects.get(key=request.auth.key).delete()
-        return response
+        # 204 No Content
+        return Response(status=204)
 
 
 class UserProfileView(APIView):
@@ -218,18 +237,3 @@ class UserProfileView(APIView):
         serializer = UserSerializer(User.objects.get(username=request.user))
         content = self.repackage_for_frontend(serializer.data)
         return Response(content)
-
-
-class SignUpPage(APIView):
-    def post(self, request, **kwargs):
-        signup_message = "Thank you! You'll receive an email shortly with a link to complete your account. Click the link to create your profile and get started with ECHO."
-        try:
-            user_serializer = HouseSeekerSignUpSerializer(data=request.data)
-            user_serializer.is_valid(raise_exception=True)
-            user_serializer.save()
-            send_login_link(request)
-        except IntegrityError:
-            signup_message = "It looks like we already have an account with that email. Sign in by clicking the link below!"
-        except ValidationError:
-            signup_message = "Please try again with a valid email address."
-        return Response(data=signup_message, content_type="application/json")


### PR DESCRIPTION
## Overview

This PR refactors the backend user authentication API endpoints:
- POST to `api/login/` to log in or register as a new user, send an email with Auth token
- POST `api/logout/` to log out and delete API token
- GET to `api/auth/login/?echo_auth=` to obtain an API token by an Auth token (btw, I am open to changing the URL to something like `api/auth/?echo_auth=` or `api/token/?echo_auth=`; right now, I kept what's originally there though)

### Checklist

- [ ] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] Run `./scripts/format` to lint, format, and fix the application source code.
- [ ] CI passes after rebase

### Notes

1. The previous implementation is cookie-based. This PR changes to token-based:
    - Frontend checks local storage for an **API token**
    - If it does not have an API token, redirect to login page, go through the login workflow, user will receive an email. What happens after user clicks the link in the email is described in item 2 below
    - If it has an API token, read that token into Redux store
    - All subsequent API calls will use the API token from Redux store and pass it as header
    - On log out, frontend will remove the API token from local storage; backend will delete the API token
2. To build in the next card: The URL in the authentication email has the (one-time) **Auth token** embedded, and the path is actually a page to be supported in the frontend router. This will be a frontend page with path `/login/callback?echo_auth=<auth_token>`, which has no real component on the page, but only for redirect:
    - It calls the `/api/auth/login/?echo_auth=<auth_token>` endpoint, which return a JSON response `{"token": <API Token>}`
    - Store the API token in the Redux store and Local Storage. Redirect to the discover page
    - If the API endpoint call's status code is not 200, redirect to the login page


## Testing Instructions

* `./scripts/update` and `./scripts/server`
* Replace with your email and run the following to log in. Look for the URL in the email logged to the API server console logs
```bash
curl --location 'http://localhost:9966/api/login/' \
--header 'Content-Type: application/json' \
--data-raw '{"username": "<replace with your email>"}'
```
* The URL in the email will be something like `http://localhost:9966/login/callback?echo_auth=<Auth Token>`. Grab the **Auth Token**. This is a one-time token
* Run the following to get an API token
```
curl --location 'http://localhost:9966/api/auth/login/?echo_auth=<Auth Token goes here>'
```
* The above response should be like `{"token": <API Token>}`. The **API Token** is long-living and is what we need for API calls. In the upcoming frontend development, this will be stored in Local Storage and in the Redux store
* Use the API token to list neighborhoods:
```
curl --location 'http://localhost:9966/api/neighborhoods' \
--header 'Authorization: Token <API Token goes here>'
```
* Log out:
```
curl -X POST --location 'http://localhost:9966/api/logout/' \
--header 'Content-Type: application/json' \
--header 'Authorization: Token <API Token goes here>'
```

Resolves https://github.com/azavea/echo-locator/issues/641
