### PR TITLE
Fix various modal & autocomplete UX issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,5 +66,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix staging basemap glyphs error [#707](https://github.com/azavea/echo-locator/pull/707)
 - Refactor text search desktop list view [#764](https://github.com/azavea/echo-locator/pull/764)
 - Fix neighborhood detail and wizard UX bugs [#762](https://github.com/azavea/echo-locator/pull/762)
+- Fix various modal & autocomplete UX issues [#766](https://github.com/azavea/echo-locator/pull/766)
 
 ### Removed

--- a/src/frontend/src/components/base/Autocomplete/Autocomplete.tsx
+++ b/src/frontend/src/components/base/Autocomplete/Autocomplete.tsx
@@ -1,11 +1,11 @@
 import { useAsyncList, type AsyncListData } from "@react-stately/data";
 import type { Point } from "geojson";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
     ComboBox as AriaCombobox,
     Input,
-    Menu,
-    MenuItem,
+    ListBox,
+    ListBoxItem,
     SearchField,
 } from "react-aria-components";
 
@@ -74,15 +74,9 @@ export function Autocomplete({
         initialFilterText: value ?? "",
     });
 
-    // Force close menu on suggestion selection
-    useEffect(() => {
-        setIsMenuOpen(
-            !!filteredSuggestions.items.length &&
-                !filteredSuggestions.items.find(
-                    i => i.name === filteredSuggestions.filterText
-                )
-        );
-    }, [filteredSuggestions.items, filteredSuggestions.filterText]);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const listRef = useRef<HTMLDivElement>(null);
+    const clearButtonRef = useRef<HTMLButtonElement>(null);
 
     // Handles filter text set from other parent search,
     // to keep the map search and list search values in sync
@@ -91,7 +85,6 @@ export function Autocomplete({
     }, [value]);
 
     const handleTextSearch = () => {
-        setIsMenuOpen(false);
         if (filteredSuggestions.filterText) {
             const search = allowFuzzySearch
                 ? { name: filteredSuggestions.filterText }
@@ -119,6 +112,8 @@ export function Autocomplete({
                 inputValue={filteredSuggestions.filterText}
                 allowsCustomValue
                 aria-label="Search"
+                onOpenChange={isOpen => setIsMenuOpen(isOpen)}
+                onBlur={handleTextSearch}
             >
                 <SearchField
                     aria-label="Search Input"
@@ -130,11 +125,13 @@ export function Autocomplete({
                     <Input
                         placeholder={placeholder}
                         className={inputStyles()}
+                        ref={inputRef}
                     />
                     {filteredSuggestions.filterText && (
                         <Button
                             variant="outline"
                             size="small"
+                            ref={clearButtonRef}
                             leftIcon={
                                 <TimesIcon className="h-5 w-5 font-ligth fill-black" />
                             }
@@ -144,26 +141,27 @@ export function Autocomplete({
                         />
                     )}
                 </SearchField>
-                <Menu
+                <ListBox
+                    ref={listRef}
                     aria-label="Search suggestions"
-                    items={isMenuOpen ? filteredSuggestions.items : []}
+                    items={filteredSuggestions.items}
                     className={`${baseDropdownPopoverStyles} ${isMenuOpen ? "!block" : "hidden"} w-full rounded-t-none`}
                 >
                     {item => {
                         const distinctItem =
                             item.full_address ?? item.address ?? item.name;
                         return (
-                            <MenuItem
+                            <ListBoxItem
                                 id={distinctItem}
                                 onAction={() => handleSelection(item)}
                                 className={baseDropdownItemStyles}
                                 aria-label="item"
                             >
                                 {distinctItem}
-                            </MenuItem>
+                            </ListBoxItem>
                         );
                     }}
-                </Menu>
+                </ListBox>
             </AriaCombobox>
         </div>
     );

--- a/src/frontend/src/components/base/Button/Button.tsx
+++ b/src/frontend/src/components/base/Button/Button.tsx
@@ -5,6 +5,7 @@ import {
 } from "react-aria-components";
 import { type VariantProps } from "tailwind-variants";
 
+import type { Ref } from "react";
 import buttonStyles from "./Button.styles";
 
 export interface ButtonProps
@@ -14,6 +15,7 @@ export interface ButtonProps
     leftIcon?: React.ReactNode;
     rightIcon?: React.ReactNode;
     info?: string;
+    ref?: Ref<HTMLButtonElement> | null;
     children?: React.ReactNode;
 }
 
@@ -25,11 +27,13 @@ const Button = ({
     leftIcon,
     rightIcon,
     info,
+    ref,
     ...props
 }: ButtonProps) => {
     return (
         <AriaButton
             {...props}
+            ref={ref}
             className={composeRenderProps(className, (className, renderProps) =>
                 buttonStyles({
                     ...renderProps,

--- a/src/frontend/src/components/base/Modal/Modal.styles.ts
+++ b/src/frontend/src/components/base/Modal/Modal.styles.ts
@@ -21,7 +21,7 @@ export const modalOverlayStyles = tv({
 
 export const modalStyles = tv({
     base: [
-        "relative z-50 w-full justify-self-center rounded-[var(--spacing-4)] max-h-full overflow-y-scroll",
+        "relative z-50 w-full justify-self-center mx-auto rounded-[var(--spacing-4)] max-h-full overflow-y-scroll",
         "bg-white shadow-md",
     ],
     variants: {

--- a/src/frontend/src/pages/NeighborhoodDetail/styles/NeighborhoodDetail.styles.ts
+++ b/src/frontend/src/pages/NeighborhoodDetail/styles/NeighborhoodDetail.styles.ts
@@ -2,7 +2,7 @@ import { tv } from "tailwind-variants";
 
 const neighborhoodDetailStyles = tv({
     slots: {
-        root: "flex flex-col items-start max-w-[900px] min-h-[530px] m-2 rounded-2xl bg-white shadow-2xl",
+        root: "flex flex-col items-start max-w-[900px] min-h-[530px] rounded-2xl bg-white shadow-2xl",
         headerMapContainer: "relative min-h-[330px] h-[330px] w-full",
         headerContainer:
             "flex flex-col self-stretch items-start p-4 gap-3 border-t border-b border-gray-300 bg-gray-50",
@@ -39,7 +39,7 @@ const neighborhoodDetailStyles = tv({
     variants: {
         isMobile: {
             true: {
-                root: "m-2",
+                root: "m-0",
                 headerContainer: "p-5",
                 headerContent: "flex-col",
                 toggleGroup: "p-5 pb-0",


### PR DESCRIPTION
## Overview

1. Fixes all modal alignment so that centered on Safari and iOS

2. Fixes autocomplete UX bugs:
   - Dispatches text search on exiting modals vs explicitly clicking outside of input and then exiting modal
   - Prevents autocomplete dropdown suggestions from remaining open following selection or search between mobile map and list view displays. Broadly cleans up autocomplete dropdown open logic
   - Allows keyboard navigation to text search clear button Note: I still can't setup keyboard navigation for the dropdown options. The react-aria combobox component has a lot of internal logic that *should* setup navigation from the get-go but I think is getting thrown off since we're using it within modals  (under the hood it expects a popover ref for the dropdown) and that's overwriting my explicit keydown callbacks. I'm leaving this for now with our remaining budget and we have an issue open to address (#751 ) 

### Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] Run `./scripts/format` to lint, format, and fix the application source code.
- [x] CI passes after rebase

### Demo

Modals centered in Safari and iOS:
<img width="576" height="799" alt="Screenshot 2025-10-30 at 10 48 25 AM" src="https://github.com/user-attachments/assets/48a16024-e22a-4332-bbad-5ec8e5b5a7f6" />

Text search UX cleanup:


https://github.com/user-attachments/assets/604af3a0-6570-40fa-a807-f36c1135d1f0


## Testing Instructions

 * `scripts/server` and login
 * On mobile in the map display page, open up the text seach modal
 * Add some text input for a fuzzy search and exit the search modal
 * Confirm search performs as expected and navigate to list display
 * Confirm text search updated in list display search input and no dropdown is open
 * Clear text search and confirm no regressions resetting that filter
 * Input text search and make a neighborhood selection
 * Confirm the dropdown closes and the search performs as expected
 * Navigate to the map display and open the search modal
 * Confirm the dropdown is not open
 * Confirm no regressions with text search on desktop view
 * Open the app in a Safari browser
 * Confirm modals are centered as expected, specifically with login input modal, neighborhood details, and the search modal
 * Open the app in a Firefox browswer
 * Open responsive design mode and select different devices, specifically various iOS devices
 * Confirm modals are centered as expected in each device type


Resolves #750 #752 #757 
