### PR TITLE
Add a wizard component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add region field to neighborhood [#709](https://github.com/azavea/echo-locator/pull/709)
 - Add neighborhood detail modal [#722](https://github.com/azavea/echo-locator/pull/722)
 - Add frontend sign in page and authentication workflows [#723](https://github.com/azavea/echo-locator/pull/723)
+- Add a wizard component [#725](https://github.com/azavea/echo-locator/pull/725)
 
 ### Changed
 

--- a/src/frontend/src/components/Wizard/Wizard.styles.ts
+++ b/src/frontend/src/components/Wizard/Wizard.styles.ts
@@ -1,0 +1,36 @@
+import { tv } from "tailwind-variants";
+
+export const wizardStyle = tv({
+    slots: {
+        rootContainer: "flex flex-col p-5",
+        titleContainer: "flex items-start justify-between",
+        titleText: "text-[17px] font-bold text-gray-600",
+        progressContainer: "flex items-center my-6",
+        stepContainer: "flex flex-col gap-6 flex-grow",
+        questionContainer: "flex flex-col gap-3",
+        questionText: "text-2xl font-xbold text-orange-700",
+        descriptionText: "text-[17px] font-normal text-gray-600",
+        buttonContainer: "flex items-center justify-between mt-6 gap-3",
+    },
+});
+
+export const progressDotStyle = tv({
+    base: "w-[20px] h-[20px] rounded-full border-2 flex-shrink-0 flex items-center justify-center transition-all duration-300 ease-in-out",
+    variants: {
+        state: {
+            completed: "bg-teal-800 border-teal-800",
+            current: "bg-white border-teal-800 scale-110",
+            upcoming: "bg-white border-gray-300",
+        },
+    },
+});
+
+export const progressLineStyle = tv({
+    base: "h-1 w-full transition-colors",
+    variants: {
+        state: {
+            completed: "bg-teal-800",
+            upcoming: "bg-gray-300",
+        },
+    },
+});

--- a/src/frontend/src/components/Wizard/Wizard.tsx
+++ b/src/frontend/src/components/Wizard/Wizard.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { Dialog } from "react-aria-components";
+
+import {
+    Modal,
+    ModalOverlay,
+    type ModalWidth,
+} from "components/base/Modal/Modal";
+import WizardProgress from "./WizardProgress";
+import { wizardStyle } from "./Wizard.styles";
+
+interface WizardProps {
+    currentStep: number;
+    isOpen: boolean;
+    title: string;
+    totalSteps: number;
+    showProgress?: boolean;
+    size?: ModalWidth;
+    isMobile?: boolean;
+    handleClose: () => void;
+    children: React.ReactNode;
+}
+
+const Wizard = ({
+    currentStep,
+    isOpen,
+    title,
+    totalSteps,
+    showProgress = true,
+    size = "small",
+    isMobile = true,
+    handleClose,
+    children,
+}: WizardProps) => {
+    const stepContents = React.Children.toArray(children);
+
+    const { rootContainer, titleContainer, titleText } = wizardStyle();
+
+    return (
+        isOpen && (
+            <ModalOverlay
+                isDismissable
+                isMobile={isMobile}
+                isOpen={isOpen}
+                onOpenChange={handleClose}
+            >
+                <Modal size={size}>
+                    <Dialog aria-label={title}>
+                        <div className={rootContainer()}>
+                            {/* Header */}
+                            <div className={titleContainer()}>
+                                <h2 className={titleText()}>{title}</h2>
+                            </div>
+
+                            {/* Progress tracker */}
+                            {showProgress && (
+                                <WizardProgress
+                                    totalSteps={totalSteps}
+                                    currentStep={currentStep}
+                                />
+                            )}
+
+                            {/* Step Content */}
+                            {stepContents[currentStep - 1]}
+                        </div>
+                    </Dialog>
+                </Modal>
+            </ModalOverlay>
+        )
+    );
+};
+
+export default Wizard;

--- a/src/frontend/src/components/Wizard/WizardProgress.tsx
+++ b/src/frontend/src/components/Wizard/WizardProgress.tsx
@@ -6,6 +6,7 @@ import {
     progressLineStyle,
     wizardStyle,
 } from "./Wizard.styles";
+import CheckIcon from "assets/icons/check.svg?react";
 
 interface WizardProgressProps {
     totalSteps: number;
@@ -35,7 +36,7 @@ const WizardProgress = ({ totalSteps, currentStep }: WizardProgressProps) => {
                 );
                 return (
                     <React.Fragment key={step}>
-                       <div className={progressDotStyle({ state })}>
+                        <div className={progressDotStyle({ state })}>
                             {isCompleted && (
                                 <CheckIcon className="w-[10px] h-[10px] fill-white" />
                             )}

--- a/src/frontend/src/components/Wizard/WizardProgress.tsx
+++ b/src/frontend/src/components/Wizard/WizardProgress.tsx
@@ -35,7 +35,11 @@ const WizardProgress = ({ totalSteps, currentStep }: WizardProgressProps) => {
                 );
                 return (
                     <React.Fragment key={step}>
-                        <div className={progressDotStyle({ state })} />
+                       <div className={progressDotStyle({ state })}>
+                            {isCompleted && (
+                                <CheckIcon className="w-[10px] h-[10px] fill-white" />
+                            )}
+                        </div>
                         {step < totalSteps && (
                             <div
                                 className={progressLineStyle({

--- a/src/frontend/src/components/Wizard/WizardProgress.tsx
+++ b/src/frontend/src/components/Wizard/WizardProgress.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import type { VariantProps } from "tailwind-variants";
+
+import {
+    progressDotStyle,
+    progressLineStyle,
+    wizardStyle,
+} from "./Wizard.styles";
+
+interface WizardProgressProps {
+    totalSteps: number;
+    currentStep: number;
+}
+
+const getProgressInfo = (index: number, currentStep: number) => {
+    const step = index + 1;
+    const isCompleted = step < currentStep;
+    const isCurrent = step === currentStep;
+
+    let state: VariantProps<typeof progressDotStyle>["state"] = "upcoming";
+    if (isCompleted) state = "completed";
+    if (isCurrent) state = "current";
+    return { step, isCompleted, state };
+};
+
+const WizardProgress = ({ totalSteps, currentStep }: WizardProgressProps) => {
+    const { progressContainer } = wizardStyle();
+
+    return (
+        <div className={progressContainer()}>
+            {Array.from({ length: totalSteps }).map((_, index) => {
+                const { step, isCompleted, state } = getProgressInfo(
+                    index,
+                    currentStep
+                );
+                return (
+                    <React.Fragment key={step}>
+                        <div className={progressDotStyle({ state })} />
+                        {step < totalSteps && (
+                            <div
+                                className={progressLineStyle({
+                                    state: isCompleted
+                                        ? "completed"
+                                        : "upcoming",
+                                })}
+                            />
+                        )}
+                    </React.Fragment>
+                );
+            })}
+        </div>
+    );
+};
+
+export default WizardProgress;

--- a/src/frontend/src/components/Wizard/WizardStep.tsx
+++ b/src/frontend/src/components/Wizard/WizardStep.tsx
@@ -45,7 +45,7 @@ const WizardStep = ({
                     size="large"
                     isDisabled={disableBack}
                     leftIcon={
-                        <ArrowLeftIcon className="font-normal h-[14px] w-[14px] text-black" />
+                         <ArrowLeftIcon className={`font-normal h-[14px] w-[14px] ${disableBack ? "fill-gray-300" : "text-black"}`} />
                     }
                     onPress={handleBack}
                 />

--- a/src/frontend/src/components/Wizard/WizardStep.tsx
+++ b/src/frontend/src/components/Wizard/WizardStep.tsx
@@ -45,7 +45,9 @@ const WizardStep = ({
                     size="large"
                     isDisabled={disableBack}
                     leftIcon={
-                         <ArrowLeftIcon className={`font-normal h-[14px] w-[14px] ${disableBack ? "fill-gray-300" : "text-black"}`} />
+                        <ArrowLeftIcon
+                            className={`font-normal h-[14px] w-[14px] ${disableBack ? "fill-gray-300" : "text-black"}`}
+                        />
                     }
                     onPress={handleBack}
                 />

--- a/src/frontend/src/components/Wizard/WizardStep.tsx
+++ b/src/frontend/src/components/Wizard/WizardStep.tsx
@@ -1,0 +1,65 @@
+import Button from "../base/Button/Button";
+import { wizardStyle } from "./Wizard.styles";
+
+import ArrowLeftIcon from "assets/icons/arrow-left.svg?react";
+
+interface WizardStep {
+    question: string;
+    description?: string;
+    buttonText?: string;
+    disableBack?: boolean;
+    children: React.ReactNode;
+    handleBack: () => void;
+    handleNext: () => void;
+}
+
+const WizardStep = ({
+    question,
+    description = undefined,
+    buttonText = "Continue",
+    disableBack = false,
+    handleBack,
+    handleNext,
+    children,
+}: WizardStep) => {
+    const {
+        stepContainer,
+        questionContainer,
+        questionText,
+        descriptionText,
+        buttonContainer,
+    } = wizardStyle();
+
+    return (
+        <div className={stepContainer()}>
+            <div className={questionContainer()}>
+                <h3 className={questionText()}>{question}</h3>
+                {!!description && (
+                    <p className={descriptionText()}>{description}</p>
+                )}
+            </div>
+            {children}
+            <div className={buttonContainer()}>
+                <Button
+                    variant="outline"
+                    size="large"
+                    isDisabled={disableBack}
+                    leftIcon={
+                        <ArrowLeftIcon className="font-normal h-[14px] w-[14px] text-black" />
+                    }
+                    onPress={handleBack}
+                />
+                <Button
+                    variant="primary"
+                    size="large"
+                    className="w-full"
+                    onPress={handleNext}
+                >
+                    {buttonText}
+                </Button>
+            </div>
+        </div>
+    );
+};
+
+export default WizardStep;

--- a/src/frontend/src/components/base/Modal/Modal.tsx
+++ b/src/frontend/src/components/base/Modal/Modal.tsx
@@ -6,7 +6,7 @@ import {
 } from "react-aria-components";
 import { modalOverlayStyles, modalStyles } from "./Modal.styles";
 
-type ModalWidth = "small" | "medium" | "large";
+export type ModalWidth = "small" | "medium" | "large";
 type AriaModalBaseProps = ComponentProps<typeof AriaModal>;
 interface AriaModalProps extends AriaModalBaseProps {
     size?: ModalWidth;

--- a/src/frontend/src/pages/Components.tsx
+++ b/src/frontend/src/pages/Components.tsx
@@ -20,6 +20,8 @@ import InputText from "components/InputText";
 import InputNumber from "components/InputNumber";
 import Checkbox from "components/base/Checkbox/Checkbox";
 import ImportanceSliders from "components/ImportanceSliders";
+import Wizard from "components/Wizard/Wizard";
+import WizardStep from "components/Wizard/WizardStep";
 
 const neighborhood = {
     name: "Brookline",
@@ -76,7 +78,37 @@ const Components = () => {
     const [largeTextInput, setLargeTextInput] = useState<string>("");
     const [numberValue, setNumberValue] = useState(2);
     const [isExpress, setIsExpress] = useState(false);
+    const [isWizardOpen, setWizardOpen] = useState(false);
+    const [currentStep, setCurrentStep] = useState(1);
+
+    const totalSteps = 4;
+
     const { lang } = useParams<{ lang: LanguageKey | undefined }>();
+
+    const handleClose = () => {
+        setWizardOpen(false);
+        // TODO: clear data buffer
+        // Reset to first step when the modal is closed
+        setTimeout(() => setCurrentStep(1), 200);
+    };
+
+    const handleNext = () => {
+        if (currentStep < totalSteps) {
+            setCurrentStep(prev => prev + 1);
+        }
+    };
+
+    const handleBack = () => {
+        if (currentStep > 1) {
+            setCurrentStep(prev => prev - 1);
+        }
+    };
+
+    const handleFinish = () => {
+        console.log("Wizard finished! Submitting data...");
+        // TODO: Persist data to backend
+        handleClose();
+    };
 
     return (
         <div className="items-center px-10 py-16 max-w-4xl mx-auto space-y-8">
@@ -468,6 +500,81 @@ const Components = () => {
                     <div className="flex flex-col gap-4 w-[292px]">
                         <h3 className="text-xl text-gray-800 mb-2">Sliders</h3>
                         <ImportanceSliders />
+                    </div>
+                </div>
+            </section>
+
+            {/* Wizard section */}
+            <section className="p-8 bg-white border border-gray-200 rounded-lg shadow-sm">
+                <h2 className="text-3xl font-medium text-gray-800 mb-8 pb-4 border-b">
+                    Wizard
+                </h2>
+
+                <div className="space-y-8">
+                    <div>
+                        <div className="flex flex-column flex-wrap items-center gap-4">
+                            <Button
+                                variant="primary"
+                                onPress={() => setWizardOpen(true)}
+                            >
+                                Trigger
+                            </Button>
+                            <Wizard
+                                title="Your Profile"
+                                currentStep={currentStep}
+                                isOpen={isWizardOpen}
+                                totalSteps={totalSteps}
+                                handleClose={handleClose}
+                            >
+                                {/* Each direct child is treated as a step */}
+                                <WizardStep
+                                    question="How many bedrooms does your voucher have?"
+                                    description="Reach out to your BHA Housing Coordinator if you're unsure."
+                                    handleBack={handleBack}
+                                    handleNext={handleNext}
+                                    disableBack
+                                >
+                                    <InputNumber
+                                        label="Number input"
+                                        value={numberValue}
+                                        onChange={setNumberValue}
+                                    />
+                                </WizardStep>
+                                <WizardStep
+                                    question="What is important to you??"
+                                    handleBack={handleBack}
+                                    handleNext={handleNext}
+                                >
+                                    <ImportanceSliders />
+                                </WizardStep>
+                                <WizardStep
+                                    question="How do you typically get around?"
+                                    handleBack={handleBack}
+                                    handleNext={handleNext}
+                                >
+                                    <p>Car/Transit toggle goes here</p>
+                                    <Checkbox
+                                        isSelected={isExpress}
+                                        onChange={setIsExpress}
+                                        description="The Commuter rail and express bus allow us to recommend more neighborhoods, but they usually cost more than the subway or local bus."
+                                    >
+                                        I'm willing to take the express bus or
+                                        commuter rail
+                                    </Checkbox>
+                                </WizardStep>
+                                <WizardStep
+                                    question="Which trips do you make frequently?"
+                                    description="We use this information to recommend neighborhoods near the places you visit often"
+                                    buttonText="Finish"
+                                    handleBack={handleBack}
+                                    handleNext={handleFinish}
+                                >
+                                    <p className=" text-gray-600">
+                                        Step 4. The "Add trip" logic goes here
+                                    </p>
+                                </WizardStep>
+                            </Wizard>
+                        </div>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
## Overview

This PR builds on top of the base Modal component and adds a Wizard component that has multiple steps. It provides an example on the components page, which includes the components for supporting the user profile walk-through.


### Checklist

- [ ] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] Run `./scripts/format` to lint, format, and fix the application source code.
- [ ] CI passes after rebase

### Demo


https://github.com/user-attachments/assets/a3fa4cce-f61e-4db2-896c-10c882be03c1

### Notes

1. I could not get the white checkmarks positioned and styled correctly in each progress circle and decided to bail due to budget.

## Testing Instructions

 * Log in and go to components page
 * At the bottom of the page, there is a trigger button for the wizard
 * Click the button and make sure it brings up the wizard
 * Make sure the back button in the wizard is disabled on the first step (visually, it's not obvious- maybe we should update the style of the `outline` button when it's disabled, thoughts?)
 * Clicking on continue button in the wizard should take you to the next step and the progress tracker should change as well
 * At the last step, clicking on the finish button in the wizard should close the wizard. Re-opening the wizard should take you back to the first step
 * On any step of the wizard, clicking outside of the wizard should close the wizard. Re-opening the wizard should take you back to the first step

Resolves https://github.com/azavea/echo-locator/issues/712
