### PR TITLE
Add edit trip modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add base Trips Wizard [#740](https://github.com/azavea/echo-locator/pull/740)
 - Add neighborhood list display filters [#738](https://github.com/azavea/echo-locator/pull/738)
 - Add address autocomplete and handle invalid destinations [#742](https://github.com/azavea/echo-locator/pull/742)
+- Add edit trip modal [#744](https://github.com/azavea/echo-locator/pull/744)
 
 ### Changed
 

--- a/src/frontend/public/locales/en/translation.json
+++ b/src/frontend/public/locales/en/translation.json
@@ -182,5 +182,13 @@
         "echoLink": "Learn more about ECHO",
         "regionsFilterLabel": "Filter by region selections",
         "eccFilter": "Only recommend Expanded Choice Communities (ECC)"
+    },
+    "editTripsModal": {
+        "dialogHeading": "Choose a trip",
+        "dialogSubHeading": "We recommend neighborhoods that are conveniently located.",
+        "trafficHeading": "Choose traffic conditions",
+        "travelModeHeading": "How do you usually get around?",
+        "peak": "Peak",
+        "offPeak": "Off-peak"
     }
 }

--- a/src/frontend/public/locales/es/translation.json
+++ b/src/frontend/public/locales/es/translation.json
@@ -182,5 +182,13 @@
         "echoLink": "Learn more about ECHO",
         "regionsFilterLabel": "Filter by region selections",
         "eccFilter": "Only recommend Expanded Choice Communities (ECC)"
+    },
+    "editTripsModal": {
+        "dialogHeading": "Choose a trip",
+        "dialogSubHeading": "We recommend neighborhoods that are conveniently located.",
+        "trafficHeading": "Choose traffic conditions",
+        "travelModeHeading": "How do you usually get around?",
+        "peak": "Peak",
+        "offPeak": "Off-peak"
     }
 }

--- a/src/frontend/public/locales/zh/translation.json
+++ b/src/frontend/public/locales/zh/translation.json
@@ -182,5 +182,13 @@
         "echoLink": "Learn more about ECHO",
         "regionsFilterLabel": "Filter by region selections",
         "eccFilter": "Only recommend Expanded Choice Communities (ECC)"
+    },
+    "editTripsModal": {
+        "dialogHeading": "Choose a trip",
+        "dialogSubHeading": "We recommend neighborhoods that are conveniently located.",
+        "trafficHeading": "Choose traffic conditions",
+        "travelModeHeading": "How do you usually get around?",
+        "peak": "Peak",
+        "offPeak": "Off-peak"
     }
 }

--- a/src/frontend/src/components/EditFiltersModal.tsx
+++ b/src/frontend/src/components/EditFiltersModal.tsx
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
     CheckboxGroup as AriaCheckboxGroup,
     Dialog,
