### PR TITLE
Enable profile/trip wizards edit mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add address autocomplete and handle invalid destinations [#742](https://github.com/azavea/echo-locator/pull/742)
 - Add edit trip modal [#744](https://github.com/azavea/echo-locator/pull/744)
 - Add neighborhood search [#743](https://github.com/azavea/echo-locator/pull/743)
+- Enable profile/trip wizards edit mode [#745](https://github.com/azavea/echo-locator/pull/745)
 
 ### Changed
 

--- a/src/frontend/src/components/EditFiltersModal.tsx
+++ b/src/frontend/src/components/EditFiltersModal.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from "react-i18next";
 import {
     selectIsEditFiltersOpen,
     setIsEditFiltersOpen,
+    setIsEditProfileWizardOpen,
 } from "reducers/modalsDisplay/modalsDisplaySlice";
 import {
     selectNeighborhoodFilters,
@@ -119,9 +120,9 @@ const EditFiltersModal = ({ isMobile = false }) => {
                                 variant="outline"
                                 size="small"
                                 className="font-normal text-gray-800"
-                                onPress={() => {
-                                    /* TODO: Open edit trips */
-                                }}
+                                onPress={() =>
+                                    dispatch(setIsEditProfileWizardOpen(true))
+                                }
                             >
                                 {t("filterModal.edit")}
                             </Button>

--- a/src/frontend/src/components/EditTripsModal.tsx
+++ b/src/frontend/src/components/EditTripsModal.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import {
     selectIsEditTripsOpen,
     setIsEditTripsOpen,
+    setIsEditTripsWizardOpen,
 } from "reducers/modalsDisplay/modalsDisplaySlice";
 import {
     selectTrafficConditions,
@@ -136,8 +137,7 @@ const EditTripsModal = ({ isMobile = false }) => {
                             size="medium"
                             className="flex w-full"
                             onPress={() =>
-                                // TODO Issue 739: Open Trips Wizard
-                                console.log("open trips wizard step")
+                                dispatch(setIsEditTripsWizardOpen(true))
                             }
                         >
                             {t("yourTrips.editTrips")}

--- a/src/frontend/src/components/EditWizard/EditTripsWizard.tsx
+++ b/src/frontend/src/components/EditWizard/EditTripsWizard.tsx
@@ -1,0 +1,22 @@
+import {
+    selectIsEditTripsWizardOpen,
+    setIsEditTripsWizardOpen,
+} from "src/reducers/modalsDisplay/modalsDisplaySlice";
+import { useAppDispatch, useAppSelector } from "src/store/store";
+import EditWizard from "./EditWizard";
+import StepTrips from "./StepTrips";
+
+const EditTripsWizard = () => {
+    const dispatch = useAppDispatch();
+    const isWizardOpen = useAppSelector(selectIsEditTripsWizardOpen);
+    return (
+        <EditWizard
+            isWizardOpen={isWizardOpen}
+            setWizardOpen={isOpen => dispatch(setIsEditTripsWizardOpen(isOpen))}
+        >
+            <StepTrips disableBack />
+        </EditWizard>
+    );
+};
+
+export default EditTripsWizard;

--- a/src/frontend/src/components/EditWizard/EditUserProfileWizard.tsx
+++ b/src/frontend/src/components/EditWizard/EditUserProfileWizard.tsx
@@ -1,0 +1,28 @@
+import {
+    selectIsEditProfileWizardOpen,
+    setIsEditProfileWizardOpen,
+} from "src/reducers/modalsDisplay/modalsDisplaySlice";
+import { useAppDispatch, useAppSelector } from "src/store/store";
+import EditWizard from "./EditWizard";
+import StepBedroom from "./StepBedroom";
+import StepImportance from "./StepImportance";
+import StepTravelMode from "./StepTravelMode";
+
+const EditUserProfileWizard = () => {
+    const dispatch = useAppDispatch();
+    const isWizardOpen = useAppSelector(selectIsEditProfileWizardOpen);
+    return (
+        <EditWizard
+            isWizardOpen={isWizardOpen}
+            setWizardOpen={isOpen =>
+                dispatch(setIsEditProfileWizardOpen(isOpen))
+            }
+        >
+            <StepBedroom />
+            <StepImportance />
+            <StepTravelMode />
+        </EditWizard>
+    );
+};
+
+export default EditUserProfileWizard;

--- a/src/frontend/src/components/EditWizard/EditWizard.tsx
+++ b/src/frontend/src/components/EditWizard/EditWizard.tsx
@@ -13,6 +13,7 @@ import Wizard from "components/Wizard/Wizard";
 import { updateUserProfile } from "reducers/userProfile/userProfileThunk";
 import { useAppDispatch, type RootState } from "store/store";
 
+import _ from "lodash";
 import type { BaseProps } from "../../pages/Discover/Profile/types";
 
 type EditWizardChildComponent<P = {}> = React.ReactElement<P & BaseProps>;
@@ -74,19 +75,20 @@ const EditWizard = ({
         if (!destinations.find(d => d.primary)) {
             destinations[0] = { ...destinations[0], primary: true };
         }
-        dispatch(
-            updateUserProfile({
-                ...profileBuffer,
-                voucherRooms: profileBuffer.rooms,
-                importanceAccessibility: parseInt(
-                    profileBuffer.importanceAccessibility
-                ),
-                importanceSchools: parseInt(profileBuffer.importanceSchools),
-                importanceViolentCrime: parseInt(
-                    profileBuffer.importanceViolentCrime
-                ),
-            })
-        );
+        const updatedProfile = {
+            ...profileBuffer,
+            voucherRooms: profileBuffer.rooms,
+            importanceAccessibility: parseInt(
+                profileBuffer.importanceAccessibility
+            ),
+            importanceSchools: parseInt(profileBuffer.importanceSchools),
+            importanceViolentCrime: parseInt(
+                profileBuffer.importanceViolentCrime
+            ),
+        };
+        if (!_.isEqual(updatedProfile, profile)) {
+            dispatch(updateUserProfile(updatedProfile));
+        }
         handleClose();
     };
 

--- a/src/frontend/src/components/EditWizard/EditWizard.tsx
+++ b/src/frontend/src/components/EditWizard/EditWizard.tsx
@@ -1,0 +1,127 @@
+import {
+    Children,
+    cloneElement,
+    isValidElement,
+    useEffect,
+    useState,
+    type ReactNode,
+} from "react";
+import { useTranslation } from "react-i18next";
+import { useSelector } from "react-redux";
+
+import Wizard from "components/Wizard/Wizard";
+import { updateUserProfile } from "reducers/userProfile/userProfileThunk";
+import { useAppDispatch, type RootState } from "store/store";
+
+import type { BaseProps } from "../../pages/Discover/Profile/types";
+
+type EditWizardChildComponent<P = {}> = React.ReactElement<P & BaseProps>;
+
+interface EditWizardProps {
+    isWizardOpen: boolean;
+    setWizardOpen: (isOpen: boolean) => void;
+    children: ReactNode;
+}
+
+const EditWizard = ({
+    isWizardOpen,
+    setWizardOpen,
+    children,
+}: EditWizardProps) => {
+    const profile = useSelector((state: RootState) => state.userProfile);
+    const [profileBuffer, setProfileBuffer] = useState({ ...profile });
+    const [currentStep, setCurrentStep] = useState(1);
+
+    const totalSteps = Children.count(children);
+
+    const dispatch = useAppDispatch();
+    const { t } = useTranslation();
+
+    // listen to profile change in redux store and update local buffer
+    useEffect(() => {
+        setProfileBuffer({ ...profile });
+    }, [profile]);
+
+    const handleClose = () => {
+        // clear buffers and states
+        setProfileBuffer({ ...profile });
+        setWizardOpen(false);
+        // Reset to first step when the modal is closed
+        setTimeout(() => setCurrentStep(1), 200);
+    };
+
+    // next button callback, only for navigation
+    const handleNext = () => {
+        if (currentStep < totalSteps) {
+            setCurrentStep(prev => prev + 1);
+        }
+    };
+
+    // previous button callback, only for navigation
+    const handleBack = () => {
+        if (currentStep > 1) {
+            setCurrentStep(prev => prev - 1);
+        }
+    };
+
+    // persist data to backend via PUT endpoint
+    // redux store's user profile gets updated on fulfilled PUT in the reducer
+    const handleFinish = () => {
+        const destinations = profileBuffer.destinations;
+        // One destination must be primary, used to set
+        // userProfile.activeDestination to calculate score.
+        // Use first destination by default.
+        if (!destinations.find(d => d.primary)) {
+            destinations[0] = { ...destinations[0], primary: true };
+        }
+        dispatch(
+            updateUserProfile({
+                ...profileBuffer,
+                voucherRooms: profileBuffer.rooms,
+                importanceAccessibility: parseInt(
+                    profileBuffer.importanceAccessibility
+                ),
+                importanceSchools: parseInt(profileBuffer.importanceSchools),
+                importanceViolentCrime: parseInt(
+                    profileBuffer.importanceViolentCrime
+                ),
+            })
+        );
+        handleClose();
+    };
+
+    const childrenWithStepProps = Children.map(children, (child, index) => {
+        // We only clone valid elements (not strings, numbers, null, etc.)
+        if (isValidElement(child)) {
+            // Clone the element and merge the new props
+            return cloneElement(child as EditWizardChildComponent, {
+                buffer: profileBuffer,
+                setProfileBuffer: setProfileBuffer,
+                handleBack: handleBack,
+                handleNext:
+                    index === totalSteps - 1 ? handleFinish : handleNext,
+            });
+        }
+
+        // Return non-elements as they are
+        return child;
+    });
+
+    return (
+        <Wizard
+            title={t(
+                totalSteps > 1 && currentStep < 4
+                    ? "userProfile.wizard.header"
+                    : "userTrip.wizard.header"
+            )}
+            currentStep={currentStep}
+            isOpen={isWizardOpen}
+            totalSteps={totalSteps}
+            handleClose={handleClose}
+        >
+            {childrenWithStepProps}
+        </Wizard>
+    );
+};
+
+export default EditWizard;

--- a/src/frontend/src/components/EditWizard/EditWizard.tsx
+++ b/src/frontend/src/components/EditWizard/EditWizard.tsx
@@ -75,19 +75,22 @@ const EditWizard = ({
         if (!destinations.find(d => d.primary)) {
             destinations[0] = { ...destinations[0], primary: true };
         }
-        const updatedProfile = {
-            ...profileBuffer,
-            voucherRooms: profileBuffer.rooms,
-            importanceAccessibility: parseInt(
-                profileBuffer.importanceAccessibility
-            ),
-            importanceSchools: parseInt(profileBuffer.importanceSchools),
-            importanceViolentCrime: parseInt(
-                profileBuffer.importanceViolentCrime
-            ),
-        };
-        if (!_.isEqual(updatedProfile, profile)) {
-            dispatch(updateUserProfile(updatedProfile));
+        if (!_.isEqual(profileBuffer, profile)) {
+            dispatch(
+                updateUserProfile({
+                    ...profileBuffer,
+                    voucherRooms: profileBuffer.rooms,
+                    importanceAccessibility: parseInt(
+                        profileBuffer.importanceAccessibility
+                    ),
+                    importanceSchools: parseInt(
+                        profileBuffer.importanceSchools
+                    ),
+                    importanceViolentCrime: parseInt(
+                        profileBuffer.importanceViolentCrime
+                    ),
+                })
+            );
         }
         handleClose();
     };
@@ -120,6 +123,7 @@ const EditWizard = ({
             isOpen={isWizardOpen}
             totalSteps={totalSteps}
             handleClose={handleClose}
+            showProgress={totalSteps > 1}
         >
             {childrenWithStepProps}
         </Wizard>

--- a/src/frontend/src/components/EditWizard/StepBedroom.tsx
+++ b/src/frontend/src/components/EditWizard/StepBedroom.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from "react-i18next";
 
 import InputNumber from "components/InputNumber";
 import WizardStep from "components/Wizard/WizardStep";
-import type { BaseProps } from "./types";
+import type { BaseProps } from "../../pages/Discover/Profile/types";
 
 const StepBedroom = ({
     buffer,
@@ -11,6 +11,10 @@ const StepBedroom = ({
     handleNext,
 }: BaseProps) => {
     const { t } = useTranslation();
+
+    if (!buffer || !setProfileBuffer || !handleBack || !handleNext) {
+        return <></>;
+    }
 
     const onChange = (rooms: number) =>
         setProfileBuffer(state => ({

--- a/src/frontend/src/components/EditWizard/StepImportance.tsx
+++ b/src/frontend/src/components/EditWizard/StepImportance.tsx
@@ -5,7 +5,7 @@ import ImportanceSliders, {
     type FactorKeys,
 } from "components/ImportanceSliders";
 import WizardStep from "components/Wizard/WizardStep";
-import type { BaseProps } from "./types";
+import type { BaseProps } from "../../pages/Discover/Profile/types";
 
 const StepImportance = ({
     buffer,
@@ -14,6 +14,10 @@ const StepImportance = ({
     handleNext,
 }: BaseProps) => {
     const { t } = useTranslation();
+
+    if (!buffer || !setProfileBuffer || !handleBack || !handleNext) {
+        return <></>;
+    }
 
     const onChange = (value: number, factor: FactorKeys) =>
         setProfileBuffer(state => ({

--- a/src/frontend/src/components/EditWizard/StepTravelMode.tsx
+++ b/src/frontend/src/components/EditWizard/StepTravelMode.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import CommuterRailCheckbox from "components/CommuterRailCheckbox";
 import TravelModeToggle from "components/TravelModeToggle";
 import WizardStep from "components/Wizard/WizardStep";
-import type { BaseProps } from "./types";
+import type { BaseProps } from "../../pages/Discover/Profile/types";
 
 const StepTravelMode = ({
     buffer,
@@ -13,6 +13,10 @@ const StepTravelMode = ({
     handleNext,
 }: BaseProps) => {
     const { t } = useTranslation();
+
+    if (!buffer || !setProfileBuffer || !handleBack || !handleNext) {
+        return <></>;
+    }
 
     const onChangeToggle = (keys: Set<Key>) =>
         setProfileBuffer(state => {

--- a/src/frontend/src/components/EditWizard/StepTrips.tsx
+++ b/src/frontend/src/components/EditWizard/StepTrips.tsx
@@ -2,15 +2,15 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { Destination } from "reducers/userProfile/types";
-import type { BaseProps } from "./types";
 
 import PlusIcon from "assets/icons/plus.svg?react";
 import TimesIcon from "assets/icons/times.svg?react";
 import Button from "components/base/Button/Button";
 import WizardStep from "components/Wizard/WizardStep";
-import { selectInvalidTimesAndPathsData } from "src/reducers/networks/networksSlice";
-import { useAppSelector } from "src/store/store";
-import AddTripModal from "./AddTripModal";
+import AddTripModal from "pages/Discover/Profile/AddTripModal";
+import { selectInvalidTimesAndPathsData } from "reducers/networks/networksSlice";
+import { useAppSelector } from "store/store";
+import type { BaseProps } from "../../pages/Discover/Profile/types";
 
 const StepTrips = ({
     buffer,
@@ -22,6 +22,10 @@ const StepTrips = ({
     const invalidData = useAppSelector(selectInvalidTimesAndPathsData);
     const [addTripModalOpen, setIsAddTripModalOpen] = useState(false);
     const [showErrorMessage, setShowErrorMessage] = useState(false);
+
+    if (!buffer || !setProfileBuffer || !handleBack || !handleNext) {
+        return <></>;
+    }
     const destinations = buffer.destinations;
 
     const onRemoveDestination = (destinationIndex: number) => {

--- a/src/frontend/src/components/EditWizard/StepTrips.tsx
+++ b/src/frontend/src/components/EditWizard/StepTrips.tsx
@@ -12,12 +12,17 @@ import { selectInvalidTimesAndPathsData } from "reducers/networks/networksSlice"
 import { useAppSelector } from "store/store";
 import type { BaseProps } from "../../pages/Discover/Profile/types";
 
+interface TripsStepProps extends BaseProps {
+    disableBack?: boolean;
+}
+
 const StepTrips = ({
     buffer,
     setProfileBuffer,
     handleBack,
     handleNext,
-}: BaseProps) => {
+    disableBack,
+}: TripsStepProps) => {
     const { t } = useTranslation();
     const invalidData = useAppSelector(selectInvalidTimesAndPathsData);
     const [addTripModalOpen, setIsAddTripModalOpen] = useState(false);
@@ -59,6 +64,7 @@ const StepTrips = ({
             handleBack={handleBack}
             handleNext={handleNext}
             disableNext={!destinations.length || showErrorMessage}
+            disableBack={disableBack}
         >
             <AddTripModal
                 isModalOpen={addTripModalOpen}

--- a/src/frontend/src/components/YourTrips/YourTrips.tsx
+++ b/src/frontend/src/components/YourTrips/YourTrips.tsx
@@ -1,18 +1,18 @@
 import { useTranslation } from "react-i18next";
 
-import Button from "components/base/Button/Button";
-import { yourTripsStyles } from "./YourTrips.styles";
-import { useAppSelector } from "src/store/store";
-import { selectUseTransit } from "src/reducers/networks/networksSlice";
-import neighborhoodDetailStyles from "src/pages/NeighborhoodDetail/styles/NeighborhoodDetail.styles";
 import TouchPromptIcon from "assets/icons/touch-prompt.svg?react";
-import CommuteGroup from "./CommuteGroup";
-import type { TripType } from "./types";
-import { selectUserDestinations } from "src/reducers/userProfile/userSlice";
-import type { Destination } from "src/reducers/userProfile/types";
+import Button from "components/base/Button/Button";
 import { useMemo } from "react";
 import { useDispatch } from "react-redux";
-import { setIsEditTripsOpen } from "src/reducers/modalsDisplay/modalsDisplaySlice";
+import neighborhoodDetailStyles from "src/pages/NeighborhoodDetail/styles/NeighborhoodDetail.styles";
+import { setIsEditTripsWizardOpen } from "src/reducers/modalsDisplay/modalsDisplaySlice";
+import { selectUseTransit } from "src/reducers/networks/networksSlice";
+import type { Destination } from "src/reducers/userProfile/types";
+import { selectUserDestinations } from "src/reducers/userProfile/userSlice";
+import { useAppSelector } from "src/store/store";
+import CommuteGroup from "./CommuteGroup";
+import type { TripType } from "./types";
+import { yourTripsStyles } from "./YourTrips.styles";
 
 const YourTrips = ({
     isMobile,
@@ -97,7 +97,7 @@ const YourTrips = ({
                 variant="outline"
                 size="medium"
                 className={styles.editButton()}
-                onPress={() => dispatch(setIsEditTripsOpen(true))}
+                onPress={() => dispatch(setIsEditTripsWizardOpen(true))}
             >
                 {t("yourTrips.editTrips")}
             </Button>

--- a/src/frontend/src/pages/Discover/Discover.tsx
+++ b/src/frontend/src/pages/Discover/Discover.tsx
@@ -2,7 +2,10 @@ import { useEffect } from "react";
 import { useParams } from "react-router";
 
 import useMediaQuery from "hooks/useMediaQuery";
-import { setIsNeighborhoodDetailsOpen } from "reducers/modalsDisplay/modalsDisplaySlice";
+import {
+    setIsEditTripsWizardOpen,
+    setIsNeighborhoodDetailsOpen,
+} from "reducers/modalsDisplay/modalsDisplaySlice";
 import {
     getNeighborhoodsAndBounds,
     getRankedNeighborhoodLists,
@@ -17,6 +20,7 @@ import {
     getNetworks,
 } from "reducers/networks/networksThunk";
 import { getUserProfile } from "reducers/userProfile/userProfileThunk";
+import EditTripsWizard from "src/components/EditWizard/EditTripsWizard";
 import { useAppDispatch, useAppSelector, type RootState } from "store/store";
 import Desktop from "./Desktop";
 import discoverStyles from "./Discover.styles";
@@ -105,6 +109,11 @@ const Discover = () => {
             dispatch(getRankedNeighborhoodLists());
         }
     }, [networksDataIsReady, activeMode, userProfile]);
+
+    useEffect(() => {
+        if (!userProfileLoading && destinations.length && invalidData?.length)
+            dispatch(setIsEditTripsWizardOpen(true));
+    }, [invalidData, destinations]);
     // --------------------------------------
 
     useEffect(() => {
@@ -112,11 +121,13 @@ const Discover = () => {
     }, [zipcode]);
 
     return userProfileLoading ||
-        (destinations.length && !networksDataIsReady && !invalidData) ? (
+        (destinations.length && !networksDataIsReady) ? (
         <div className={loadingWrapper()}>
             <div className={loadingSpinner()} />
+            {/* Enable displaying invalid destination error */}
+            <EditTripsWizard />
         </div>
-    ) : destinations.length && !invalidData?.length ? (
+    ) : destinations.length ? (
         isDesktop ? (
             <Desktop />
         ) : (

--- a/src/frontend/src/pages/Discover/Discover.tsx
+++ b/src/frontend/src/pages/Discover/Discover.tsx
@@ -38,11 +38,14 @@ const Discover = () => {
         networks,
         timesAndRoutesData,
     } = useAppSelector(({ networks }: RootState) => networks);
+    const userProfile = useAppSelector(
+        ({ userProfile }: RootState) => userProfile
+    );
     const {
         destinations,
         loading: userProfileLoading,
         error: userProfileError,
-    } = useAppSelector(({ userProfile }: RootState) => userProfile);
+    } = userProfile;
     const isDesktop = useMediaQuery("(min-width: 768px)");
 
     const { loadingWrapper, loadingSpinner } = discoverStyles({
@@ -93,10 +96,15 @@ const Discover = () => {
     const invalidData = useAppSelector(selectInvalidTimesAndPathsData);
     const activeMode = useAppSelector(selectActiveMode);
     useEffect(() => {
-        if (networksDataIsReady && activeMode) {
+        if (
+            networksDataIsReady &&
+            activeMode &&
+            !userProfileLoading &&
+            !userProfileError
+        ) {
             dispatch(getRankedNeighborhoodLists());
         }
-    }, [networksDataIsReady, activeMode]);
+    }, [networksDataIsReady, activeMode, userProfile]);
     // --------------------------------------
 
     useEffect(() => {

--- a/src/frontend/src/pages/Discover/ModalsWrapper.tsx
+++ b/src/frontend/src/pages/Discover/ModalsWrapper.tsx
@@ -2,6 +2,7 @@ import EditFiltersModal from "components/EditFiltersModal";
 import EditTripsModal from "components/EditTripsModal";
 import EditUserProfileWizard from "components/EditWizard/EditUserProfileWizard";
 import SearchModal from "components/SearchModal";
+import EditTripsWizard from "src/components/EditWizard/EditTripsWizard";
 import NeighborhoodDetail from "../NeighborhoodDetail";
 
 const ModalsWrapper = ({ isMobile }: { isMobile?: boolean }) => (
@@ -11,6 +12,7 @@ const ModalsWrapper = ({ isMobile }: { isMobile?: boolean }) => (
         <EditFiltersModal isMobile={isMobile} />
         <EditTripsModal isMobile={isMobile} />
         <EditUserProfileWizard />
+        <EditTripsWizard />
     </>
 );
 

--- a/src/frontend/src/pages/Discover/ModalsWrapper.tsx
+++ b/src/frontend/src/pages/Discover/ModalsWrapper.tsx
@@ -1,5 +1,6 @@
 import EditFiltersModal from "components/EditFiltersModal";
 import EditTripsModal from "components/EditTripsModal";
+import EditUserProfileWizard from "components/EditWizard/EditUserProfileWizard";
 import SearchModal from "components/SearchModal";
 import NeighborhoodDetail from "../NeighborhoodDetail";
 
@@ -9,6 +10,7 @@ const ModalsWrapper = ({ isMobile }: { isMobile?: boolean }) => (
         <SearchModal isMobile={isMobile} />
         <EditFiltersModal isMobile={isMobile} />
         <EditTripsModal isMobile={isMobile} />
+        <EditUserProfileWizard />
     </>
 );
 

--- a/src/frontend/src/pages/Discover/Profile/Profile.tsx
+++ b/src/frontend/src/pages/Discover/Profile/Profile.tsx
@@ -1,91 +1,28 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 
-import Button from "components/base/Button/Button";
-import SelectLanguageButtons from "components/SelectLanguageButtons";
-import Wizard from "components/Wizard/Wizard";
-import useMediaQuery from "hooks/useMediaQuery";
-import { updateUserProfile } from "reducers/userProfile/userProfileThunk";
-import { Language, type LanguageKey } from "src/enums";
-import { useAppDispatch, type RootState } from "store/store";
-import profileStyles from "./Profile.styles";
-import StepBedroom from "./StepBedroom";
-import StepImportance from "./StepImportance";
-import StepTravelMode from "./StepTravelMode";
-
 import NeighborhoodLiteImage from "assets/icons/neighborhood-lite.svg?react";
-import StepTrips from "./StepTrips";
-
-const TOTAL_STEPS = 4;
+import Button from "components/base/Button/Button";
+import EditWizard from "components/EditWizard/EditWizard";
+import StepBedroom from "components/EditWizard/StepBedroom";
+import StepImportance from "components/EditWizard/StepImportance";
+import StepTravelMode from "components/EditWizard/StepTravelMode";
+import StepTrips from "components/EditWizard/StepTrips";
+import SelectLanguageButtons from "components/SelectLanguageButtons";
+import useMediaQuery from "hooks/useMediaQuery";
+import { Language, type LanguageKey } from "src/enums";
+import profileStyles from "./Profile.styles";
 
 const Profile = () => {
-    const profile = useSelector((state: RootState) => state.userProfile);
-    const [profileBuffer, setProfileBuffer] = useState({ ...profile });
     const [isWizardOpen, setWizardOpen] = useState(false);
-    const [currentStep, setCurrentStep] = useState(1);
 
-    const dispatch = useAppDispatch();
     const { t } = useTranslation();
     const { lang } = useParams<{ lang: LanguageKey | undefined }>();
     const isDesktop = useMediaQuery("(min-width: 768px)");
     const { root, content, title, description, caption } = profileStyles({
         isMobile: !isDesktop,
     });
-
-    // listen to profile change in redux store and update local buffer
-    useEffect(() => {
-        setProfileBuffer({ ...profile });
-    }, [profile]);
-
-    const handleClose = () => {
-        // clear buffers and states
-        setProfileBuffer({ ...profile });
-        setWizardOpen(false);
-        // Reset to first step when the modal is closed
-        setTimeout(() => setCurrentStep(1), 200);
-    };
-
-    // next button callback, only for navigation
-    const handleNext = () => {
-        if (currentStep < TOTAL_STEPS) {
-            setCurrentStep(prev => prev + 1);
-        }
-    };
-
-    // previous button callback, only for navigation
-    const handleBack = () => {
-        if (currentStep > 1) {
-            setCurrentStep(prev => prev - 1);
-        }
-    };
-
-    // persist data to backend via PUT endpoint
-    // redux store's user profile gets updated on fulfilled PUT in the reducer
-    const handleFinish = () => {
-        const destinations = profileBuffer.destinations;
-        // One destination must be primary, used to set
-        // userProfile.activeDestination to calculate score.
-        // Use first destination by default.
-        if (!destinations.find(d => d.primary)) {
-            destinations[0] = { ...destinations[0], primary: true };
-        }
-        dispatch(
-            updateUserProfile({
-                ...profileBuffer,
-                voucherRooms: profileBuffer.rooms,
-                importanceAccessibility: parseInt(
-                    profileBuffer.importanceAccessibility
-                ),
-                importanceSchools: parseInt(profileBuffer.importanceSchools),
-                importanceViolentCrime: parseInt(
-                    profileBuffer.importanceViolentCrime
-                ),
-            })
-        );
-        handleClose();
-    };
 
     return (
         <div className={root()}>
@@ -109,42 +46,15 @@ const Profile = () => {
             {isDesktop && (
                 <SelectLanguageButtons language={lang || Language.EN} />
             )}
-            <Wizard
-                title={t(
-                    currentStep < 4
-                        ? "userProfile.wizard.header"
-                        : "userTrip.wizard.header"
-                )}
-                currentStep={currentStep}
-                isOpen={isWizardOpen}
-                totalSteps={TOTAL_STEPS}
-                handleClose={handleClose}
+            <EditWizard
+                isWizardOpen={isWizardOpen}
+                setWizardOpen={setWizardOpen}
             >
-                <StepBedroom
-                    buffer={profileBuffer}
-                    setProfileBuffer={setProfileBuffer}
-                    handleBack={handleBack}
-                    handleNext={handleNext}
-                />
-                <StepImportance
-                    buffer={profileBuffer}
-                    setProfileBuffer={setProfileBuffer}
-                    handleBack={handleBack}
-                    handleNext={handleNext}
-                />
-                <StepTravelMode
-                    buffer={profileBuffer}
-                    setProfileBuffer={setProfileBuffer}
-                    handleBack={handleBack}
-                    handleNext={handleNext}
-                />
-                <StepTrips
-                    buffer={profileBuffer}
-                    setProfileBuffer={setProfileBuffer}
-                    handleBack={handleBack}
-                    handleNext={handleFinish}
-                />
-            </Wizard>
+                <StepBedroom />
+                <StepImportance />
+                <StepTravelMode />
+                <StepTrips />
+            </EditWizard>
         </div>
     );
 };

--- a/src/frontend/src/pages/Discover/Profile/types.ts
+++ b/src/frontend/src/pages/Discover/Profile/types.ts
@@ -3,8 +3,9 @@ import type { Dispatch, SetStateAction } from "react";
 import type { UserProfileSliceState } from "reducers/userProfile/types";
 
 export interface BaseProps {
-    buffer: UserProfileSliceState;
-    setProfileBuffer: Dispatch<SetStateAction<UserProfileSliceState>>;
-    handleBack: () => void;
-    handleNext: () => void;
+    buffer?: UserProfileSliceState;
+    setProfileBuffer?: Dispatch<SetStateAction<UserProfileSliceState>>;
+    handleBack?: () => void;
+    handleNext?: () => void;
+    handleFinish?: () => void;
 }

--- a/src/frontend/src/reducers/modalsDisplay/modalsDisplaySlice.ts
+++ b/src/frontend/src/reducers/modalsDisplay/modalsDisplaySlice.ts
@@ -7,6 +7,7 @@ interface modalsDisplaySliceState {
     isEditTripsOpen: boolean;
     isSearchModalOpen: boolean;
     isEditProfileWizardOpen: boolean;
+    isEditTripsWizardOpen: boolean;
 }
 
 const initialState: modalsDisplaySliceState = {
@@ -15,6 +16,7 @@ const initialState: modalsDisplaySliceState = {
     isEditTripsOpen: false,
     isSearchModalOpen: false,
     isEditProfileWizardOpen: false,
+    isEditTripsWizardOpen: false,
 };
 
 export const modalsDisplaySlice = createSlice({
@@ -51,6 +53,12 @@ export const modalsDisplaySlice = createSlice({
         ) => {
             state.isEditProfileWizardOpen = status;
         },
+        setIsEditTripsWizardOpen: (
+            state,
+            { payload: status }: { payload: boolean }
+        ) => {
+            state.isEditTripsWizardOpen = status;
+        },
     },
 });
 
@@ -60,6 +68,7 @@ export const {
     setIsEditFiltersOpen,
     setIsSearchModalOpen,
     setIsEditProfileWizardOpen,
+    setIsEditTripsWizardOpen,
 } = modalsDisplaySlice.actions;
 
 export const selectIsNeighborhoodDetailsOpen = (state: RootState) =>
@@ -72,5 +81,7 @@ export const selectIsSearchModalOpen = (state: RootState) =>
     state.modalsDisplay.isSearchModalOpen;
 export const selectIsEditProfileWizardOpen = (state: RootState) =>
     state.modalsDisplay.isEditProfileWizardOpen;
+export const selectIsEditTripsWizardOpen = (state: RootState) =>
+    state.modalsDisplay.isEditTripsWizardOpen;
 
 export default modalsDisplaySlice.reducer;

--- a/src/frontend/src/reducers/modalsDisplay/modalsDisplaySlice.ts
+++ b/src/frontend/src/reducers/modalsDisplay/modalsDisplaySlice.ts
@@ -6,6 +6,7 @@ interface modalsDisplaySliceState {
     isEditFiltersOpen: boolean;
     isEditTripsOpen: boolean;
     isSearchModalOpen: boolean;
+    isEditProfileWizardOpen: boolean;
 }
 
 const initialState: modalsDisplaySliceState = {
@@ -13,6 +14,7 @@ const initialState: modalsDisplaySliceState = {
     isEditFiltersOpen: false,
     isEditTripsOpen: false,
     isSearchModalOpen: false,
+    isEditProfileWizardOpen: false,
 };
 
 export const modalsDisplaySlice = createSlice({
@@ -43,6 +45,12 @@ export const modalsDisplaySlice = createSlice({
         ) => {
             state.isSearchModalOpen = status;
         },
+        setIsEditProfileWizardOpen: (
+            state,
+            { payload: status }: { payload: boolean }
+        ) => {
+            state.isEditProfileWizardOpen = status;
+        },
     },
 });
 
@@ -51,6 +59,7 @@ export const {
     setIsEditTripsOpen,
     setIsEditFiltersOpen,
     setIsSearchModalOpen,
+    setIsEditProfileWizardOpen,
 } = modalsDisplaySlice.actions;
 
 export const selectIsNeighborhoodDetailsOpen = (state: RootState) =>
@@ -61,5 +70,7 @@ export const selectIsEditTripsOpen = (state: RootState) =>
     state.modalsDisplay.isEditTripsOpen;
 export const selectIsSearchModalOpen = (state: RootState) =>
     state.modalsDisplay.isSearchModalOpen;
+export const selectIsEditProfileWizardOpen = (state: RootState) =>
+    state.modalsDisplay.isEditProfileWizardOpen;
 
 export default modalsDisplaySlice.reducer;

--- a/src/frontend/src/reducers/networks/networksSlice.ts
+++ b/src/frontend/src/reducers/networks/networksSlice.ts
@@ -6,11 +6,7 @@ import {
 } from "reducers/userProfile/userProfileThunk";
 import { NetworkModeOptions } from "src/enums";
 import type { RootState } from "store/store";
-import {
-    getAllTimesAndPathsData,
-    getNetworks,
-    getTimesAndPathsDataForPlace,
-} from "./networksThunk";
+import { getAllTimesAndPathsData, getNetworks } from "./networksThunk";
 import type { NetworksSliceState, TrafficType } from "./types";
 
 import getActiveModeKey from "./utils/getActiveModeKey";
@@ -50,31 +46,17 @@ export const networksSlice = createSlice({
                 state.error =
                     action.error.message ?? "Failed to fetch networks.";
             })
-            .addCase(getTimesAndPathsDataForPlace.pending, state => {
-                state.loading = true;
-            })
-            .addCase(
-                getTimesAndPathsDataForPlace.fulfilled,
-                (state, action) => {
-                    state.loading = false;
-                    state.timesAndRoutesData = {
-                        ...state.timesAndRoutesData,
-                        [action.payload.label]: action.payload.data,
-                    };
-                }
-            )
-            .addCase(getTimesAndPathsDataForPlace.rejected, (state, action) => {
-                state.loading = false;
-                state.error =
-                    action.error.message ??
-                    "Failed to fetch time and paths data.";
-            })
             .addCase(getAllTimesAndPathsData.pending, state => {
                 state.loading = true;
             })
             .addCase(getAllTimesAndPathsData.fulfilled, (state, action) => {
                 state.loading = false;
-                state.timesAndRoutesData = action.payload;
+                state.timesAndRoutesData = state.timesAndRoutesData
+                    ? {
+                          ...state.timesAndRoutesData,
+                          ...action.payload,
+                      }
+                    : action.payload;
             })
             .addCase(getAllTimesAndPathsData.rejected, (state, action) => {
                 state.loading = false;

--- a/src/frontend/src/reducers/networks/networksThunk.ts
+++ b/src/frontend/src/reducers/networks/networksThunk.ts
@@ -44,27 +44,6 @@ export const getNetworks = createAsyncThunk(
     }
 );
 
-export const getTimesAndPathsDataForPlace = createAsyncThunk<
-    any,
-    Destination,
-    { state: RootState }
->(
-    "networks/getTimesAndPathsDataForPlace",
-    async (destination, { getState, rejectWithValue }) => {
-        const state = getState();
-
-        if (!destination) {
-            return null;
-        }
-
-        try {
-            return await fetchAndProcessDataByDestination(destination, state);
-        } catch (error: any) {
-            return rejectWithValue(error.message);
-        }
-    }
-);
-
 export const getAllTimesAndPathsData = createAsyncThunk<
     any,
     Destination[],

--- a/src/frontend/src/reducers/userProfile/userProfileThunk.ts
+++ b/src/frontend/src/reducers/userProfile/userProfileThunk.ts
@@ -1,5 +1,7 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
 import { fetchUserProfile, putUserProfile } from "api/userProfile";
+import { type AppDispatch, type RootState } from "src/store/store";
+import { getAllTimesAndPathsData } from "../networks/networksThunk";
 import type { UserProfile } from "./types";
 
 export const getUserProfile = createAsyncThunk(
@@ -9,5 +11,30 @@ export const getUserProfile = createAsyncThunk(
 
 export const updateUserProfile = createAsyncThunk(
     "userProfile/updateUserProfile",
-    async (profile: UserProfile) => await putUserProfile(profile)
+    async (profile: UserProfile, { dispatch, getState, rejectWithValue }) => {
+        const data = await putUserProfile(profile);
+        const state = getState() as RootState;
+        const appDispatch = dispatch as AppDispatch;
+        // Fetch times and paths data for any new destinations
+        const newDestinations = data.destinations.filter(
+            d =>
+                !state.networks.timesAndRoutesData ||
+                !Object.keys(state.networks.timesAndRoutesData).includes(
+                    d.location.label
+                )
+        );
+        const pathsAndTimesData = await appDispatch(
+            getAllTimesAndPathsData(newDestinations)
+        );
+
+        if (getAllTimesAndPathsData.rejected.match(pathsAndTimesData)) {
+            return rejectWithValue(
+                pathsAndTimesData.payload ??
+                    "Error fetching paths and times data for new destinations"
+            );
+        }
+
+        console.log(pathsAndTimesData);
+        return data;
+    }
 );

--- a/src/frontend/src/reducers/userProfile/userProfileThunk.ts
+++ b/src/frontend/src/reducers/userProfile/userProfileThunk.ts
@@ -34,7 +34,6 @@ export const updateUserProfile = createAsyncThunk(
             );
         }
 
-        console.log(pathsAndTimesData);
         return data;
     }
 );


### PR DESCRIPTION
## Overview

Enables opening the profile and trips wizards separately for editing profile/destination information. Creates separate "user profile wizard" and "trips wizard" components to be opened on respective button calls through the app.

Also updates invalid destination handling so edits trip wizard re-opens on error.

### Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] Run `./scripts/format` to lint, format, and fix the application source code.
- [x] CI passes after rebase

### Demo


https://github.com/user-attachments/assets/01a60f9a-8227-4fb1-a08e-3e08d8ac9ee8


## Testing Instructions

 * Login as a user without destinations
 * Move through profile setup wizard and confirm no regressions
 * Add an invalid destination as part of adding trips in last step (213 scraggy neck rd, for instance)
 * Confirm that edit trips wizard re-opens on invalid data for a user to fix
 * Remove invalid destination and confirm no regressions navigating to discover page
 * Open profile/filters edit modal and select button to edit user profile
 * Confirm wizard opens and only 3 steps in progress tracker
 * Confirm user profile updates on finishing modal and components' state updates as expected in app
 * Open edit trips modal and select button to "Edit your trips"
 * Confirm trips wizard opens without progress tracker (only 1 step)
 * Confirm can open modal to add a new trip
 * Add an invalid destination and a valid boston destination
 * Confirm on selecting "finish" that the trips edit wizard re-opens prompting user to remove invalid data
 * Remove invalid data and confirm user profile updates and new destinations have paths/times data
 * Confirm destination updates are reflected in components' state (in immediate trip accordion, in destination markers, in neighborhood details "your trips")
 * Click "edit your trips" button in neighborhood details "Your Trips" section
 * Confirm no issues adding/removing destinations in wizard from here


Resolves #739 
