### PR TITLE
Refactor text search desktop list view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,5 +64,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix staging deploy workflow [#613](https://github.com/azavea/echo-locator/pull/613)
 - Fix staging basemap glyphs error [#707](https://github.com/azavea/echo-locator/pull/707)
+- Refactor text search desktop list view [#764](https://github.com/azavea/echo-locator/pull/764)
 
 ### Removed

--- a/src/frontend/src/pages/Discover/Map/NeighborhoodDetailPreviewPopup.tsx
+++ b/src/frontend/src/pages/Discover/Map/NeighborhoodDetailPreviewPopup.tsx
@@ -1,6 +1,7 @@
 import { type PopupOptions } from "maplibre-gl";
 
 import formatNeighborhoodDataByViewType from "libs/formatNeighborhoodDataByCard";
+import { useNavigate } from "react-router";
 import selectNeighborhoodZipcodeMap from "reducers/neighborhoods/selectors/selectNeighborhoodZipcodeMap";
 import { selectActiveDestination } from "reducers/userProfile/userSlice";
 import NeighborhoodCard from "src/components/NeighborhoodCard/NeighborhoodCard";
@@ -15,6 +16,7 @@ export interface DetailPreviewPopupProps extends PopupOptions {
 const NeighborhoodDetailPreviewPopup = ({
     zipcode,
 }: DetailPreviewPopupProps) => {
+    const navigate = useNavigate();
     const neighborhoodDetailsMap = useAppSelector(selectNeighborhoodZipcodeMap);
     const activeDestination = useAppSelector(selectActiveDestination);
 
@@ -29,7 +31,19 @@ const NeighborhoodDetailPreviewPopup = ({
             true
         );
 
-    return <NeighborhoodCard {...neighborhoodCardData} isPopup />;
+    const detailClick = () => {
+        navigate(`${location.pathname}/${zipcode}?display=map`, {
+            replace: true,
+        });
+    };
+
+    return (
+        <NeighborhoodCard
+            {...neighborhoodCardData}
+            onDetails={detailClick}
+            isPopup
+        />
+    );
 };
 
 export default NeighborhoodDetailPreviewPopup;

--- a/src/frontend/src/pages/Discover/Neighborhoods.tsx
+++ b/src/frontend/src/pages/Discover/Neighborhoods.tsx
@@ -45,11 +45,21 @@ const Neighborhoods = ({
     const isLoading = isRankCalculating || !networksReady;
     const neighborhoodDetailsMap = useAppSelector(selectNeighborhoodZipcodeMap);
     const {
-        groupedTopTen: topTen,
-        groupedRecommended: recommended,
-        groupedTooFar: tooFar,
+        groupedTopTen,
+        groupedRecommended,
+        groupedTooFar,
+        groupedSearchableTopTen,
+        groupedSearchableRecommended,
+        groupedSearchableTooFar,
     } = useAppSelector(selectRankedNeighborhoodsLists);
     const activeDestination = useAppSelector(selectActiveDestination) ?? "";
+
+    // If mobile, text search enabled so use groupedSearchable lists from state
+    const topTen = mobile ? groupedSearchableTopTen : groupedTopTen;
+    const recommended = mobile
+        ? groupedSearchableRecommended
+        : groupedRecommended;
+    const tooFar = mobile ? groupedSearchableTooFar : groupedTooFar;
 
     // Only show the tooFar list if there are no recommendations
     // or if all recommendations have been displayed.

--- a/src/frontend/src/reducers/neighborhoods/neighborhoodsSlice.ts
+++ b/src/frontend/src/reducers/neighborhoods/neighborhoodsSlice.ts
@@ -25,6 +25,9 @@ const initialState: NeighborhoodsSliceState = {
         groupedTopTen: [],
         groupedRecommended: [],
         groupedTooFar: [],
+        groupedSearchableTopTen: [],
+        groupedSearchableRecommended: [],
+        groupedSearchableTooFar: [],
     },
 };
 
@@ -138,17 +141,20 @@ export const selectFilterableNeighborhoodBounds = createSelector(
     ],
     (rankedNeighborhoodsLists, isFiltered, neighborhoodBounds, filters) => {
         if (isFiltered) {
-            // Use grouped lists since includes text search filtering for list view.
+            // Use searchable grouped lists since to include text search filtering.
             // If text search, include tooFar list in results since high specificity
             // that we would still want to display even if "not a match".
-            const { groupedTopTen, groupedRecommended, groupedTooFar } =
-                rankedNeighborhoodsLists;
+            const {
+                groupedSearchableTopTen,
+                groupedSearchableRecommended,
+                groupedSearchableTooFar,
+            } = rankedNeighborhoodsLists;
             const tooFarIfTextSearch = filters.textSearch?.trim()
-                ? groupedTooFar
+                ? groupedSearchableTooFar
                 : [];
             const filteredList = [
-                ...groupedTopTen,
-                ...groupedRecommended,
+                ...groupedSearchableTopTen,
+                ...groupedSearchableRecommended,
                 ...tooFarIfTextSearch,
             ].flat();
             return {

--- a/src/frontend/src/reducers/neighborhoods/neighborhoodsThunk.ts
+++ b/src/frontend/src/reducers/neighborhoods/neighborhoodsThunk.ts
@@ -38,6 +38,9 @@ export const getRankedNeighborhoodLists =
             groupedTopTen: [],
             groupedRecommended: [],
             groupedTooFar: [],
+            groupedSearchableTopTen: [],
+            groupedSearchableRecommended: [],
+            groupedSearchableTooFar: [],
         };
 
         // Get ranked list
@@ -58,6 +61,7 @@ export const getRankedNeighborhoodLists =
             );
         }
 
+        // Set base neighborhood recommendations
         groupedNeighborhoodsLists.topTen = neighborhoodsList.recommended.slice(
             0,
             10
@@ -67,7 +71,7 @@ export const getRankedNeighborhoodLists =
         groupedNeighborhoodsLists.tooFar = neighborhoodsList.tooFar;
 
         if (neighborhoodNameByZipcode) {
-            // Filter by text search for grouped list view display
+            // Filter by text search for mobile grouped list view display
             const searchTerm = state.neighborhoods.filters.textSearch
                 ?.trim()
                 .toLowerCase();
@@ -84,18 +88,35 @@ export const getRankedNeighborhoodLists =
                 zip => passesTextSearchFilter(zip as string)
             );
 
-            // Group neighborhoods by same name for list view display
+            // Group neighborhoods by same name for list view display.
+            // Text-searched recommendations list and base recommendations list
+            // stay separate since desktop list view does not enable text searching.
             groupedNeighborhoodsLists.groupedTopTen =
                 groupRankingsByLikeNeigborhoodName(
-                    recommendedFilteredListView.slice(0, 10),
+                    groupedNeighborhoodsLists.topTen,
                     neighborhoodNameByZipcode
                 );
             groupedNeighborhoodsLists.groupedRecommended =
                 groupRankingsByLikeNeigborhoodName(
-                    recommendedFilteredListView.slice(10),
+                    groupedNeighborhoodsLists.recommended,
                     neighborhoodNameByZipcode
                 );
             groupedNeighborhoodsLists.groupedTooFar =
+                groupRankingsByLikeNeigborhoodName(
+                    groupedNeighborhoodsLists.tooFar,
+                    neighborhoodNameByZipcode
+                );
+            groupedNeighborhoodsLists.groupedSearchableTopTen =
+                groupRankingsByLikeNeigborhoodName(
+                    recommendedFilteredListView.slice(0, 10),
+                    neighborhoodNameByZipcode
+                );
+            groupedNeighborhoodsLists.groupedSearchableRecommended =
+                groupRankingsByLikeNeigborhoodName(
+                    recommendedFilteredListView.slice(10),
+                    neighborhoodNameByZipcode
+                );
+            groupedNeighborhoodsLists.groupedSearchableTooFar =
                 groupRankingsByLikeNeigborhoodName(
                     tooFarFilteredListView,
                     neighborhoodNameByZipcode

--- a/src/frontend/src/reducers/neighborhoods/types.ts
+++ b/src/frontend/src/reducers/neighborhoods/types.ts
@@ -97,6 +97,9 @@ export interface RankedNeighborhoodsLists {
     groupedTopTen: (string | string[])[];
     groupedRecommended: (string | string[])[];
     groupedTooFar: (string | string[])[];
+    groupedSearchableTopTen: (string | string[])[];
+    groupedSearchableRecommended: (string | string[])[];
+    groupedSearchableTooFar: (string | string[])[];
 }
 
 export interface NeighborhoodsSliceState {

--- a/src/frontend/src/reducers/networks/networksSlice.ts
+++ b/src/frontend/src/reducers/networks/networksSlice.ts
@@ -113,7 +113,7 @@ export const selectInvalidTimesAndPathsData = createSelector(
     timesAndRoutesData =>
         timesAndRoutesData &&
         Object.keys(timesAndRoutesData).filter(key =>
-            Object.values(timesAndRoutesData[key]).every(
+            Object.values(timesAndRoutesData[key]).some(
                 n => !n.timesAndRoutesDataReady
             )
         )


### PR DESCRIPTION
## Overview

Refactors the text search list display so that the desktop list view does not update on text search. The text search should affect the desktop map view and existing conditions of mobile (ie text search is synced between mobile map and list, filtering both).

Brings the detail button into the desktop neighborhood hover popover for easily navigating to details now that the list view does not update.

Commit b6a66cdd5e98e07f68078fa1af95f866778353f9 also addresses an error I found along the way. Apparently some destinations have paths/times data for *some* network types but not all (ex: `111 Massachusetts Avenue, Billerica, Massachusetts 01821, United States` has data for peak, peak no express, and car but no data for off-peak travel modes). We would need a more surgical fix in many different components to handle destinations that conditionally work with the right user selections (and would be invalid with others) so for the time being I'm treating these destinations as invalid.

### Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] Run `./scripts/format` to lint, format, and fix the application source code.
- [x] CI passes after rebase

### Demo

https://github.com/user-attachments/assets/62280201-51c3-4e2f-8dd8-a3a3b16a47b9




## Testing Instructions

 * Login with desktop screen view
 * Open up the text search and input text (either fuzzy search or neighborhood selection)
 * On search modal close, confirm map updates as expected but the sidebar list no longer updates
 * Open up filters and make some adjustments
 * Confirm list view updates and neighborhood names are grouped as expected
 * Text search again and confirm no changes to list view
 * On mobile, confirm text searches continue to be synced between map and list view. Both the map and list view should be affected by text search. 


Resolves #749
