### PR TITLE
Add neighborhood detail preview cards to Discover page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add transit trip directions overlay [#726](https://github.com/azavea/echo-locator/pull/726)
 - Add user profile wizard [#729](https://github.com/azavea/echo-locator/pull/729) [#737](https://github.com/azavea/echo-locator/pull/737)
 - Add top 10 tour [#730](https://github.com/azavea/echo-locator/pull/730)
+- Add neighborhood detail preview cards to Discover page [#741](https://github.com/azavea/echo-locator/pull/741)
 
 ### Changed
 

--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -1,0 +1,33 @@
+/* Hides default white background and popup tip */
+
+.map-popup-style-override .maplibregl-popup-content {
+    background-color: transparent !important;
+    padding: 0 !important;
+    box-shadow: none !important;
+}
+
+.map-popup-style-override .maplibregl-popup-tip {
+    display: none !important;
+}
+
+.map-popup-style-override .popup-title {
+    color: var(--Gray-900, #111827);
+    font-variant-numeric: lining-nums tabular-nums;
+
+    font-family: "Mulish";
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 130%; /* 18.2px */
+}
+
+.map-popup-style-override .popup-zipcode {
+    color: var(--Gray-600, #4b5563);
+    font-variant-numeric: lining-nums tabular-nums;
+
+    font-family: "Mulish";
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 130%; /* 18.2px */
+}

--- a/src/frontend/src/components/NeighborhoodCard/NeighborhoodCard.tsx
+++ b/src/frontend/src/components/NeighborhoodCard/NeighborhoodCard.tsx
@@ -1,13 +1,13 @@
-import { cardStyles } from "./NeighborhoodCard.styles";
 import Button from "components/base/Button/Button";
 import Meter, { type MeterProps } from "components/base/Meter/Meter";
 import Range, { type RangeProps } from "components/base/Range/Range";
+import { cardStyles } from "./NeighborhoodCard.styles";
 
-import TimesIcon from "assets/icons/times.svg?react";
-import FlagIcon from "assets/icons/flag.svg?react";
-import SquareDollarIcon from "assets/icons/square-dollar.svg?react";
 import ArrowLeftIcon from "assets/icons/arrow-left.svg?react";
 import ArrowRightIcon from "assets/icons/arrow-right.svg?react";
+import FlagIcon from "assets/icons/flag.svg?react";
+import SquareDollarIcon from "assets/icons/square-dollar.svg?react";
+import TimesIcon from "assets/icons/times.svg?react";
 
 export interface NeighborhoodCardProps {
     name: string;
@@ -25,6 +25,7 @@ export interface NeighborhoodCardProps {
     onPrev?: () => void;
     onDetails?: () => void;
     onNext?: () => void;
+    isPopup?: boolean;
 }
 
 const NeighborhoodCard = ({
@@ -39,6 +40,7 @@ const NeighborhoodCard = ({
     onPrev,
     onDetails,
     onNext,
+    isPopup,
 }: NeighborhoodCardProps) => {
     const {
         root,
@@ -83,8 +85,16 @@ const NeighborhoodCard = ({
             </div>
             <div className={content()}>
                 <div className={header()}>
-                    <h3 className={title()}>{name}</h3>
-                    <p className={zipStyle()}>{zip}</p>
+                    <h3
+                        className={`${title()} ${isPopup ? "popup-title" : ""}`}
+                    >
+                        {name}
+                    </h3>
+                    <p
+                        className={`${zipStyle()} ${isPopup ? "popup-zipcode" : ""}`}
+                    >
+                        {zip}
+                    </p>
                 </div>
                 {hasTag && (
                     <div className={tagsContainer()}>

--- a/src/frontend/src/components/Top10Tour/top10Tour.styles.ts
+++ b/src/frontend/src/components/Top10Tour/top10Tour.styles.ts
@@ -2,7 +2,7 @@ import { tv } from "tailwind-variants";
 
 export const top10TourStyles = tv({
     slots: {
-        root: "absolute w-full h-full p-3 content-end z-50",
+        root: "absolute w-full h-fit bottom-0 p-3 content-end z-50",
         startModalRoot: "content-end z-50",
         modalContent: "flex flex-col w-full gap-5 py-4 px-5",
         modalHeader: "text-2xl font-bold text-orange-700",

--- a/src/frontend/src/pages/Discover/Map/Map.tsx
+++ b/src/frontend/src/pages/Discover/Map/Map.tsx
@@ -5,6 +5,7 @@ import {
     Map as MapContainer,
     Marker,
     NavigationControl,
+    Popup,
     Source,
     type MapLayerMouseEvent,
     type MapRef,
@@ -33,6 +34,9 @@ import {
     neighborhoodsStyle,
 } from "./mapLayerStyles";
 import NeighborhoodDetailPreviewCard from "./NeighborhoodDetailPreviewCard";
+import NeighborhoodDetailPreviewPopup, {
+    type DetailPreviewPopupProps,
+} from "./NeighborhoodDetailPreviewPopup";
 
 interface Props {
     isMobile?: boolean;
@@ -44,6 +48,8 @@ const Map = ({ isMobile = true, mapDisplay = true }: Props) => {
     const [neighborhoodMobilePreview, setNeighborhoodMobilePreview] = useState<
         string | null
     >(null);
+    const [neighborhoodDesktopPreview, setNeighborhoodDesktopPreview] =
+        useState<DetailPreviewPopupProps | null>(null);
     const hasViewedInstructions = useAppSelector(
         selectUserHasViewedStartInstructions
     );
@@ -144,13 +150,19 @@ const Map = ({ isMobile = true, mapDisplay = true }: Props) => {
     const onMouseMove = (event: MapLayerMouseEvent) => {
         if (isMobile) return;
         const map = mapRef.current?.getMap();
-        const feature = event.features && event.features[0];
+        const { features, lngLat } = event;
+        const feature = features && features[0];
         if (map && feature?.id) {
             map.setFilter("neighborhoods-borders-hover", [
                 "==",
                 ["id"],
                 feature?.id,
             ]);
+            setNeighborhoodDesktopPreview({
+                longitude: lngLat.lng,
+                latitude: lngLat.lat,
+                zipcode: feature?.properties.zipcode,
+            });
         }
     };
 
@@ -160,6 +172,7 @@ const Map = ({ isMobile = true, mapDisplay = true }: Props) => {
         const map = mapRef.current?.getMap();
         if (map) {
             map.setFilter("neighborhoods-borders-hover", ["==", ["id"], ""]);
+            setNeighborhoodDesktopPreview(null);
         }
     };
 
@@ -277,6 +290,20 @@ const Map = ({ isMobile = true, mapDisplay = true }: Props) => {
                         }}
                     />
                 </CustomControlOverlay>
+                {neighborhoodDesktopPreview && (
+                    <Popup
+                        longitude={neighborhoodDesktopPreview.longitude}
+                        latitude={neighborhoodDesktopPreview.latitude}
+                        closeButton={false}
+                        closeOnClick={false}
+                        anchor="bottom-left"
+                        className="map-popup-style-override"
+                    >
+                        <NeighborhoodDetailPreviewPopup
+                            {...neighborhoodDesktopPreview}
+                        />
+                    </Popup>
+                )}
             </MapContainer>
             <Legend isMobile={isMobile} />
         </div>

--- a/src/frontend/src/pages/Discover/Map/Map.tsx
+++ b/src/frontend/src/pages/Discover/Map/Map.tsx
@@ -138,6 +138,8 @@ const Map = ({ isMobile = true, mapDisplay = true }: Props) => {
             { padding: 100, duration: 1000 }
         );
 
+        // Open neighborhood details preview card.
+        // Pauses Top 10 Tour if opened to view preview
         if (isMobile) {
             if (isTop10TourOpen) {
                 setIsTop10TourOpen(false);
@@ -146,7 +148,8 @@ const Map = ({ isMobile = true, mapDisplay = true }: Props) => {
         }
     };
 
-    // Desktop-only: highlight neighborhood on hover
+    // Desktop-only: highlight neighborhood on hover &
+    // display neighborhood detail preview popup anchored at cursor
     const onMouseMove = (event: MapLayerMouseEvent) => {
         if (isMobile) return;
         const map = mapRef.current?.getMap();
@@ -166,7 +169,8 @@ const Map = ({ isMobile = true, mapDisplay = true }: Props) => {
         }
     };
 
-    // Desktop-only: highlight neighborhood on hover
+    // Desktop-only: highlight neighborhood on hover &
+    // remove neighborhood detail preview popup
     const onMouseLeave = () => {
         if (isMobile) return;
         const map = mapRef.current?.getMap();
@@ -209,6 +213,8 @@ const Map = ({ isMobile = true, mapDisplay = true }: Props) => {
         );
     };
 
+    // On mobile preview card close:
+    // Remove neighborhood detail preview card & reset map bounds
     const handleNeighborhoodPreviewClose = () => {
         manualSelectCallback();
         setNeighborhoodMobilePreview(null);

--- a/src/frontend/src/pages/Discover/Map/Map.tsx
+++ b/src/frontend/src/pages/Discover/Map/Map.tsx
@@ -133,6 +133,9 @@ const Map = ({ isMobile = true, mapDisplay = true }: Props) => {
         );
 
         if (isMobile) {
+            if (isTop10TourOpen) {
+                setIsTop10TourOpen(false);
+            }
             setNeighborhoodMobilePreview(feature.properties.zipcode);
         }
     };
@@ -268,7 +271,10 @@ const Map = ({ isMobile = true, mapDisplay = true }: Props) => {
                         isVisible={
                             isMobile && !isTop10TourOpen && !!topTen.length
                         }
-                        onClickCallback={() => setIsTop10TourOpen(true)}
+                        onClickCallback={() => {
+                            setIsTop10TourOpen(true);
+                            setNeighborhoodMobilePreview(null);
+                        }}
                     />
                 </CustomControlOverlay>
             </MapContainer>

--- a/src/frontend/src/pages/Discover/Map/Map.tsx
+++ b/src/frontend/src/pages/Discover/Map/Map.tsx
@@ -32,6 +32,7 @@ import {
     neighborhoodsSelectedStyle,
     neighborhoodsStyle,
 } from "./mapLayerStyles";
+import NeighborhoodDetailPreviewCard from "./NeighborhoodDetailPreviewCard";
 
 interface Props {
     isMobile?: boolean;
@@ -40,6 +41,9 @@ interface Props {
 
 const Map = ({ isMobile = true, mapDisplay = true }: Props) => {
     const [isTop10TourOpen, setIsTop10TourOpen] = useState(false);
+    const [neighborhoodMobilePreview, setNeighborhoodMobilePreview] = useState<
+        string | null
+    >(null);
     const hasViewedInstructions = useAppSelector(
         selectUserHasViewedStartInstructions
     );
@@ -127,6 +131,10 @@ const Map = ({ isMobile = true, mapDisplay = true }: Props) => {
             ],
             { padding: 100, duration: 1000 }
         );
+
+        if (isMobile) {
+            setNeighborhoodMobilePreview(feature.properties.zipcode);
+        }
     };
 
     // Desktop-only: highlight neighborhood on hover
@@ -185,6 +193,11 @@ const Map = ({ isMobile = true, mapDisplay = true }: Props) => {
         );
     };
 
+    const handleNeighborhoodPreviewClose = () => {
+        manualSelectCallback();
+        setNeighborhoodMobilePreview(null);
+    };
+
     return (
         <div className={mapContainer()}>
             <Top10Tour
@@ -192,6 +205,11 @@ const Map = ({ isMobile = true, mapDisplay = true }: Props) => {
                 setIsTop10TourOpen={setIsTop10TourOpen}
                 tourStopCallback={manualSelectCallback}
                 showInstructions={!hasViewedInstructions}
+            />
+            <NeighborhoodDetailPreviewCard
+                isPreviewOpen={isMobile && !!neighborhoodMobilePreview}
+                onPreviewOpenChange={handleNeighborhoodPreviewClose}
+                zipcode={neighborhoodMobilePreview}
             />
             <MapContainer
                 ref={mapRef}

--- a/src/frontend/src/pages/Discover/Map/NeighborhoodDetailPreviewCard.tsx
+++ b/src/frontend/src/pages/Discover/Map/NeighborhoodDetailPreviewCard.tsx
@@ -1,0 +1,59 @@
+import { useLocation, useNavigate } from "react-router";
+
+import selectNeighborhoodZipcodeMap from "reducers/neighborhoods/selectors/selectNeighborhoodZipcodeMap";
+import { selectActiveDestination } from "reducers/userProfile/userSlice";
+import { useAppSelector } from "store/store";
+
+import NeighborhoodCard from "components/NeighborhoodCard/NeighborhoodCard";
+import { top10TourStyles } from "components/Top10Tour/top10Tour.styles";
+import formatNeighborhoodDataByViewType from "libs/formatNeighborhoodDataByCard";
+
+const NeighborhoodDetailPreviewCard = ({
+    isPreviewOpen,
+    onPreviewOpenChange,
+    zipcode,
+}: {
+    isPreviewOpen: boolean;
+    onPreviewOpenChange: () => void;
+    zipcode: string | null;
+}) => {
+    const navigate = useNavigate();
+    const location = useLocation();
+    const sharedStyles = top10TourStyles();
+    const neighborhoodDetailsMap = useAppSelector(selectNeighborhoodZipcodeMap);
+    const activeDestination = useAppSelector(selectActiveDestination);
+
+    if (!activeDestination || !zipcode) {
+        return <></>;
+    }
+
+    const { cardNoImage: neighborhoodCardData } =
+        formatNeighborhoodDataByViewType(
+            neighborhoodDetailsMap[zipcode],
+            activeDestination,
+            true
+        );
+
+    const detailClick = () => {
+        onPreviewOpenChange();
+        navigate(`${location.pathname}/${zipcode}`, {
+            replace: true,
+        });
+    };
+
+    return (
+        <div
+            className={sharedStyles.root({
+                isOpen: isPreviewOpen,
+            })}
+        >
+            <NeighborhoodCard
+                {...neighborhoodCardData}
+                onClose={onPreviewOpenChange}
+                onDetails={detailClick}
+            />
+        </div>
+    );
+};
+
+export default NeighborhoodDetailPreviewCard;

--- a/src/frontend/src/pages/Discover/Map/NeighborhoodDetailPreviewPopup.tsx
+++ b/src/frontend/src/pages/Discover/Map/NeighborhoodDetailPreviewPopup.tsx
@@ -1,0 +1,35 @@
+import { type PopupOptions } from "maplibre-gl";
+
+import formatNeighborhoodDataByViewType from "libs/formatNeighborhoodDataByCard";
+import selectNeighborhoodZipcodeMap from "reducers/neighborhoods/selectors/selectNeighborhoodZipcodeMap";
+import { selectActiveDestination } from "reducers/userProfile/userSlice";
+import NeighborhoodCard from "src/components/NeighborhoodCard/NeighborhoodCard";
+import { useAppSelector } from "store/store";
+
+export interface DetailPreviewPopupProps extends PopupOptions {
+    zipcode?: string | null;
+    longitude: number;
+    latitude: number;
+}
+
+const NeighborhoodDetailPreviewPopup = ({
+    zipcode,
+}: DetailPreviewPopupProps) => {
+    const neighborhoodDetailsMap = useAppSelector(selectNeighborhoodZipcodeMap);
+    const activeDestination = useAppSelector(selectActiveDestination);
+
+    if (!activeDestination || !zipcode) {
+        return <></>;
+    }
+
+    const { cardNoImage: neighborhoodCardData } =
+        formatNeighborhoodDataByViewType(
+            neighborhoodDetailsMap[zipcode],
+            activeDestination,
+            true
+        );
+
+    return <NeighborhoodCard {...neighborhoodCardData} isPopup />;
+};
+
+export default NeighborhoodDetailPreviewPopup;


### PR DESCRIPTION
## Overview

Adds neighborhood preview cards to the Discover map page:
1. If on mobile, preview cards available on click to neighborhood feature. Preview cards will include "detail" button to navigate to neighborhood details page.
2. If on desktop, preview cards available on hover of neighborhood feature. Preview cards are not interactive and will display neighborhood details preview at cursor anchor.

### Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] Run `./scripts/format` to lint, format, and fix the application source code.
- [x] CI passes after rebase

### Demo

https://github.com/user-attachments/assets/25af0055-3e79-4bc3-aeed-78f5d4bf00ff

https://github.com/user-attachments/assets/28b42091-8a55-49d9-aa4a-bdbe91b36c65



### Notes

- The figma designs only have name, zipcode, and tags in the desktop popup preview cards. I kept the metrics for the sake of time since that was already built and easily available, but can easily take that out if its too busy.

## Testing Instructions

 * `scripts/server`
 * Login and open discover page in mobile view
 * Start top 10 tour and click outside to select a different neighborhood than tour stop
 * Confirm tour pauses, bounds reset to selected neighborhood and preview card displays
 * Click around the different neighborhood features and confirm preview changes
 * Click "detail" in preview and confirm neighborhood details page opens
 * Go back to discover and confirm bounds reset and no preview cards are displaying
 * Click a neighborhood to open preview card
 * Click the top 10 tour button
 * Confirm neighborhood preview card closes and tour opens to neighborhood
 * Close the tour
 * Switch screen to desktop view
 * Click neighborhood and confirm map bounds fit neighborhood selection but large preview card details does not open
 * Confirm on hover smaller preview card displays following cursor anchor
 * Confirm popup content updates as mouse hovers over different neighborhood features


Resolves #734 #691