@@ -57,19 +57,8 @@ const EditFiltersModal = ({ isMobile = false }) => {
     const modalOpen = useAppSelector(selectIsEditFiltersOpen);
     const bedrooms = useAppSelector(selectUserBedroomCount);
     const mode = useAppSelector(selectActiveMode);
-    const [filtersBuffer, setFiltersBuffer] = useState<FiltersState | null>(
-        null
-    );
-
     const filters = useAppSelector(selectNeighborhoodFilters);
-
-    useEffect(() => {
-        setFiltersBuffer({ ...filters });
-    }, [filters]);
-
-    if (!filtersBuffer) {
-        return <></>;
-    }
+    const [filtersBuffer, setFiltersBuffer] = useState<FiltersState>(filters);
 
     const regionsFilterSelected = (isSelected: boolean, region: string) => {
         const updatedRegionsFilter = [...filtersBuffer.regions];

--- a/src/frontend/src/components/EditTripsModal.tsx
+++ b/src/frontend/src/components/EditTripsModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type { Key } from "react-aria-components";
 import { Dialog, Heading } from "react-aria-components";
 import { useTranslation } from "react-i18next";
@@ -23,12 +23,13 @@ import {
     ToggleButton,
     ToggleButtonGroup,
 } from "components/base/ToggleButton/ToggleButton";
-import { modalHeadingClassName } from "pages/Discover/ModalsWrapper";
 import { Accordion } from "./base/Accordion/Accordion";
 import { AccordionItem } from "./base/Accordion/AccordionItem";
 import CommuterRailCheckbox from "./CommuterRailCheckbox";
 import ModalCloseButton from "./ModalCloseButton";
 import TravelModeToggle from "./TravelModeToggle";
+
+const modalHeadingClassName = "text-lg font-bold text-gray-900";
 
 const EditTripsModal = () => {
     const { t } = useTranslation();
@@ -37,15 +38,7 @@ const EditTripsModal = () => {
     const profile = useAppSelector(selectUserProfile);
     const trafficConditions = useAppSelector(selectTrafficConditions);
     const [profileBuffer, setProfileBuffer] =
-        useState<UserProfileSliceState | null>(null);
-
-    useEffect(() => {
-        setProfileBuffer({ ...profile });
-    }, [profile]);
-
-    if (!profileBuffer) {
-        return <></>;
-    }
+        useState<UserProfileSliceState>(profile);
 
     // Update active destination
     const onSelectDestination = (keys: Iterable<string, void, undefined>) => {
@@ -182,8 +175,6 @@ const EditTripsModal = () => {
                         <h2 className={modalHeadingClassName}>
                             {t("editTripsModal.travelModeHeading")}
                         </h2>
-                        {/* Toggles in sync with logic in StepTravelMode
-                         */}
                         <TravelModeToggle
                             buffer={profileBuffer}
                             handleChange={onChangeHasVehicleToggle}

--- a/src/frontend/src/components/EditTripsModal.tsx
+++ b/src/frontend/src/components/EditTripsModal.tsx
@@ -1,32 +1,198 @@
-import { ModalOverlay, Modal } from "components/base/Modal/Modal";
+import { useEffect, useState } from "react";
+import type { Key } from "react-aria-components";
 import { Dialog, Heading } from "react-aria-components";
-import { useDispatch } from "react-redux";
+import { useTranslation } from "react-i18next";
+
 import {
     selectIsEditTripsOpen,
     setIsEditTripsOpen,
-} from "src/reducers/modalsDisplay/modalsDisplaySlice";
-import { useAppSelector } from "src/store/store";
+} from "reducers/modalsDisplay/modalsDisplaySlice";
+import {
+    selectTrafficConditions,
+    setTrafficConditions,
+} from "reducers/networks/networksSlice";
+import type { TrafficType } from "reducers/networks/types";
+import type { UserProfileSliceState } from "reducers/userProfile/types";
+import { updateUserProfile } from "reducers/userProfile/userProfileThunk";
+import { selectUserProfile } from "reducers/userProfile/userSlice";
+import { useAppDispatch, useAppSelector } from "store/store";
+
+import Button from "components/base/Button/Button";
+import { Modal, ModalOverlay } from "components/base/Modal/Modal";
+import {
+    ToggleButton,
+    ToggleButtonGroup,
+} from "components/base/ToggleButton/ToggleButton";
+import { modalHeadingClassName } from "pages/Discover/ModalsWrapper";
+import { Accordion } from "./base/Accordion/Accordion";
+import { AccordionItem } from "./base/Accordion/AccordionItem";
+import CommuterRailCheckbox from "./CommuterRailCheckbox";
 import ModalCloseButton from "./ModalCloseButton";
+import TravelModeToggle from "./TravelModeToggle";
 
 const EditTripsModal = () => {
-    const dispatch = useDispatch();
+    const { t } = useTranslation();
+    const dispatch = useAppDispatch();
     const modalOpen = useAppSelector(selectIsEditTripsOpen);
+    const profile = useAppSelector(selectUserProfile);
+    const trafficConditions = useAppSelector(selectTrafficConditions);
+    const [profileBuffer, setProfileBuffer] =
+        useState<UserProfileSliceState | null>(null);
+
+    useEffect(() => {
+        setProfileBuffer({ ...profile });
+    }, [profile]);
+
+    if (!profileBuffer) {
+        return <></>;
+    }
+
+    // Update active destination
+    const onSelectDestination = (keys: Iterable<string, void, undefined>) => {
+        const selection = [...keys][0];
+        if (!selection) return;
+        const destinations = profileBuffer.destinations.map(d => {
+            return { ...d, primary: d.location.label === selection };
+        });
+        setProfileBuffer({ ...profileBuffer, destinations: destinations });
+    };
+
+    // Directly update networks state for traffic changes. Avoids
+    // race conditions correctly updating activeMode following user profile update
+    const onTrafficChange = (keys: Iterable<Key, void, undefined>) => {
+        const selection = [...keys][0];
+        if (!selection) return;
+        dispatch(setTrafficConditions(selection as TrafficType));
+    };
+
+    const onChangeHasVehicleToggle = (keys: Set<Key>) =>
+        setProfileBuffer({
+            ...profileBuffer,
+            hasVehicle: keys.has("car"),
+            useCommuterRail: keys.has("car")
+                ? false
+                : profileBuffer.useCommuterRail,
+        });
+
+    const onChangeCommuterCheckbox = (value: boolean) =>
+        setProfileBuffer({
+            ...profileBuffer,
+            useCommuterRail: value,
+        });
+
+    const onOpenChange = (isOpen: boolean) => {
+        dispatch(
+            updateUserProfile({
+                ...profileBuffer,
+                voucherRooms: profileBuffer.rooms,
+                importanceAccessibility: parseInt(
+                    profileBuffer.importanceAccessibility
+                ),
+                importanceSchools: parseInt(profileBuffer.importanceSchools),
+                importanceViolentCrime: parseInt(
+                    profileBuffer.importanceViolentCrime
+                ),
+            })
+        );
+        dispatch(setIsEditTripsOpen(isOpen));
+    };
+
     return (
         <ModalOverlay
             isDismissable
             isMobile
             isOpen={modalOpen}
-            onOpenChange={(isOpen: boolean) =>
-                dispatch(setIsEditTripsOpen(isOpen))
-            }
+            onOpenChange={onOpenChange}
         >
-            <Modal size="large">
-                <Dialog>
-                    <Heading slot="title">Trips</Heading>
-                    <ModalCloseButton
-                        onPress={() => dispatch(setIsEditTripsOpen(false))}
-                    />
-                    <div></div>
+            <Modal size="medium" className="p-5 max-h-full overflow-y-scroll">
+                <Dialog className="flex flex-col w-full gap-5">
+                    <div>
+                        <Heading slot="title" className={modalHeadingClassName}>
+                            {t("editTripsModal.dialogHeading")}
+                        </Heading>
+
+                        <p className="text-sm text-gray-600">
+                            {t("editTripsModal.dialogSubHeading")}
+                        </p>
+                        <ModalCloseButton onPress={() => onOpenChange(false)} />
+                    </div>
+                    <div className="flex flex-col gap-4">
+                        <Accordion
+                            defaultExpandedKeys={[
+                                profileBuffer.activeDestination ??
+                                    profileBuffer.destinations[0].location
+                                        .label,
+                            ]}
+                            expandedItemCallback={onSelectDestination}
+                            className="w-full"
+                        >
+                            {profileBuffer.destinations.map(destination => (
+                                <AccordionItem
+                                    id={destination.location.label}
+                                    key={destination.location.label}
+                                    title={t(
+                                        `destinationPurposes.${destination.purpose}`
+                                    )}
+                                    subtitle={destination.location.label}
+                                    overridePanelOpen
+                                />
+                            ))}
+                        </Accordion>
+                        <Button
+                            variant="outline"
+                            size="medium"
+                            className="flex w-full"
+                            onPress={() =>
+                                // TODO Issue 739: Open Trips Wizard
+                                console.log("open trips wizard step")
+                            }
+                        >
+                            {t("yourTrips.editTrips")}
+                        </Button>
+                    </div>
+                    <div className="flex flex-col gap-4">
+                        <h2 className={modalHeadingClassName}>
+                            {t("editTripsModal.trafficHeading")}
+                        </h2>
+                        <ToggleButtonGroup
+                            selectionMode="single"
+                            className="w-full"
+                            selectedKeys={new Set([trafficConditions])}
+                            onSelectionChange={(keys: Set<Key>) =>
+                                keys.size === 1 && onTrafficChange(keys)
+                            }
+                        >
+                            <ToggleButton
+                                id="peak"
+                                size="large"
+                                className="w-full"
+                            >
+                                {t("editTripsModal.peak")}
+                            </ToggleButton>
+                            <ToggleButton
+                                id="offPeak"
+                                size="large"
+                                className="w-full"
+                            >
+                                {t("editTripsModal.offPeak")}
+                            </ToggleButton>
+                        </ToggleButtonGroup>
+                    </div>
+                    <div className="flex flex-col gap-4">
+                        <h2 className={modalHeadingClassName}>
+                            {t("editTripsModal.travelModeHeading")}
+                        </h2>
+                        {/* Toggles in sync with logic in StepTravelMode
+                         */}
+                        <TravelModeToggle
+                            buffer={profileBuffer}
+                            handleChange={onChangeHasVehicleToggle}
+                        />
+                        <CommuterRailCheckbox
+                            buffer={profileBuffer}
+                            handleChange={onChangeCommuterCheckbox}
+                        />
+                    </div>
                 </Dialog>
             </Modal>
         </ModalOverlay>

--- a/src/frontend/src/components/UserProfileSubheader.tsx
+++ b/src/frontend/src/components/UserProfileSubheader.tsx
@@ -98,7 +98,9 @@ export const UserProfileSubheaderMobile = ({
                 }
                 onPress={() => dispatch(setIsEditTripsOpen(true))}
             >
-                {t(`destinationPurposes.${destination?.purpose}`)}
+                <span className="overflow-hidden whitespace-nowrap text-ellipsis">
+                    {t(`destinationPurposes.${destination?.purpose}`)}
+                </span>
             </Button>
             <ToggleButtonGroup
                 selectionMode="single"

--- a/src/frontend/src/components/base/Accordion/Accordion.styles.ts
+++ b/src/frontend/src/components/base/Accordion/Accordion.styles.ts
@@ -11,7 +11,7 @@ export const accordionStyles = tv({
         accordionButton: "flex w-full px-4 py-3 justify-between gap-2",
         accordionItemTextWrapper:
             "flex flex-col items-start items-baseline text-gray-800 text-base gap-0",
-        accordionItemSubText: "text-gray-600 text-xs",
+        accordionItemSubText: "text-gray-600 text-xs text-left",
         accordionItemPanel: "flex flex-col w-full",
     },
     variants: {

--- a/src/frontend/src/components/base/Accordion/AccordionItem.tsx
+++ b/src/frontend/src/components/base/Accordion/AccordionItem.tsx
@@ -13,7 +13,7 @@ export interface AccordionItemProps extends DisclosureProps {
     id: string;
     title: string;
     subtitle: string;
-    titleContentRight: ReactNode;
+    titleContentRight?: ReactNode;
     isMobile?: boolean;
     overridePanelOpen?: boolean;
     children?: ReactNode;

--- a/src/frontend/src/pages/Discover/Discover.tsx
+++ b/src/frontend/src/pages/Discover/Discover.tsx
@@ -8,6 +8,7 @@ import {
     getRankedNeighborhoodLists,
 } from "reducers/neighborhoods/neighborhoodsThunk";
 import {
+    selectActiveMode,
     selectAllNetworksDataReady,
     selectInvalidTimesAndPathsData,
 } from "reducers/networks/networksSlice";
@@ -90,11 +91,12 @@ const Discover = () => {
 
     const networksDataIsReady = useAppSelector(selectAllNetworksDataReady);
     const invalidData = useAppSelector(selectInvalidTimesAndPathsData);
+    const activeMode = useAppSelector(selectActiveMode);
     useEffect(() => {
-        if (networksDataIsReady) {
+        if (networksDataIsReady && activeMode) {
             dispatch(getRankedNeighborhoodLists());
         }
-    }, [networksDataIsReady]);
+    }, [networksDataIsReady, activeMode]);
     // --------------------------------------
 
     useEffect(() => {

--- a/src/frontend/src/pages/Discover/ModalsWrapper.tsx
+++ b/src/frontend/src/pages/Discover/ModalsWrapper.tsx
@@ -2,8 +2,6 @@ import EditFiltersModal from "src/components/EditFiltersModal";
 import EditTripsModal from "src/components/EditTripsModal";
 import NeighborhoodDetail from "../NeighborhoodDetail";
 
-export const modalHeadingClassName = "text-lg font-bold text-gray-900";
-
 const ModalsWrapper = ({ isMobile }: { isMobile?: boolean }) => (
     <>
         <NeighborhoodDetail isMobile={isMobile} />

--- a/src/frontend/src/pages/Discover/ModalsWrapper.tsx
+++ b/src/frontend/src/pages/Discover/ModalsWrapper.tsx
@@ -1,6 +1,8 @@
 import EditFiltersModal from "src/components/EditFiltersModal";
-import NeighborhoodDetail from "../NeighborhoodDetail";
 import EditTripsModal from "src/components/EditTripsModal";
+import NeighborhoodDetail from "../NeighborhoodDetail";
+
+export const modalHeadingClassName = "text-lg font-bold text-gray-900";
 
 const ModalsWrapper = ({ isMobile }: { isMobile?: boolean }) => (
     <>

--- a/src/frontend/src/reducers/networks/networksSlice.ts
+++ b/src/frontend/src/reducers/networks/networksSlice.ts
@@ -11,11 +11,12 @@ import {
     getNetworks,
     getTimesAndPathsDataForPlace,
 } from "./networksThunk";
-import type { NetworksSliceState } from "./types";
+import type { NetworksSliceState, TrafficType } from "./types";
 
 const initialState: NetworksSliceState = {
     networks: null,
     timesAndRoutesData: null,
+    trafficConditions: "peak",
     // Default to use first transit network with commuter rail
     activeMode: "peak",
     loading: false,
@@ -26,11 +27,11 @@ export const networksSlice = createSlice({
     name: "networks",
     initialState,
     reducers: {
-        setActiveMode: (
+        setTrafficConditions: (
             state,
-            { payload: mode }: { payload: NetworkModeOptionKey }
+            { payload: mode }: { payload: TrafficType }
         ) => {
-            state.activeMode = mode;
+            state.trafficConditions = mode;
         },
     },
     extraReducers: builder => {
@@ -80,8 +81,6 @@ export const networksSlice = createSlice({
                     "Failed to fetch all times and paths data.";
             })
             .addCase(getUserProfile.fulfilled, (state, action) => {
-                // TODO: active mode needs to depend on a third variable
-                // https://github.com/azavea/echo-locator/issues/728
                 state.activeMode = action.payload.hasVehicle
                     ? (NetworkModeOptions.car as NetworkModeOptionKey)
                     : action.payload.useCommuterRail
@@ -136,7 +135,9 @@ export const selectUseTransit = createSelector(
     activeMode => activeMode !== "car"
 );
 export const selectActiveMode = (state: RootState) => state.networks.activeMode;
+export const selectTrafficConditions = (state: RootState) =>
+    state.networks.trafficConditions;
 
-export const { setActiveMode } = networksSlice.actions;
+export const { setTrafficConditions } = networksSlice.actions;
 
 export default networksSlice.reducer;

--- a/src/frontend/src/reducers/networks/networksSlice.ts
+++ b/src/frontend/src/reducers/networks/networksSlice.ts
@@ -4,7 +4,7 @@ import {
     getUserProfile,
     updateUserProfile,
 } from "reducers/userProfile/userProfileThunk";
-import { NetworkModeOptions, type NetworkModeOptionKey } from "src/enums";
+import { NetworkModeOptions } from "src/enums";
 import type { RootState } from "store/store";
 import {
     getAllTimesAndPathsData,
@@ -12,6 +12,8 @@ import {
     getTimesAndPathsDataForPlace,
 } from "./networksThunk";
 import type { NetworksSliceState, TrafficType } from "./types";
+
+import getActiveModeKey from "./utils/getActiveModeKey";
 
 const initialState: NetworksSliceState = {
     networks: null,
@@ -81,13 +83,18 @@ export const networksSlice = createSlice({
                     "Failed to fetch all times and paths data.";
             })
             .addCase(getUserProfile.fulfilled, (state, action) => {
-                state.activeMode = action.payload.hasVehicle
-                    ? (NetworkModeOptions.car as NetworkModeOptionKey)
-                    : action.payload.useCommuterRail
-                      ? (NetworkModeOptions.peak as NetworkModeOptionKey)
-                      : (NetworkModeOptions.peakNoExpress as NetworkModeOptionKey);
+                state.activeMode = getActiveModeKey(
+                    state.trafficConditions === NetworkModeOptions.peak,
+                    action.payload.hasVehicle,
+                    action.payload.useCommuterRail
+                );
             })
             .addCase(updateUserProfile.fulfilled, (state, action) => {
+                state.activeMode = getActiveModeKey(
+                    state.trafficConditions === NetworkModeOptions.peak,
+                    action.payload.hasVehicle,
+                    action.payload.useCommuterRail
+                );
                 // Remove times and paths data for deleted destinations
                 if (state.timesAndRoutesData) {
                     const newDestinationKeys = action.payload.destinations.map(

--- a/src/frontend/src/reducers/networks/types.ts
+++ b/src/frontend/src/reducers/networks/types.ts
@@ -148,9 +148,12 @@ export type Networks = {
     [key in NetworkModeOptionKey]: Network;
 };
 
+export type TrafficType = "peak" | "offPeak";
+
 export interface NetworksSliceState {
     networks: Networks | null;
     timesAndRoutesData: TimesAndPathsByPlace | null;
+    trafficConditions: TrafficType;
     activeMode: NetworkModeOptionKey;
     loading: boolean;
     error: string | null;

--- a/src/frontend/src/reducers/networks/utils/getActiveModeKey.ts
+++ b/src/frontend/src/reducers/networks/utils/getActiveModeKey.ts
@@ -1,0 +1,18 @@
+import { NetworkModeOptions, type NetworkModeOptionKey } from "src/enums";
+
+const getActiveModeKey = (
+    isPeak: boolean,
+    hasVehicle: boolean,
+    useCommuterRail: boolean
+): NetworkModeOptionKey =>
+    hasVehicle
+        ? (NetworkModeOptions.car as NetworkModeOptionKey)
+        : useCommuterRail
+          ? isPeak
+              ? (NetworkModeOptions.peak as NetworkModeOptionKey)
+              : (NetworkModeOptions.offPeak as NetworkModeOptionKey)
+          : isPeak
+            ? (NetworkModeOptions.peakNoExpress as NetworkModeOptionKey)
+            : (NetworkModeOptions.offPeakNoExpress as NetworkModeOptionKey);
+
+export default getActiveModeKey;

--- a/src/frontend/src/reducers/userProfile/userSlice.ts
+++ b/src/frontend/src/reducers/userProfile/userSlice.ts
@@ -112,6 +112,7 @@ export const {
     setHasViewedStartInstructions,
 } = userProfileSlice.actions;
 
+export const selectUserProfile = (state: RootState) => state.userProfile;
 export const selectActiveDestination = (state: RootState) =>
     state.userProfile.activeDestination;
 export const selectActiveDestinationDetails = (state: RootState) =>


### PR DESCRIPTION
## Overview

Adds the trip editing modal for users to update:
1. active destination
2. the active mode used for routing an calculations, set by toggles for traffic conditions, is user has vehicle or is using commuter rail.

Currently "Edit your trips" does not open anything until #739 (any addition/removing of destinations expected to be handled in wizard).

### Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] Run `./scripts/format` to lint, format, and fix the application source code.
- [x] CI passes after rebase

### Demo


https://github.com/user-attachments/assets/0ac92e8b-9f00-4ae5-a37f-652dc5386a45



## Testing Instructions

 * `scripts/server`
 * Login to django admin and confirm your user has multiple destinations
 * Login to app and confirm correct active destination (first in destinations list, if none selected) in redux state
 * Click on the edit trips button in the user profile subheader
 * Confirm edit trips modal opens
 * Confirm user profile state in redux is selected by default (eg. the active destination is expanded option in accordion, the correct traffic condition is toggled ("Peak" by default), the correct commute options are selected ("car" if user.hasVehicle and commuter checkbox selected if "user.useCommuterRail).
 * Select a variety of options and confirm user profile state updates correctly when closing modal
 * Confirm the `networks.activeMode` updates after fulfilled user profile with the correct option key (now taking into account "peak" and "off-peak")
 * Confirm ranking list re-generates
 * In neighborhood details confirm commute range and "Your Trips" maps updated to match user-selected options (e.g. car instead of transit)

Resolves #728 
