### PR TITLE
Add base Trips Wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add user profile wizard [#729](https://github.com/azavea/echo-locator/pull/729) [#737](https://github.com/azavea/echo-locator/pull/737)
 - Add top 10 tour [#730](https://github.com/azavea/echo-locator/pull/730)
 - Add neighborhood detail preview cards to Discover page [#741](https://github.com/azavea/echo-locator/pull/741)
+- Add base Trips Wizard [#740](https://github.com/azavea/echo-locator/pull/740)
 
 ### Changed
 

--- a/src/frontend/public/locales/en/translation.json
+++ b/src/frontend/public/locales/en/translation.json
@@ -127,7 +127,7 @@
             "stepAddTrip": {
                 "question": "Which trips do you make frequently?",
                 "description": "We use this information to recommend neighborhoods near the places you visit often",
-                "addATrip": "Add a trip"
+                "addATrip": "Add another trip"
             },
             "button": {
                 "continue": "Continue",

--- a/src/frontend/public/locales/en/translation.json
+++ b/src/frontend/public/locales/en/translation.json
@@ -127,7 +127,8 @@
             "stepAddTrip": {
                 "question": "Which trips do you make frequently?",
                 "description": "We use this information to recommend neighborhoods near the places you visit often",
-                "addATrip": "Add another trip"
+                "addATrip": "Add a trip",
+                "addAnotherTrip": "Add another trip"
             },
             "addNewTripModal": {
                 "question": "Add new trip",

--- a/src/frontend/public/locales/en/translation.json
+++ b/src/frontend/public/locales/en/translation.json
@@ -129,6 +129,13 @@
                 "description": "We use this information to recommend neighborhoods near the places you visit often",
                 "addATrip": "Add another trip"
             },
+            "addNewTripModal": {
+                "question": "Add new trip",
+                "purposeLabel": "What kind of place is it?",
+                "locationLabel": "Where is it?",
+                "locationPlaceholder": "Enter an address",
+                "finish": "Add trip"
+            },
             "button": {
                 "continue": "Continue",
                 "finish": "Finish"

--- a/src/frontend/public/locales/es/translation.json
+++ b/src/frontend/public/locales/es/translation.json
@@ -127,7 +127,8 @@
             "stepAddTrip": {
                 "question": "Which trips do you make frequently?",
                 "description": "We use this information to recommend neighborhoods near the places you visit often",
-                "addATrip": "Add another trip"
+                "addATrip": "Add a trip",
+                "addAnotherTrip": "Add another trip"
             },
             "addNewTripModal": {
                 "question": "Add new trip",

--- a/src/frontend/public/locales/es/translation.json
+++ b/src/frontend/public/locales/es/translation.json
@@ -129,6 +129,13 @@
                 "description": "We use this information to recommend neighborhoods near the places you visit often",
                 "addATrip": "Add another trip"
             },
+            "addNewTripModal": {
+                "question": "Add new trip",
+                "purposeLabel": "What kind of place is it?",
+                "locationLabel": "Where is it?",
+                "locationPlaceholder": "Enter an address",
+                "finish": "Add trip"
+            },
             "button": {
                 "continue": "Continuar",
                 "finish": "Finish"

--- a/src/frontend/public/locales/es/translation.json
+++ b/src/frontend/public/locales/es/translation.json
@@ -127,7 +127,7 @@
             "stepAddTrip": {
                 "question": "Which trips do you make frequently?",
                 "description": "We use this information to recommend neighborhoods near the places you visit often",
-                "addATrip": "Add a trip"
+                "addATrip": "Add another trip"
             },
             "button": {
                 "continue": "Continuar",

--- a/src/frontend/public/locales/zh/translation.json
+++ b/src/frontend/public/locales/zh/translation.json
@@ -127,7 +127,7 @@
             "stepAddTrip": {
                 "question": "Which trips do you make frequently?",
                 "description": "We use this information to recommend neighborhoods near the places you visit often",
-                "addATrip": "Add a trip"
+                "addATrip": "Add another trip"
             },
             "button": {
                 "continue": "EXAMPLE 继续",

--- a/src/frontend/public/locales/zh/translation.json
+++ b/src/frontend/public/locales/zh/translation.json
@@ -127,7 +127,8 @@
             "stepAddTrip": {
                 "question": "Which trips do you make frequently?",
                 "description": "We use this information to recommend neighborhoods near the places you visit often",
-                "addATrip": "Add another trip"
+                "addATrip": "Add a trip",
+                "addAnotherTrip": "Add another trip"
             },
             "addNewTripModal": {
                 "question": "Add new trip",

--- a/src/frontend/public/locales/zh/translation.json
+++ b/src/frontend/public/locales/zh/translation.json
@@ -129,6 +129,13 @@
                 "description": "We use this information to recommend neighborhoods near the places you visit often",
                 "addATrip": "Add another trip"
             },
+            "addNewTripModal": {
+                "question": "Add new trip",
+                "purposeLabel": "What kind of place is it?",
+                "locationLabel": "Where is it?",
+                "locationPlaceholder": "Enter an address",
+                "finish": "Add trip"
+            },
             "button": {
                 "continue": "EXAMPLE 继续",
                 "finish": "完成"

--- a/src/frontend/src/components/base/Autocomplete/Autocomplete.styles.ts
+++ b/src/frontend/src/components/base/Autocomplete/Autocomplete.styles.ts
@@ -1,0 +1,10 @@
+import { tv } from "tailwind-variants";
+
+const autocompleteStyles = tv({
+    slots: {
+        searchRoot: "flex w-full border border-gray-300 rounded-lg max-h-fit",
+        input: "p-4 overflow-clip w-full justify-between text-md font-normal text-gray-800 placeholder:text-gray-500 [&::-webkit-search-cancel-button]:hidden",
+    },
+});
+
+export default autocompleteStyles;

--- a/src/frontend/src/components/base/Autocomplete/Autocomplete.styles.ts
+++ b/src/frontend/src/components/base/Autocomplete/Autocomplete.styles.ts
@@ -2,8 +2,9 @@ import { tv } from "tailwind-variants";
 
 const autocompleteStyles = tv({
     slots: {
-        searchRoot: "flex w-full border border-gray-300 rounded-lg max-h-fit",
-        input: "p-4 overflow-clip w-full justify-between text-md font-normal text-gray-800 placeholder:text-gray-500 [&::-webkit-search-cancel-button]:hidden",
+        searchRoot:
+            "flex w-full border border-gray-300 rounded-lg max-h-fit focus-within:border-teal-600 focus-within:border-2 cursor-pointer hover:border-gray-500",
+        input: "p-4 overflow-clip w-full justify-between text-md font-normal text-gray-800 placeholder:text-gray-500 [&::-webkit-search-cancel-button]:hidden focus:outline-none",
     },
 });
 

--- a/src/frontend/src/components/base/Autocomplete/Autocomplete.tsx
+++ b/src/frontend/src/components/base/Autocomplete/Autocomplete.tsx
@@ -1,0 +1,99 @@
+import { useAsyncList, type AsyncListData } from "@react-stately/data";
+import {
+    Autocomplete as AriaAutocomplete,
+    Input,
+    Menu,
+    MenuItem,
+    SearchField,
+} from "react-aria-components";
+
+import TimesIcon from "assets/icons/times.svg?react";
+import Button from "components/base/Button/Button";
+import {
+    dropdownItemStyles,
+    dropdownPopoverStyles,
+} from "../Dropdown/Dropdown.styles";
+import autocompleteStyles from "./Autocomplete.styles";
+
+type Suggestion = { name: string; [key: string]: any };
+
+export function Autocomplete({
+    placeholder,
+    suggestions,
+    loadAsyncSuggestions,
+    onSuggestionCallback,
+}: {
+    placeholder: string;
+    suggestions?: Suggestion[];
+    loadAsyncSuggestions?: (
+        query: string,
+        signal: AbortSignal
+    ) => Promise<Suggestion[]>;
+    onSuggestionCallback?: (suggestion: Suggestion) => void;
+}) {
+    const { searchRoot, input: inputStyles } = autocompleteStyles();
+    const baseDropdownPopoverStyles = dropdownPopoverStyles();
+    const baseDropdownItemStyles = dropdownItemStyles();
+
+    let filteredSuggestions: AsyncListData<Suggestion> = useAsyncList({
+        async load({ signal, filterText }) {
+            if (loadAsyncSuggestions && filterText) {
+                const items = await loadAsyncSuggestions(filterText, signal);
+                return { items };
+            } else if (suggestions && filterText) {
+                const filtered = suggestions.filter(item =>
+                    item.name.toLowerCase().includes(filterText.toLowerCase())
+                );
+                return { items: filtered };
+            }
+            return { items: [] };
+        },
+        initialFilterText: "",
+    });
+
+    // Force close menu on suggestion selection
+    const menuIsOpen =
+        filteredSuggestions.items.length > 1 ||
+        (filteredSuggestions.items.length === 1 &&
+            filteredSuggestions.filterText !==
+                filteredSuggestions.items[0].name);
+
+    return (
+        <AriaAutocomplete
+            onInputChange={filteredSuggestions.setFilterText}
+            inputValue={filteredSuggestions.filterText}
+        >
+            <SearchField aria-label="Search" autoFocus className={searchRoot()}>
+                <Input placeholder={placeholder} className={inputStyles()} />
+                <Button
+                    variant="outline"
+                    size="small"
+                    leftIcon={
+                        <TimesIcon className="h-5 w-5 font-ligth fill-black" />
+                    }
+                    className="h-7 w-7 py-2 px-3 self-center mr-3"
+                />
+            </SearchField>
+            <Menu
+                items={menuIsOpen ? filteredSuggestions.items : []}
+                className={`${baseDropdownPopoverStyles} ${menuIsOpen ? "visible" : "invisible"}`}
+            >
+                {item => (
+                    <MenuItem
+                        id={item.name}
+                        onAction={() => {
+                            filteredSuggestions.setFilterText(item.name);
+                            if (onSuggestionCallback) {
+                                onSuggestionCallback(item);
+                            }
+                        }}
+                        className={baseDropdownItemStyles}
+                        aria-label="item"
+                    >
+                        {item.name}
+                    </MenuItem>
+                )}
+            </Menu>
+        </AriaAutocomplete>
+    );
+}

--- a/src/frontend/src/components/base/Autocomplete/Autocomplete.tsx
+++ b/src/frontend/src/components/base/Autocomplete/Autocomplete.tsx
@@ -37,6 +37,11 @@ export function Autocomplete({
     const baseDropdownPopoverStyles = dropdownPopoverStyles();
     const baseDropdownItemStyles = dropdownItemStyles();
 
+    // Avoids using react-aria filter prop to handle suggesting async data or static data
+    // Expanded from example of useAsyncList from react-aria Autocomplete docs:
+    // https://react-spectrum.adobe.com/react-aria/Autocomplete.html#async-loading
+    // If loadAsyncSuggestions passed in, handles load fn that returns promise of filtered data from server.
+    // If not async, handles filtering of static list manually.
     let filteredSuggestions: AsyncListData<Suggestion> = useAsyncList({
         async load({ signal, filterText }) {
             if (loadAsyncSuggestions && filterText) {

--- a/src/frontend/src/components/base/Autocomplete/Autocomplete.tsx
+++ b/src/frontend/src/components/base/Autocomplete/Autocomplete.tsx
@@ -69,7 +69,7 @@ export function Autocomplete({
                 aria-label="Search"
                 autoFocus
                 onClear={onClearCallback}
-                className={searchRoot()}
+                className={`${searchRoot()} ${menuIsOpen ? "rounded-b-none" : ""} `}
             >
                 <Input placeholder={placeholder} className={inputStyles()} />
                 <Button
@@ -83,7 +83,7 @@ export function Autocomplete({
             </SearchField>
             <Menu
                 items={menuIsOpen ? filteredSuggestions.items : []}
-                className={`${baseDropdownPopoverStyles} ${menuIsOpen ? "visible" : "invisible"}`}
+                className={`${baseDropdownPopoverStyles} ${menuIsOpen ? "visible" : "invisible"} rounded-t-none`}
             >
                 {item => (
                     <MenuItem

--- a/src/frontend/src/components/base/Autocomplete/Autocomplete.tsx
+++ b/src/frontend/src/components/base/Autocomplete/Autocomplete.tsx
@@ -22,6 +22,7 @@ export function Autocomplete({
     suggestions,
     loadAsyncSuggestions,
     onSuggestionCallback,
+    onClearCallback,
 }: {
     placeholder: string;
     suggestions?: Suggestion[];
@@ -30,6 +31,7 @@ export function Autocomplete({
         signal: AbortSignal
     ) => Promise<Suggestion[]>;
     onSuggestionCallback?: (suggestion: Suggestion) => void;
+    onClearCallback?: () => void;
 }) {
     const { searchRoot, input: inputStyles } = autocompleteStyles();
     const baseDropdownPopoverStyles = dropdownPopoverStyles();
@@ -63,7 +65,12 @@ export function Autocomplete({
             onInputChange={filteredSuggestions.setFilterText}
             inputValue={filteredSuggestions.filterText}
         >
-            <SearchField aria-label="Search" autoFocus className={searchRoot()}>
+            <SearchField
+                aria-label="Search"
+                autoFocus
+                onClear={onClearCallback}
+                className={searchRoot()}
+            >
                 <Input placeholder={placeholder} className={inputStyles()} />
                 <Button
                     variant="outline"

--- a/src/frontend/src/components/base/Modal/Modal.styles.ts
+++ b/src/frontend/src/components/base/Modal/Modal.styles.ts
@@ -21,7 +21,7 @@ export const modalOverlayStyles = tv({
 
 export const modalStyles = tv({
     base: [
-        "relative z-50 w-full justify-self-center rounded-[var(--spacing-4)]",
+        "relative z-50 w-full justify-self-center rounded-[var(--spacing-4)] max-h-full overflow-y-scroll",
         "bg-white shadow-md",
     ],
     variants: {

--- a/src/frontend/src/constants.ts
+++ b/src/frontend/src/constants.ts
@@ -1,4 +1,4 @@
-import { Language, type NetworkModeOptionKey } from "./enums";
+import { Language, Place, type NetworkModeOptionKey } from "./enums";
 
 export const languageToLabel = {
     [Language.EN]: "English",
@@ -28,6 +28,11 @@ export const networks: Record<NetworkModeOptionKey, any> = {
         commuter: null,
     },
 };
+
+export const purposesMap = Object.values(Place).map(value => ({
+    id: value,
+    name: value,
+}));
 
 // Network colors
 export const NETWORK_COLORS = [

--- a/src/frontend/src/pages/Components.tsx
+++ b/src/frontend/src/pages/Components.tsx
@@ -2,23 +2,23 @@ import { useState } from "react";
 import { useParams } from "react-router";
 
 import Button from "components/base/Button/Button";
+import Meter from "components/base/Meter/Meter";
+import Range from "components/base/Range/Range";
+import CompareFavoritesButton from "components/CompareFavoritesButton";
+import NeighborhoodCard from "components/NeighborhoodCard/NeighborhoodCard";
+import SelectLanguageButtons from "components/SelectLanguageButtons";
 import {
     UserProfileSubheader,
     UserProfileSubheaderMobile,
 } from "components/UserProfileSubheader";
-import CompareFavoritesButton from "components/CompareFavoritesButton";
-import SelectLanguageButtons from "components/SelectLanguageButtons";
-import Meter from "components/base/Meter/Meter";
-import Range from "components/base/Range/Range";
-import NeighborhoodCard from "components/NeighborhoodCard/NeighborhoodCard";
 import { Language, Place, type LanguageKey } from "src/enums";
 
 import ArrowLeftIcon from "assets/icons/arrow-left.svg?react";
 import ArrowRightIcon from "assets/icons/arrow-right.svg?react";
 import StarIcon from "assets/icons/star.svg?react";
-import InputText from "components/InputText";
-import InputNumber from "components/InputNumber";
 import Checkbox from "components/base/Checkbox/Checkbox";
+import InputNumber from "components/InputNumber";
+import InputText from "components/InputText";
 import Wizard from "components/Wizard/Wizard";
 import WizardStep from "components/Wizard/WizardStep";
 import { Accordion } from "src/components/base/Accordion/Accordion";

--- a/src/frontend/src/pages/Discover/Profile/AddTripModal.tsx
+++ b/src/frontend/src/pages/Discover/Profile/AddTripModal.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { Destination } from "reducers/userProfile/types";
+import { Place, type PlaceKey } from "src/enums";
+
+import { Modal, ModalOverlay } from "components/base/Modal/Modal";
+import WizardStep from "components/Wizard/WizardStep";
+
+const EMPTY_DESTINATION = {
+    location: {
+        label: "",
+        position: {
+            lat: 0,
+            lon: 0,
+        },
+    },
+    primary: false,
+    purpose: "",
+};
+
+// AddTripsModal is stylistically a wizard step,
+// but functionally a modal only called within the StepTrips component.
+// Custom handleBack and handleNext does not affect edit trips wizard progess.
+const AddTripModal = ({
+    isModalOpen,
+    isModalOpenChangeCallback,
+    handleBack,
+    handleNext,
+    isPrimary = false,
+}: {
+    isModalOpen: boolean;
+    isModalOpenChangeCallback: (b: boolean) => void;
+    handleBack: () => void;
+    handleNext: (d: Destination) => void;
+    isPrimary: boolean;
+}) => {
+    const { t } = useTranslation();
+
+    const TEMP_NEW_DEST = {
+        location: {
+            label: "1234 Address Ave Boston 12345",
+            position: {
+                lat: 1,
+                lon: 2,
+            },
+        },
+        primary: false,
+        purpose: "Daycare",
+    };
+
+    const [destination, setDestination] = useState<Destination>({
+        ...EMPTY_DESTINATION,
+        primary: isPrimary,
+    });
+
+    return (
+        <ModalOverlay
+            isDismissable
+            isMobile
+            isOpen={isModalOpen}
+            onOpenChange={isModalOpenChangeCallback}
+        >
+            <Modal size="small" className="flex flex-col gap-6 p-5">
+                <WizardStep
+                    question={t("userTrip.wizard.addNewTripModal.question")}
+                    buttonText={t("userTrip.wizard.addNewTripModal.finish")}
+                    handleBack={handleBack}
+                    handleNext={() => handleNext(TEMP_NEW_DEST)}
+                >
+                    <div>
+                        <h2>
+                            {t("userTrip.wizard.addNewTripModal.purposeLabel")}
+                        </h2>
+                    </div>
+                    <div>
+                        <h2>
+                            {t("userTrip.wizard.addNewTripModal.locationLabel")}
+                        </h2>
+                    </div>
+                </WizardStep>
+            </Modal>
+        </ModalOverlay>
+    );
+};
+
+export default AddTripModal;

--- a/src/frontend/src/pages/Discover/Profile/AddTripModal.tsx
+++ b/src/frontend/src/pages/Discover/Profile/AddTripModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { GridList, GridListItem, type Selection } from "react-aria-components";
 import { useTranslation } from "react-i18next";
 
 import type { Destination } from "reducers/userProfile/types";
@@ -54,6 +55,25 @@ const AddTripModal = ({
         primary: isPrimary,
     });
 
+    const handlePurposeSelection = (keys: Selection) => {
+        if (keys !== "all") {
+            if (keys.size > 0) {
+                const purposeKey = [...keys][0];
+                setDestination({
+                    ...destination,
+                    purpose: purposeKey as PlaceKey,
+                });
+            } else {
+                setDestination({ ...destination, purpose: "" });
+            }
+        }
+    };
+
+    const purposesMap = Object.values(Place).map(value => ({
+        id: value,
+        name: value,
+    }));
+
     return (
         <ModalOverlay
             isDismissable
@@ -72,6 +92,29 @@ const AddTripModal = ({
                         <h2>
                             {t("userTrip.wizard.addNewTripModal.purposeLabel")}
                         </h2>
+                        <GridList
+                            aria-label="Places to select"
+                            items={purposesMap}
+                            selectionMode="single"
+                            selectedKeys={[destination.purpose]}
+                            onSelectionChange={handlePurposeSelection}
+                            className="grid grid-cols-2 gap-3 list-none"
+                        >
+                            {item => (
+                                <GridListItem
+                                    id={item.id}
+                                    textValue={item.name}
+                                >
+                                    {({ isSelected }) => (
+                                        <div
+                                            className={`w-full h-full ${isSelected ? "border-2 border-teal-600" : "border-2 border-transparent"}`}
+                                        >
+                                            {item.name}
+                                        </div>
+                                    )}
+                                </GridListItem>
+                            )}
+                        </GridList>
                     </div>
                     <div>
                         <h2>

--- a/src/frontend/src/pages/Discover/Profile/AddTripModal.tsx
+++ b/src/frontend/src/pages/Discover/Profile/AddTripModal.tsx
@@ -3,12 +3,13 @@ import { GridList, GridListItem, type Selection } from "react-aria-components";
 import { useTranslation } from "react-i18next";
 
 import type { Destination } from "reducers/userProfile/types";
-import { Place, type PlaceKey } from "src/enums";
+import { type PlaceKey } from "src/enums";
 
 import { Modal, ModalOverlay } from "components/base/Modal/Modal";
 import WizardStep from "components/Wizard/WizardStep";
 import { Autocomplete } from "src/components/base/Autocomplete/Autocomplete";
 import buttonStyles from "src/components/base/Button/Button.styles";
+import { purposesMap } from "src/constants";
 
 // TODO: Remove following async Mapbox Search API Fetch
 // Example from autocomplete suggestions docs: https://docs.mapbox.com/api/search/search-box/#example-request-get-suggested-results
@@ -74,21 +75,15 @@ const AddTripModal = ({
     isModalOpenChangeCallback,
     handleBack,
     handleNext,
-    isPrimary = false,
 }: {
     isModalOpen: boolean;
     isModalOpenChangeCallback: (b: boolean) => void;
     handleBack: () => void;
     handleNext: (d: Destination) => void;
-    isPrimary: boolean;
 }) => {
-    const initialDestination = {
-        ...EMPTY_DESTINATION,
-        primary: isPrimary,
-    };
     const { t } = useTranslation();
     const [destination, setDestination] =
-        useState<Destination>(initialDestination);
+        useState<Destination>(EMPTY_DESTINATION);
 
     const handlePurposeSelection = (keys: Selection) => {
         if (keys !== "all") {
@@ -103,11 +98,6 @@ const AddTripModal = ({
             }
         }
     };
-
-    const purposesMap = Object.values(Place).map(value => ({
-        id: value,
-        name: value,
-    }));
 
     const handleLocationSelection = (selection: {
         name: string;
@@ -141,7 +131,7 @@ const AddTripModal = ({
     const handleLocationClear = () => {
         setDestination({
             ...destination,
-            location: initialDestination.location,
+            location: EMPTY_DESTINATION.location,
         });
     };
 
@@ -151,7 +141,7 @@ const AddTripModal = ({
             isMobile
             isOpen={isModalOpen}
             onOpenChange={isOpen => {
-                setDestination(initialDestination);
+                setDestination(EMPTY_DESTINATION);
                 isModalOpenChangeCallback(isOpen);
             }}
         >
@@ -160,10 +150,13 @@ const AddTripModal = ({
                     question={t("userTrip.wizard.addNewTripModal.question")}
                     buttonText={t("userTrip.wizard.addNewTripModal.finish")}
                     handleBack={() => {
-                        setDestination(initialDestination);
+                        setDestination(EMPTY_DESTINATION);
                         handleBack();
                     }}
-                    handleNext={() => handleNext(destination)}
+                    handleNext={() => {
+                        setDestination(EMPTY_DESTINATION);
+                        handleNext(destination);
+                    }}
                     disableNext={
                         !destination.purpose || !destination.location.label
                     }

--- a/src/frontend/src/pages/Discover/Profile/AddTripModal.tsx
+++ b/src/frontend/src/pages/Discover/Profile/AddTripModal.tsx
@@ -81,24 +81,13 @@ const AddTripModal = ({
     handleNext: (d: Destination) => void;
     isPrimary: boolean;
 }) => {
-    const { t } = useTranslation();
-
-    const TEMP_NEW_DEST = {
-        location: {
-            label: "1234 Address Ave Boston 12345",
-            position: {
-                lat: 1,
-                lon: 2,
-            },
-        },
-        primary: false,
-        purpose: "Daycare",
-    };
-
-    const [destination, setDestination] = useState<Destination>({
+    const initialDestination = {
         ...EMPTY_DESTINATION,
         primary: isPrimary,
-    });
+    };
+    const { t } = useTranslation();
+    const [destination, setDestination] =
+        useState<Destination>(initialDestination);
 
     const handlePurposeSelection = (keys: Selection) => {
         if (keys !== "all") {
@@ -151,7 +140,7 @@ const AddTripModal = ({
     const handleLocationClear = () => {
         setDestination({
             ...destination,
-            location: EMPTY_DESTINATION.location,
+            location: initialDestination.location,
         });
     };
 
@@ -160,14 +149,23 @@ const AddTripModal = ({
             isDismissable
             isMobile
             isOpen={isModalOpen}
-            onOpenChange={isModalOpenChangeCallback}
+            onOpenChange={isOpen => {
+                setDestination(initialDestination);
+                isModalOpenChangeCallback(isOpen);
+            }}
         >
             <Modal size="small" className="flex flex-col gap-6 p-5">
                 <WizardStep
                     question={t("userTrip.wizard.addNewTripModal.question")}
                     buttonText={t("userTrip.wizard.addNewTripModal.finish")}
-                    handleBack={handleBack}
-                    handleNext={() => handleNext(TEMP_NEW_DEST)}
+                    handleBack={() => {
+                        setDestination(initialDestination);
+                        handleBack();
+                    }}
+                    handleNext={() => handleNext(destination)}
+                    disableNext={
+                        !destination.purpose || !destination.location.label
+                    }
                 >
                     <div>
                         <h2>

--- a/src/frontend/src/pages/Discover/Profile/AddTripModal.tsx
+++ b/src/frontend/src/pages/Discover/Profile/AddTripModal.tsx
@@ -8,6 +8,7 @@ import { Place, type PlaceKey } from "src/enums";
 import { Modal, ModalOverlay } from "components/base/Modal/Modal";
 import WizardStep from "components/Wizard/WizardStep";
 import { Autocomplete } from "src/components/base/Autocomplete/Autocomplete";
+import buttonStyles from "src/components/base/Button/Button.styles";
 
 // TODO: Remove following async Mapbox Search API Fetch
 // Example from autocomplete suggestions docs: https://docs.mapbox.com/api/search/search-box/#example-request-get-suggested-results
@@ -154,7 +155,7 @@ const AddTripModal = ({
                 isModalOpenChangeCallback(isOpen);
             }}
         >
-            <Modal size="small" className="flex flex-col gap-6 p-5">
+            <Modal size="small" className="flex flex-col p-5">
                 <WizardStep
                     question={t("userTrip.wizard.addNewTripModal.question")}
                     buttonText={t("userTrip.wizard.addNewTripModal.finish")}
@@ -167,17 +168,19 @@ const AddTripModal = ({
                         !destination.purpose || !destination.location.label
                     }
                 >
-                    <div>
-                        <h2>
+                    <div className="flex flex-col gap-3">
+                        <h2 className="text-lg font-bold text-black">
                             {t("userTrip.wizard.addNewTripModal.purposeLabel")}
                         </h2>
                         <GridList
-                            aria-label="Places to select"
+                            aria-label={t(
+                                "userTrip.wizard.addNewTripModal.purposeLabel"
+                            )}
                             items={purposesMap}
                             selectionMode="single"
                             selectedKeys={[destination.purpose]}
                             onSelectionChange={handlePurposeSelection}
-                            className="grid grid-cols-2 gap-3 list-none"
+                            className="grid grid-cols-2 gap-3 list-none w-full max-w-88 self-center"
                         >
                             {item => (
                                 <GridListItem
@@ -186,17 +189,19 @@ const AddTripModal = ({
                                 >
                                     {({ isSelected }) => (
                                         <div
-                                            className={`w-full h-full ${isSelected ? "border-2 border-teal-600" : "border-2 border-transparent"}`}
+                                            className={`${buttonStyles({ variant: "outline" })} w-full h-full rounded-lg !p-4 justify-items-center ${isSelected ? "border-2 border-teal-600" : "border-2 border-gray-300"}`}
                                         >
-                                            {item.name}
+                                            <p className="text-md font-bold text-black">
+                                                {item.name}
+                                            </p>
                                         </div>
                                     )}
                                 </GridListItem>
                             )}
                         </GridList>
                     </div>
-                    <div>
-                        <h2>
+                    <div className="flex flex-col -mb-6">
+                        <h2 className="text-lg font-bold text-black mb-3">
                             {t("userTrip.wizard.addNewTripModal.locationLabel")}
                         </h2>
                         <Autocomplete

--- a/src/frontend/src/pages/Discover/Profile/AddTripModal.tsx
+++ b/src/frontend/src/pages/Discover/Profile/AddTripModal.tsx
@@ -7,6 +7,51 @@ import { Place, type PlaceKey } from "src/enums";
 
 import { Modal, ModalOverlay } from "components/base/Modal/Modal";
 import WizardStep from "components/Wizard/WizardStep";
+import { Autocomplete } from "src/components/base/Autocomplete/Autocomplete";
+
+// TODO: Remove following async Mapbox Search API Fetch
+// Example from autocomplete suggestions docs: https://docs.mapbox.com/api/search/search-box/#example-request-get-suggested-results
+const MAPBOX_EMPTY_SUGGESTIONS = {
+    suggestions: [
+        {
+            name: "Michigan Stadium",
+            mapbox_id: "Example ID",
+            feature_type: "poi",
+            address: "1201 S Main St",
+            full_address:
+                "1201 S Main St, Ann Arbor, Michigan 48104, United States of America",
+            place_formatted:
+                "Ann Arbor, Michigan 48104, United States of America",
+            context: {
+                country: {
+                    name: "United States of America",
+                    country_code: "US",
+                    country_code_alpha_3: "USA",
+                },
+                region: {
+                    name: "Michigan",
+                    region_code: "MI",
+                    region_code_full: "US-MI",
+                },
+                postcode: { name: "48104" },
+                place: { name: "Ann Arbor" },
+                neighborhood: { name: "South Main" },
+                street: { name: "s main st" },
+            },
+            language: "en",
+            maki: "marker",
+            poi_category: ["track", "sports"],
+            poi_category_ids: ["track", "sports"],
+            external_ids: {
+                safegraph: "Example ID",
+                foursquare: "Example ID",
+            },
+            metadata: {},
+        },
+    ],
+    attribution:
+        "© 2023 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)",
+};
 
 const EMPTY_DESTINATION = {
     location: {
@@ -74,6 +119,42 @@ const AddTripModal = ({
         name: value,
     }));
 
+    const handleLocationSelection = (selection: {
+        name: string;
+        address?: string;
+        mapbox_id?: string;
+        [key: string]: any;
+    }) => {
+        // TODO: Use Mapbox search API to retrieve if id available.
+        // Use Mapbox forward geocoding API if only address
+        // Use address if available, else name
+        const label = selection.address ?? selection.name;
+        const EXAMPLE_COORDS_RES = {
+            longitude: -71.117229,
+            latitude: 42.4063342,
+        };
+
+        const location = {
+            label: label,
+            position: {
+                lat: EXAMPLE_COORDS_RES.latitude,
+                lon: EXAMPLE_COORDS_RES.longitude,
+            },
+        };
+
+        setDestination({
+            ...destination,
+            location: location,
+        });
+    };
+
+    const handleLocationClear = () => {
+        setDestination({
+            ...destination,
+            location: EMPTY_DESTINATION.location,
+        });
+    };
+
     return (
         <ModalOverlay
             isDismissable
@@ -120,6 +201,16 @@ const AddTripModal = ({
                         <h2>
                             {t("userTrip.wizard.addNewTripModal.locationLabel")}
                         </h2>
+                        <Autocomplete
+                            placeholder={t(
+                                "userTrip.wizard.addNewTripModal.locationPlaceholder"
+                            )}
+                            suggestions={MAPBOX_EMPTY_SUGGESTIONS.suggestions}
+                            onClearCallback={handleLocationClear}
+                            onSuggestionCallback={s =>
+                                handleLocationSelection(s)
+                            }
+                        />
                     </div>
                 </WizardStep>
             </Modal>

--- a/src/frontend/src/pages/Discover/Profile/Profile.tsx
+++ b/src/frontend/src/pages/Discover/Profile/Profile.tsx
@@ -136,7 +136,7 @@ const Profile = () => {
                     buffer={profileBuffer}
                     setProfileBuffer={setProfileBuffer}
                     handleBack={handleBack}
-                    handleNext={handleNext}
+                    handleNext={handleFinish}
                 />
             </Wizard>
         </div>

--- a/src/frontend/src/pages/Discover/Profile/Profile.tsx
+++ b/src/frontend/src/pages/Discover/Profile/Profile.tsx
@@ -64,7 +64,13 @@ const Profile = () => {
     // persist data to backend via PUT endpoint
     // redux store's user profile gets updated on fulfilled PUT in the reducer
     const handleFinish = () => {
-        // TODO: May need to take care of destinations from your trips wizard
+        const destinations = profileBuffer.destinations;
+        // One destination must be primary, used to set
+        // userProfile.activeDestination to calculate score.
+        // Use first destination by default.
+        if (!destinations.find(d => d.primary)) {
+            destinations[0].primary = true;
+        }
         dispatch(
             updateUserProfile({
                 ...profileBuffer,

--- a/src/frontend/src/pages/Discover/Profile/Profile.tsx
+++ b/src/frontend/src/pages/Discover/Profile/Profile.tsx
@@ -1,22 +1,22 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
-import { useTranslation } from "react-i18next";
 
+import Button from "components/base/Button/Button";
+import SelectLanguageButtons from "components/SelectLanguageButtons";
+import Wizard from "components/Wizard/Wizard";
+import useMediaQuery from "hooks/useMediaQuery";
+import { updateUserProfile } from "reducers/userProfile/userProfileThunk";
 import { Language, type LanguageKey } from "src/enums";
 import { useAppDispatch, type RootState } from "store/store";
-import useMediaQuery from "hooks/useMediaQuery";
-import SelectLanguageButtons from "components/SelectLanguageButtons";
-import Button from "components/base/Button/Button";
-import Wizard from "components/Wizard/Wizard";
-import WizardStep from "components/Wizard/WizardStep";
-import { updateUserProfile } from "reducers/userProfile/userProfileThunk";
+import profileStyles from "./Profile.styles";
 import StepBedroom from "./StepBedroom";
 import StepImportance from "./StepImportance";
 import StepTravelMode from "./StepTravelMode";
-import profileStyles from "./Profile.styles";
 
 import NeighborhoodLiteImage from "assets/icons/neighborhood-lite.svg?react";
+import StepTrips from "./StepTrips";
 
 const TOTAL_STEPS = 4;
 
@@ -132,18 +132,12 @@ const Profile = () => {
                     handleBack={handleBack}
                     handleNext={handleNext}
                 />
-                {/* TODO: Your trip steps */}
-                <WizardStep
-                    question={t("userTrip.wizard.stepAddTrip.question")}
-                    description={t("userTrip.wizard.stepAddTrip.description")}
-                    buttonText={t("userTrip.wizard.button.finish")}
+                <StepTrips
+                    buffer={profileBuffer}
+                    setProfileBuffer={setProfileBuffer}
                     handleBack={handleBack}
-                    handleNext={handleFinish}
-                >
-                    <p className=" text-gray-600">
-                        Step 4. The "Add trip" logic goes here
-                    </p>
-                </WizardStep>
+                    handleNext={handleNext}
+                />
             </Wizard>
         </div>
     );

--- a/src/frontend/src/pages/Discover/Profile/StepTrips.tsx
+++ b/src/frontend/src/pages/Discover/Profile/StepTrips.tsx
@@ -6,6 +6,7 @@ import Button from "components/base/Button/Button";
 import WizardStep from "components/Wizard/WizardStep";
 import { useState } from "react";
 import type { Destination } from "src/reducers/userProfile/types";
+import AddTripModal from "./AddTripModal";
 import type { BaseProps } from "./types";
 
 const StepTrips = ({
@@ -56,6 +57,7 @@ const StepTrips = ({
             ...state,
             destinations: [...destinations, destination],
         }));
+        setIsAddTripModalOpen(false);
     };
 
     return (
@@ -67,6 +69,15 @@ const StepTrips = ({
             handleNext={handleNext}
             disableNext={!destinations.length}
         >
+            <AddTripModal
+                isModalOpen={addTripModalOpen}
+                isModalOpenChangeCallback={isOpen =>
+                    setIsAddTripModalOpen(isOpen)
+                }
+                handleBack={() => setIsAddTripModalOpen(false)}
+                handleNext={onAddDestination}
+                isPrimary={!destinations.find(d => d.primary)}
+            />
             {destinations.map((destination, index) => (
                 <div
                     key={index}

--- a/src/frontend/src/pages/Discover/Profile/StepTrips.tsx
+++ b/src/frontend/src/pages/Discover/Profile/StepTrips.tsx
@@ -55,30 +55,32 @@ const StepTrips = ({
                 handleNext={onAddDestination}
                 isPrimary={!destinations.find(d => d.primary)}
             />
-            {destinations.map((destination, index) => (
-                <div
-                    key={index}
-                    className="w-full flex flex-row justify-between items-start rounded-2xl p-4 bg-gray-100"
-                >
-                    <div>
-                        <h2 className="text-xl font-bold text-gray-900">
-                            {destination.purpose}
-                        </h2>
-                        <p className="max-w-40 flex flex-wrap font-normal text-gray-600 text-sm">
-                            {destination.location.label}
-                        </p>
+            <div className="flex flex-col gap-3">
+                {destinations.map((destination, index) => (
+                    <div
+                        key={index}
+                        className="w-full flex flex-row justify-between items-start rounded-2xl p-4 bg-gray-100"
+                    >
+                        <div>
+                            <h2 className="text-xl font-bold text-gray-900">
+                                {destination.purpose}
+                            </h2>
+                            <p className="max-w-40 flex flex-wrap font-normal text-gray-600 text-sm">
+                                {destination.location.label}
+                            </p>
+                        </div>
+                        <Button
+                            variant="outline"
+                            size="small"
+                            leftIcon={
+                                <TimesIcon className="h-5 w-5 font-ligth fill-black" />
+                            }
+                            onPress={() => onRemoveDestination(index)}
+                            className="h-7 w-7 py-2 px-3"
+                        />
                     </div>
-                    <Button
-                        variant="outline"
-                        size="small"
-                        leftIcon={
-                            <TimesIcon className="h-5 w-5 font-ligth fill-black" />
-                        }
-                        onPress={() => onRemoveDestination(index)}
-                        className="h-7 w-7 py-2 px-3"
-                    />
-                </div>
-            ))}
+                ))}
+            </div>
             <Button
                 variant="outline"
                 size="large"
@@ -88,7 +90,9 @@ const StepTrips = ({
                 className="justify-normal text-gray-700 text-lg font-bold"
                 onPress={() => setIsAddTripModalOpen(true)}
             >
-                {t("userTrip.wizard.stepAddTrip.addATrip")}
+                {destinations.length
+                    ? t("userTrip.wizard.stepAddTrip.addAnotherTrip")
+                    : t("userTrip.wizard.stepAddTrip.addATrip")}
             </Button>
         </WizardStep>
     );

--- a/src/frontend/src/pages/Discover/Profile/StepTrips.tsx
+++ b/src/frontend/src/pages/Discover/Profile/StepTrips.tsx
@@ -1,13 +1,14 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
+
+import type { Destination } from "reducers/userProfile/types";
+import type { BaseProps } from "./types";
 
 import PlusIcon from "assets/icons/plus.svg?react";
 import TimesIcon from "assets/icons/times.svg?react";
 import Button from "components/base/Button/Button";
 import WizardStep from "components/Wizard/WizardStep";
-import { useState } from "react";
-import type { Destination } from "src/reducers/userProfile/types";
 import AddTripModal from "./AddTripModal";
-import type { BaseProps } from "./types";
 
 const StepTrips = ({
     buffer,
@@ -17,31 +18,7 @@ const StepTrips = ({
 }: BaseProps) => {
     const { t } = useTranslation();
     const [addTripModalOpen, setIsAddTripModalOpen] = useState(false);
-    const TEMP_DEST = [
-        {
-            location: {
-                label: "1234 Address Ave Boston 12345",
-                position: {
-                    lat: 1,
-                    lon: 2,
-                },
-            },
-            primary: true,
-            purpose: "Work",
-        },
-        {
-            location: {
-                label: "1234 Address Ave Boston 12345",
-                position: {
-                    lat: 1,
-                    lon: 2,
-                },
-            },
-            primary: false,
-            purpose: "School",
-        },
-    ];
-    const destinations = TEMP_DEST; // buffer.destinations;
+    const destinations = buffer.destinations;
 
     const onRemoveDestination = (destinationIndex: number) => {
         const updatedDestinations = [...destinations];

--- a/src/frontend/src/pages/Discover/Profile/StepTrips.tsx
+++ b/src/frontend/src/pages/Discover/Profile/StepTrips.tsx
@@ -53,7 +53,6 @@ const StepTrips = ({
                 }
                 handleBack={() => setIsAddTripModalOpen(false)}
                 handleNext={onAddDestination}
-                isPrimary={!destinations.find(d => d.primary)}
             />
             <div className="flex flex-col gap-3">
                 {destinations.map((destination, index) => (

--- a/src/frontend/src/pages/Discover/Profile/StepTrips.tsx
+++ b/src/frontend/src/pages/Discover/Profile/StepTrips.tsx
@@ -1,0 +1,47 @@
+import { useTranslation } from "react-i18next";
+
+import WizardStep from "components/Wizard/WizardStep";
+import type { Destination } from "src/reducers/userProfile/types";
+import type { BaseProps } from "./types";
+
+const StepTrips = ({
+    buffer,
+    setProfileBuffer,
+    handleBack,
+    handleNext,
+}: BaseProps) => {
+    const { t } = useTranslation();
+
+    const onRemoveDestination = (destinationIndex: number) => {
+        const updatedDestinations = [...buffer.destinations];
+        updatedDestinations.splice(destinationIndex, 1);
+        setProfileBuffer(state => ({
+            ...state,
+            destinations: updatedDestinations,
+        }));
+    };
+
+    const onAddDestination = (destination: Destination) => {
+        setProfileBuffer(state => ({
+            ...state,
+            destinations: [...buffer.destinations, destination],
+        }));
+    };
+
+    return (
+        <WizardStep
+            question={t("userTrip.wizard.stepAddTrip.question")}
+            description={t("userTrip.wizard.stepAddTrip.description")}
+            buttonText={t("userTrip.wizard.button.finish")}
+            handleBack={handleBack}
+            handleNext={handleNext}
+            disableNext={!buffer.destinations.length}
+        >
+            <p className=" text-gray-600">
+                Step 4. The "Add trip" logic goes here
+            </p>
+        </WizardStep>
+    );
+};
+
+export default StepTrips;

--- a/src/frontend/src/pages/Discover/Profile/StepTrips.tsx
+++ b/src/frontend/src/pages/Discover/Profile/StepTrips.tsx
@@ -1,6 +1,10 @@
 import { useTranslation } from "react-i18next";
 
+import PlusIcon from "assets/icons/plus.svg?react";
+import TimesIcon from "assets/icons/times.svg?react";
+import Button from "components/base/Button/Button";
 import WizardStep from "components/Wizard/WizardStep";
+import { useState } from "react";
 import type { Destination } from "src/reducers/userProfile/types";
 import type { BaseProps } from "./types";
 
@@ -11,9 +15,35 @@ const StepTrips = ({
     handleNext,
 }: BaseProps) => {
     const { t } = useTranslation();
+    const [addTripModalOpen, setIsAddTripModalOpen] = useState(false);
+    const TEMP_DEST = [
+        {
+            location: {
+                label: "1234 Address Ave Boston 12345",
+                position: {
+                    lat: 1,
+                    lon: 2,
+                },
+            },
+            primary: true,
+            purpose: "Work",
+        },
+        {
+            location: {
+                label: "1234 Address Ave Boston 12345",
+                position: {
+                    lat: 1,
+                    lon: 2,
+                },
+            },
+            primary: false,
+            purpose: "School",
+        },
+    ];
+    const destinations = TEMP_DEST; // buffer.destinations;
 
     const onRemoveDestination = (destinationIndex: number) => {
-        const updatedDestinations = [...buffer.destinations];
+        const updatedDestinations = [...destinations];
         updatedDestinations.splice(destinationIndex, 1);
         setProfileBuffer(state => ({
             ...state,
@@ -24,7 +54,7 @@ const StepTrips = ({
     const onAddDestination = (destination: Destination) => {
         setProfileBuffer(state => ({
             ...state,
-            destinations: [...buffer.destinations, destination],
+            destinations: [...destinations, destination],
         }));
     };
 
@@ -35,11 +65,43 @@ const StepTrips = ({
             buttonText={t("userTrip.wizard.button.finish")}
             handleBack={handleBack}
             handleNext={handleNext}
-            disableNext={!buffer.destinations.length}
+            disableNext={!destinations.length}
         >
-            <p className=" text-gray-600">
-                Step 4. The "Add trip" logic goes here
-            </p>
+            {destinations.map((destination, index) => (
+                <div
+                    key={index}
+                    className="w-full flex flex-row justify-between items-start rounded-2xl p-4 bg-gray-100"
+                >
+                    <div>
+                        <h2 className="text-xl font-bold text-gray-900">
+                            {destination.purpose}
+                        </h2>
+                        <p className="max-w-40 flex flex-wrap font-normal text-gray-600 text-sm">
+                            {destination.location.label}
+                        </p>
+                    </div>
+                    <Button
+                        variant="outline"
+                        size="small"
+                        leftIcon={
+                            <TimesIcon className="h-5 w-5 font-ligth fill-black" />
+                        }
+                        onPress={() => onRemoveDestination(index)}
+                        className="h-7 w-7 py-2 px-3"
+                    />
+                </div>
+            ))}
+            <Button
+                variant="outline"
+                size="large"
+                leftIcon={
+                    <PlusIcon className="h-[18px] w-[18px] fill-gray-600" />
+                }
+                className="justify-normal text-gray-700 text-lg font-bold"
+                onPress={() => setIsAddTripModalOpen(true)}
+            >
+                {t("userTrip.wizard.stepAddTrip.addATrip")}
+            </Button>
         </WizardStep>
     );
 };


### PR DESCRIPTION
## Overview

Implements the Trips wizard as well as the Add Trips modal. Adds logic to add/remove destinations to user profile buffer (using sample location data).

### Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] Run `./scripts/format` to lint, format, and fix the application source code.
- [x] CI passes after rebase

### Demo


https://github.com/user-attachments/assets/c0e79dae-21db-42f8-a417-982f833a7c48


## Testing Instructions

 * `scripts/server`
 * Login as a user with no destinations
 * Move through the user profile wizard to get to the last step
 * Confirm last step displays no destinations and the Finish button is disabled
 * Click button to add a new trip
 * Confirm Add Trip modal opens
 * Click outside modal or on the back button
 * Confirm taken back to trips wizard step and no changes to wizard progress
 * Click to add trips again
 * Confirm "Add trip" button disabled with no purpose selection or no address input
 * Select purpose option (confirm styling matches figma)
 * Begin to type address in search suggestion and use button to clear selection (confirm this works)
 * The sample autocomplete suggestions list from Mapbox includes "Michigan", type an address input with this search term
 * Confirm autocomplete dropdown opens
 * Select option and confirm input populated with full selection text (I left an inline comment here, but I had trouble with keyboard-accessible focusing for button/dropdown. For the sake of time left it as is and can open a tech-debt card)
 * Confirm on selection that "Add trip" button no enabled
 * Select Add Trip and confirm guided back to trip wizard step
 * Confirm new destination now added to step
 * Confirm "Finish" now enabled
 * Select Finish and confirm user profile successfully updates with new data (Specifically, creates new Destination)
 * Confirm paths and times data successfully fetched for all destinations (under-the-hood this is creating a destination using one sample coordinate, so they will all be the same "place")
 * Confirm rankings calculate as expected
 * Logout and re-login, confirm no longer directed to Profile page


Resolves #720 #721
