### PR TITLE
Add address autocomplete and handle invalid destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add neighborhood detail preview cards to Discover page [#741](https://github.com/azavea/echo-locator/pull/741)
 - Add base Trips Wizard [#740](https://github.com/azavea/echo-locator/pull/740)
 - Add neighborhood list display filters [#738](https://github.com/azavea/echo-locator/pull/738)
+- Add address autocomplete and handle invalid destinations [#742](https://github.com/azavea/echo-locator/pull/742)
 
 ### Changed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - VITE_APP_GIT_COMMIT=${VITE_APP_GIT_COMMIT:-latest}
       - VITE_NETWORK_URL_ROOT=${VITE_NETWORK_URL_ROOT}
       - VITE_BHA_ECHO_PROGRAM_URL=${VITE_BHA_ECHO_PROGRAM_URL}
+      - VITE_MAPBOX_API_TOKEN=${MAPBOX_ACCESS_TOKEN}
     volumes:
       - ./src/frontend:/usr/local/src
       - $HOME/.aws:/root/.aws:ro

--- a/src/frontend/public/locales/en/translation.json
+++ b/src/frontend/public/locales/en/translation.json
@@ -146,7 +146,8 @@
                 "question": "Which trips do you make frequently?",
                 "description": "We use this information to recommend neighborhoods near the places you visit often",
                 "addATrip": "Add a trip",
-                "addAnotherTrip": "Add another trip"
+                "addAnotherTrip": "Add another trip",
+                "error": "You have destinations that are not valid, please remove and try again."
             },
             "addNewTripModal": {
                 "question": "Add new trip",

--- a/src/frontend/public/locales/es/translation.json
+++ b/src/frontend/public/locales/es/translation.json
@@ -146,7 +146,8 @@
                 "question": "Which trips do you make frequently?",
                 "description": "We use this information to recommend neighborhoods near the places you visit often",
                 "addATrip": "Add a trip",
-                "addAnotherTrip": "Add another trip"
+                "addAnotherTrip": "Add another trip",
+                "error": "You have destinations that are not valid, please remove and try again."
             },
             "addNewTripModal": {
                 "question": "Add new trip",

--- a/src/frontend/public/locales/zh/translation.json
+++ b/src/frontend/public/locales/zh/translation.json
@@ -146,7 +146,8 @@
                 "question": "Which trips do you make frequently?",
                 "description": "We use this information to recommend neighborhoods near the places you visit often",
                 "addATrip": "Add a trip",
-                "addAnotherTrip": "Add another trip"
+                "addAnotherTrip": "Add another trip",
+                "error": "You have destinations that are not valid, please remove and try again."
             },
             "addNewTripModal": {
                 "question": "Add new trip",

--- a/src/frontend/src/api/addressSearch.ts
+++ b/src/frontend/src/api/addressSearch.ts
@@ -1,0 +1,30 @@
+import axios from "axios";
+import type { FeatureCollection } from "geojson";
+
+import { BOUNDS } from "pages/Discover/Map/constants";
+import { MAPBOX_GEOCODING_API_BASE_URL } from "src/constants";
+import type { LanguageKey } from "src/enums";
+
+// Mapbox Geocoding API endpoint for forward geocoding with search text input
+export const getAddressSuggestions = async (
+    address: string,
+    signal: AbortSignal,
+    language: LanguageKey
+): Promise<FeatureCollection> => {
+    const params = new URLSearchParams({
+        q: address,
+        autocomplete: "true",
+        limit: "5",
+        bbox: BOUNDS.join(","),
+        types: "address",
+        language: language,
+        access_token: import.meta.env.VITE_MAPBOX_API_TOKEN,
+    });
+
+    const response = await axios.get(
+        `${MAPBOX_GEOCODING_API_BASE_URL}?${params.toString()}`,
+        { signal }
+    );
+
+    return response.data;
+};

--- a/src/frontend/src/components/AddressAutocomplete.tsx
+++ b/src/frontend/src/components/AddressAutocomplete.tsx
@@ -1,0 +1,79 @@
+import { throttle } from "lodash";
+import { useCallback, useRef } from "react";
+import { useParams } from "react-router";
+
+import { getAddressSuggestions } from "api/addressSearch";
+import {
+    Autocomplete,
+    type Suggestion,
+} from "components/base/Autocomplete/Autocomplete";
+import type { Point } from "geojson";
+import { Language, type LanguageKey } from "src/enums";
+
+const RATE_LIMIT = 500;
+
+const AddressAutocomplete = ({
+    placeholder,
+    onClearCallback,
+    onSuggestionCallback,
+}: {
+    placeholder: string;
+    onClearCallback: () => void;
+    onSuggestionCallback: (suggestion: Suggestion) => void;
+}) => {
+    const { lang } = useParams<{ lang: LanguageKey | undefined }>();
+    const abortRef = useRef<AbortController | null>(null);
+    const cacheRef = useRef<Record<string, Suggestion[]>>({});
+
+    // When autocomplete is enabled in forward geocoding query,
+    // each user keystroke counts as one request to the Geocoding API.
+    // Implement strategies from old site to reduce requests.
+    // https://github.com/azavea/echo-locator/blob/master/taui/src/components/geocoder.js#L81-L105
+    const fetchSuggestions = useCallback(
+        async (query: string, signal: AbortSignal) => {
+            if (!query.trim()) return [];
+            // Return cached result if available
+            if (cacheRef.current[query]) {
+                return cacheRef.current[query];
+            }
+
+            // Abort previous request
+            if (abortRef.current) {
+                abortRef.current.abort();
+            }
+
+            const controller = new AbortController();
+            abortRef.current = controller;
+
+            const { features } = await getAddressSuggestions(
+                query,
+                signal,
+                lang ?? Language.EN
+            );
+            return features
+                .map(f => {
+                    if (!f.properties && f.geometry.type !== "Point")
+                        return null;
+                    return {
+                        name: f.properties?.full_address,
+                        geometry: f.geometry as Point,
+                    };
+                })
+                .filter(f => f !== null);
+        },
+        []
+    );
+
+    const throttledFetch = throttle(fetchSuggestions, RATE_LIMIT);
+
+    return (
+        <Autocomplete
+            placeholder={placeholder}
+            loadAsyncSuggestions={throttledFetch}
+            onClearCallback={onClearCallback}
+            onSuggestionCallback={onSuggestionCallback}
+        />
+    );
+};
+
+export default AddressAutocomplete;

--- a/src/frontend/src/components/CommuterRailCheckbox.tsx
+++ b/src/frontend/src/components/CommuterRailCheckbox.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 
-import type { UserProfileSliceState } from "reducers/userProfile/types";
 import Checkbox from "components/base/Checkbox/Checkbox";
+import type { UserProfileSliceState } from "reducers/userProfile/types";
 
 interface Props {
     buffer: UserProfileSliceState;
@@ -18,6 +18,7 @@ const CommuterRailCheckbox = ({ buffer, handleChange }: Props) => {
             description={t(
                 "userProfile.wizard.stepTravelMode.checkboxDescription"
             )}
+            variant="default"
             isDisabled={buffer.hasVehicle}
         >
             {t("userProfile.wizard.stepTravelMode.checkboxLabel")}

--- a/src/frontend/src/components/base/Autocomplete/Autocomplete.tsx
+++ b/src/frontend/src/components/base/Autocomplete/Autocomplete.tsx
@@ -9,13 +9,18 @@ import {
 
 import TimesIcon from "assets/icons/times.svg?react";
 import Button from "components/base/Button/Button";
+import type { Point } from "geojson";
 import {
     dropdownItemStyles,
     dropdownPopoverStyles,
 } from "../Dropdown/Dropdown.styles";
 import autocompleteStyles from "./Autocomplete.styles";
 
-type Suggestion = { name: string; [key: string]: any };
+export type Suggestion = {
+    name: string;
+    geometry?: Point;
+    [key: string]: any;
+};
 
 export function Autocomplete({
     placeholder,
@@ -90,21 +95,25 @@ export function Autocomplete({
                 items={menuIsOpen ? filteredSuggestions.items : []}
                 className={`${baseDropdownPopoverStyles} ${menuIsOpen ? "visible" : "invisible"} rounded-t-none`}
             >
-                {item => (
-                    <MenuItem
-                        id={item.name}
-                        onAction={() => {
-                            filteredSuggestions.setFilterText(item.name);
-                            if (onSuggestionCallback) {
-                                onSuggestionCallback(item);
-                            }
-                        }}
-                        className={baseDropdownItemStyles}
-                        aria-label="item"
-                    >
-                        {item.name}
-                    </MenuItem>
-                )}
+                {item => {
+                    const distinctItem =
+                        item.full_address ?? item.address ?? item.name;
+                    return (
+                        <MenuItem
+                            id={distinctItem}
+                            onAction={() => {
+                                filteredSuggestions.setFilterText(distinctItem);
+                                if (onSuggestionCallback) {
+                                    onSuggestionCallback(item);
+                                }
+                            }}
+                            className={baseDropdownItemStyles}
+                            aria-label="item"
+                        >
+                            {distinctItem}
+                        </MenuItem>
+                    );
+                }}
             </Menu>
         </AriaAutocomplete>
     );

--- a/src/frontend/src/components/base/Autocomplete/Autocomplete.tsx
+++ b/src/frontend/src/components/base/Autocomplete/Autocomplete.tsx
@@ -64,11 +64,11 @@ export function Autocomplete({
     });
 
     // Force close menu on suggestion selection
-    const menuIsOpen =
-        filteredSuggestions.items.length > 1 ||
-        (filteredSuggestions.items.length === 1 &&
-            filteredSuggestions.filterText !==
-                filteredSuggestions.items[0].name);
+    const isMenuOpen =
+        filteredSuggestions.items.length &&
+        !filteredSuggestions.items.find(
+            i => i.name === filteredSuggestions.filterText
+        );
 
     return (
         <AriaAutocomplete
@@ -79,7 +79,7 @@ export function Autocomplete({
                 aria-label="Search"
                 autoFocus
                 onClear={onClearCallback}
-                className={`${searchRoot()} ${menuIsOpen ? "rounded-b-none" : ""} `}
+                className={`${searchRoot()} ${isMenuOpen ? "rounded-b-none" : ""} `}
             >
                 <Input placeholder={placeholder} className={inputStyles()} />
                 <Button
@@ -92,8 +92,8 @@ export function Autocomplete({
                 />
             </SearchField>
             <Menu
-                items={menuIsOpen ? filteredSuggestions.items : []}
-                className={`${baseDropdownPopoverStyles} ${menuIsOpen ? "visible" : "invisible"} rounded-t-none`}
+                items={isMenuOpen ? filteredSuggestions.items : []}
+                className={`${baseDropdownPopoverStyles} ${isMenuOpen ? "visible" : "!invisible"} rounded-t-none`}
             >
                 {item => {
                     const distinctItem =

--- a/src/frontend/src/components/base/Button/Button.tsx
+++ b/src/frontend/src/components/base/Button/Button.tsx
@@ -43,8 +43,11 @@ const Button = ({
             {children}
             {rightIcon}
             {info && (
-                <div className="flex flex-1 justify-end">
-                    <span className="text-sm font-normal text-gray-600">
+                <div className="flex flex-1 justify-end overflow-hidden">
+                    <span
+                        className="text-sm font-normal text-gray-600 overflow-hidden whitespace-nowrap text-ellipsis
+"
+                    >
                         {info}
                     </span>
                 </div>

--- a/src/frontend/src/constants.ts
+++ b/src/frontend/src/constants.ts
@@ -115,3 +115,5 @@ export const BHA_URL =
     "https://www.bostonhousing.org/en/Home-New.aspx";
 export const PROTONK_URL =
     "https://commons.wikimedia.org/wiki/File:Simple_Massachusetts_Vector.svg";
+export const MAPBOX_GEOCODING_API_BASE_URL =
+    "https://api.mapbox.com/search/geocode/v6/forward";

--- a/src/frontend/src/pages/Components.tsx
+++ b/src/frontend/src/pages/Components.tsx
@@ -527,6 +527,7 @@ const Components = () => {
                         <Checkbox
                             isSelected={isExpress}
                             onChange={setIsExpress}
+                            variant="default"
                             description="The Commuter rail and express bus allow us to recommend more neighborhoods, but they usually cost more than the subway or local bus."
                         >
                             I'm willing to take the express bus or commuter rail
@@ -594,6 +595,7 @@ const Components = () => {
                                     <Checkbox
                                         isSelected={isExpress}
                                         onChange={setIsExpress}
+                                        variant="default"
                                         description="The Commuter rail and express bus allow us to recommend more neighborhoods, but they usually cost more than the subway or local bus."
                                     >
                                         I'm willing to take the express bus or

--- a/src/frontend/src/pages/Discover/Discover.tsx
+++ b/src/frontend/src/pages/Discover/Discover.tsx
@@ -7,7 +7,10 @@ import {
     getNeighborhoodsAndBounds,
     getRankedNeighborhoodLists,
 } from "reducers/neighborhoods/neighborhoodsThunk";
-import { selectAllNetworksDataReady } from "reducers/networks/networksSlice";
+import {
+    selectAllNetworksDataReady,
+    selectInvalidTimesAndPathsData,
+} from "reducers/networks/networksSlice";
 import {
     getAllTimesAndPathsData,
     getNetworks,
@@ -86,6 +89,7 @@ const Discover = () => {
     }, [destinations, neighborhoods, networks, timesAndRoutesData]);
 
     const networksDataIsReady = useAppSelector(selectAllNetworksDataReady);
+    const invalidData = useAppSelector(selectInvalidTimesAndPathsData);
     useEffect(() => {
         if (networksDataIsReady) {
             dispatch(getRankedNeighborhoodLists());
@@ -97,11 +101,12 @@ const Discover = () => {
         dispatch(setIsNeighborhoodDetailsOpen(!!zipcode));
     }, [zipcode]);
 
-    return userProfileLoading ? (
+    return userProfileLoading ||
+        (destinations.length && !networksDataIsReady && !invalidData) ? (
         <div className={loadingWrapper()}>
             <div className={loadingSpinner()} />
         </div>
-    ) : destinations.length ? (
+    ) : destinations.length && !invalidData?.length ? (
         isDesktop ? (
             <Desktop />
         ) : (

--- a/src/frontend/src/pages/Discover/Profile/AddTripModal.tsx
+++ b/src/frontend/src/pages/Discover/Profile/AddTripModal.tsx
@@ -5,55 +5,12 @@ import { useTranslation } from "react-i18next";
 import type { Destination } from "reducers/userProfile/types";
 import { type PlaceKey } from "src/enums";
 
+import AddressAutocomplete from "components/AddressAutocomplete";
+import buttonStyles from "components/base/Button/Button.styles";
 import { Modal, ModalOverlay } from "components/base/Modal/Modal";
 import WizardStep from "components/Wizard/WizardStep";
-import { Autocomplete } from "src/components/base/Autocomplete/Autocomplete";
-import buttonStyles from "src/components/base/Button/Button.styles";
+import type { Suggestion } from "src/components/base/Autocomplete/Autocomplete";
 import { purposesMap } from "src/constants";
-
-// TODO: Remove following async Mapbox Search API Fetch
-// Example from autocomplete suggestions docs: https://docs.mapbox.com/api/search/search-box/#example-request-get-suggested-results
-const MAPBOX_EMPTY_SUGGESTIONS = {
-    suggestions: [
-        {
-            name: "Michigan Stadium",
-            mapbox_id: "Example ID",
-            feature_type: "poi",
-            address: "1201 S Main St",
-            full_address:
-                "1201 S Main St, Ann Arbor, Michigan 48104, United States of America",
-            place_formatted:
-                "Ann Arbor, Michigan 48104, United States of America",
-            context: {
-                country: {
-                    name: "United States of America",
-                    country_code: "US",
-                    country_code_alpha_3: "USA",
-                },
-                region: {
-                    name: "Michigan",
-                    region_code: "MI",
-                    region_code_full: "US-MI",
-                },
-                postcode: { name: "48104" },
-                place: { name: "Ann Arbor" },
-                neighborhood: { name: "South Main" },
-                street: { name: "s main st" },
-            },
-            language: "en",
-            maki: "marker",
-            poi_category: ["track", "sports"],
-            poi_category_ids: ["track", "sports"],
-            external_ids: {
-                safegraph: "Example ID",
-                foursquare: "Example ID",
-            },
-            metadata: {},
-        },
-    ],
-    attribution:
-        "© 2023 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)",
-};
 
 const EMPTY_DESTINATION = {
     location: {
@@ -99,26 +56,13 @@ const AddTripModal = ({
         }
     };
 
-    const handleLocationSelection = (selection: {
-        name: string;
-        address?: string;
-        mapbox_id?: string;
-        [key: string]: any;
-    }) => {
-        // TODO: Use Mapbox search API to retrieve if id available.
-        // Use Mapbox forward geocoding API if only address
-        // Use address if available, else name
-        const label = selection.address ?? selection.name;
-        const EXAMPLE_COORDS_RES = {
-            longitude: -71.117229,
-            latitude: 42.4063342,
-        };
-
+    const handleLocationSelection = (selection: Suggestion) => {
+        if (!selection.geometry) return;
         const location = {
-            label: label,
+            label: selection.name,
             position: {
-                lat: EXAMPLE_COORDS_RES.latitude,
-                lon: EXAMPLE_COORDS_RES.longitude,
+                lat: selection.geometry.coordinates[1],
+                lon: selection.geometry.coordinates[0],
             },
         };
 
@@ -197,11 +141,10 @@ const AddTripModal = ({
                         <h2 className="text-lg font-bold text-black mb-3">
                             {t("userTrip.wizard.addNewTripModal.locationLabel")}
                         </h2>
-                        <Autocomplete
+                        <AddressAutocomplete
                             placeholder={t(
                                 "userTrip.wizard.addNewTripModal.locationPlaceholder"
                             )}
-                            suggestions={MAPBOX_EMPTY_SUGGESTIONS.suggestions}
                             onClearCallback={handleLocationClear}
                             onSuggestionCallback={s =>
                                 handleLocationSelection(s)

--- a/src/frontend/src/pages/Discover/Profile/Profile.tsx
+++ b/src/frontend/src/pages/Discover/Profile/Profile.tsx
@@ -69,7 +69,7 @@ const Profile = () => {
         // userProfile.activeDestination to calculate score.
         // Use first destination by default.
         if (!destinations.find(d => d.primary)) {
-            destinations[0].primary = true;
+            destinations[0] = { ...destinations[0], primary: true };
         }
         dispatch(
             updateUserProfile({

--- a/src/frontend/src/pages/Discover/Profile/StepTrips.tsx
+++ b/src/frontend/src/pages/Discover/Profile/StepTrips.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { Destination } from "reducers/userProfile/types";
@@ -8,6 +8,8 @@ import PlusIcon from "assets/icons/plus.svg?react";
 import TimesIcon from "assets/icons/times.svg?react";
 import Button from "components/base/Button/Button";
 import WizardStep from "components/Wizard/WizardStep";
+import { selectInvalidTimesAndPathsData } from "src/reducers/networks/networksSlice";
+import { useAppSelector } from "src/store/store";
 import AddTripModal from "./AddTripModal";
 
 const StepTrips = ({
@@ -17,7 +19,9 @@ const StepTrips = ({
     handleNext,
 }: BaseProps) => {
     const { t } = useTranslation();
+    const invalidData = useAppSelector(selectInvalidTimesAndPathsData);
     const [addTripModalOpen, setIsAddTripModalOpen] = useState(false);
+    const [showErrorMessage, setShowErrorMessage] = useState(false);
     const destinations = buffer.destinations;
 
     const onRemoveDestination = (destinationIndex: number) => {
@@ -37,6 +41,12 @@ const StepTrips = ({
         setIsAddTripModalOpen(false);
     };
 
+    useEffect(() => {
+        setShowErrorMessage(
+            destinations.some(d => invalidData?.includes(d.location.label))
+        );
+    }, [destinations, invalidData]);
+
     return (
         <WizardStep
             question={t("userTrip.wizard.stepAddTrip.question")}
@@ -44,7 +54,7 @@ const StepTrips = ({
             buttonText={t("userTrip.wizard.button.finish")}
             handleBack={handleBack}
             handleNext={handleNext}
-            disableNext={!destinations.length}
+            disableNext={!destinations.length || showErrorMessage}
         >
             <AddTripModal
                 isModalOpen={addTripModalOpen}
@@ -54,11 +64,16 @@ const StepTrips = ({
                 handleBack={() => setIsAddTripModalOpen(false)}
                 handleNext={onAddDestination}
             />
+            {showErrorMessage && (
+                <div className="text-sm text-red-900">
+                    {t("userTrip.wizard.stepAddTrip.error")}
+                </div>
+            )}
             <div className="flex flex-col gap-3">
                 {destinations.map((destination, index) => (
                     <div
                         key={index}
-                        className="w-full flex flex-row justify-between items-start rounded-2xl p-4 bg-gray-100"
+                        className={`w-full flex flex-row justify-between items-start rounded-2xl p-4  ${invalidData?.includes(destination.location.label) ? "bg-red-100" : "bg-gray-100"}`}
                     >
                         <div>
                             <h2 className="text-xl font-bold text-gray-900">

--- a/src/frontend/src/reducers/networks/networksSlice.ts
+++ b/src/frontend/src/reducers/networks/networksSlice.ts
@@ -1,6 +1,10 @@
 import { createSelector, createSlice } from "@reduxjs/toolkit";
 
-import { getUserProfile } from "reducers/userProfile/userProfileThunk";
+import {
+    getUserProfile,
+    updateUserProfile,
+} from "reducers/userProfile/userProfileThunk";
+import { NetworkModeOptions, type NetworkModeOptionKey } from "src/enums";
 import type { RootState } from "store/store";
 import {
     getAllTimesAndPathsData,
@@ -8,8 +12,6 @@ import {
     getTimesAndPathsDataForPlace,
 } from "./networksThunk";
 import type { NetworksSliceState } from "./types";
-
-import { NetworkModeOptions, type NetworkModeOptionKey } from "src/enums";
 
 const initialState: NetworksSliceState = {
     networks: null,
@@ -85,6 +87,20 @@ export const networksSlice = createSlice({
                     : action.payload.useCommuterRail
                       ? (NetworkModeOptions.peak as NetworkModeOptionKey)
                       : (NetworkModeOptions.peakNoExpress as NetworkModeOptionKey);
+            })
+            .addCase(updateUserProfile.fulfilled, (state, action) => {
+                // Remove times and paths data for deleted destinations
+                if (state.timesAndRoutesData) {
+                    const newDestinationKeys = action.payload.destinations.map(
+                        destination => destination.location.label
+                    );
+                    const cleanedTimesAndPathsData = Object.fromEntries(
+                        Object.entries({ ...state.timesAndRoutesData }).filter(
+                            ([key]) => newDestinationKeys.includes(key)
+                        )
+                    );
+                    state.timesAndRoutesData = cleanedTimesAndPathsData;
+                }
             });
     },
 });
@@ -101,6 +117,17 @@ export const selectAllNetworksDataReady = createSelector(
         Object.values(networks).every(n => n.ready) &&
         Object.values(timesAndRoutesData).every(place =>
             Object.values(place).every(n => n.timesAndRoutesDataReady)
+        )
+);
+
+export const selectInvalidTimesAndPathsData = createSelector(
+    [(state: RootState) => state.networks.timesAndRoutesData],
+    timesAndRoutesData =>
+        timesAndRoutesData &&
+        Object.keys(timesAndRoutesData).filter(key =>
+            Object.values(timesAndRoutesData[key]).every(
+                n => !n.timesAndRoutesDataReady
+            )
         )
 );
 

--- a/src/frontend/src/reducers/networks/networksThunk.ts
+++ b/src/frontend/src/reducers/networks/networksThunk.ts
@@ -5,10 +5,10 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
 import { fetchNetworkData } from "src/api/networks";
 import { networks } from "src/constants";
-import type { Networks } from "./types";
-import type { RootState } from "src/store/store";
 import type { NetworkModeOptionKey } from "src/enums";
+import type { RootState } from "src/store/store";
 import type { Destination } from "../userProfile/types";
+import type { Networks } from "./types";
 import { fetchAndProcessDataByDestination } from "./utils/fetchAndProcessDataByDestination";
 
 export const getNetworks = createAsyncThunk(

--- a/src/frontend/src/reducers/networks/utils/fetchAndProcessDataByDestination.ts
+++ b/src/frontend/src/reducers/networks/utils/fetchAndProcessDataByDestination.ts
@@ -2,8 +2,9 @@
 // New source code copied from latest Taui v3
 // ATTR: Taui by Conveyal, included under the MIT license (https://github.com/conveyal/taui/blob/dev/LICENSE)
 
-import type { NetworkModeOptionKey } from "src/enums";
+import { fetchPathsData, fetchTimesData } from "api/networks";
 import type { Destination } from "reducers/userProfile/types";
+import type { NetworkModeOptionKey } from "src/enums";
 import type { RootState } from "store/store";
 import type {
     NetworkAndTimeAndPathsData,
@@ -11,11 +12,10 @@ import type {
     TimesAndPathsData,
 } from "../types";
 import { coordinateToIndex } from "./coordinateToIndex";
-import { fetchPathsData, fetchTimesData } from "api/networks";
+import createNetworkNeighborhoodRoutes from "./createNetworkNeighborhoodRoutes";
+import createNetworkNeighborhoodTravelTimes from "./createNetworkNeighborhoodTravelTimes";
 import { parsePathsData } from "./parsePathsData";
 import { parseTimesData } from "./parseTimesData";
-import createNetworkNeighborhoodTravelTimes from "./createNetworkNeighborhoodTravelTimes";
-import createNetworkNeighborhoodRoutes from "./createNetworkNeighborhoodRoutes";
 
 export async function fetchAndProcessDataByDestination(
     destination: Destination,
@@ -58,7 +58,20 @@ export async function fetchAndProcessDataByDestination(
             const [pathsResponse, timesResponse] = await Promise.all([
                 pathsFetchPromise,
                 timesFetchPromise,
-            ]);
+            ]).catch(e => {
+                console.error(e);
+                return [null, null];
+            });
+
+            // Index key for destination does not exist
+            if (!pathsResponse && !timesResponse) {
+                return {
+                    name: network,
+                    routesByNeighborhood: [],
+                    travelTimesByNeighborhood: [],
+                    timesAndRoutesDataReady: false,
+                };
+            }
 
             const pathsData = pathsResponse
                 ? parsePathsData(pathsResponse.value)


### PR DESCRIPTION
## Overview

Enables address search autocomplete following previous implementation, using Mapbox Geocoding API. I started first looking into the Mapbox Search Box API as an alternative but it didn't feel worth switching since we already have an implementation to refer to and know that immediate client needs fit within that API request free tier.

### Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] Run `./scripts/format` to lint, format, and fix the application source code.
- [x] CI passes after rebase

### Demo


https://github.com/user-attachments/assets/b676e683-1806-4ec6-bfc0-a1e68ac87fdb



### Notes

The autocomplete suggestions are geographically constrained by the `BOUNDS` constant, however that bounding box still covers some area that we don't have indexes for in the network analyses on S3. On the current site, you can add a destination from anywhere, but it just shows no results. In our current implementation, we need all the path/time data for every destination upfront for commute ranges, grouped routes, and the compare page so if we have a destination with data it breaks the app. We didn't have any error handling in place for this scenario and its high impact, so I added some very basic guardrails in commit 6dfca888acfb67eb3de0ff0d08af58c6bcf3ed60.

In the event a user adds a destination we don't have analysis data for, a user is kicked back to the trips wizards (right now, the profile until we can implement editing trips). An error message will display and the invalid destination styling will be updated. A user cannot proceed to update their profile until the erroring destination is removed:
<img width="384" height="676" alt="Screenshot 2025-10-16 at 6 58 41 PM" src="https://github.com/user-attachments/assets/38796092-2a01-4e35-97ba-bbe37ab874e3" />

## Testing Instructions

 * `scripts/server`
 * Login as a user without any destinations
 * Move through the profile setup wizard and add a new trip
 * Begin to type in an address and confirm 1) Autocomplete populated with real addresses 2) Only Boston-area addresses are suggested
 * Select address option and confirm suggestions dropdown closes
 * Add trip and confirm destination updates in steps trip
 * Add more trips and confirm autocomplete updates as expected
 * Add a trip we know will fail (I've found the address "213 Scraggy Neck Rd" to be outside the bounds)
 * Select finish
 * Confirm only see loading screen for a while before see profile page again
 * Move through the wizard again and confirm trips step now displays error message
 * Remove erroring destinations and confirm message no longer displays and finish button now enabled
 * Select finish again and confirm now brought to discover page
 * Confirm destination markers on map match the points of the valid destinations added
 * Open up a couple neighborhoods and confirm routes generated for different destinations are as expected


Resolves #608 
