### PR TITLE
Offset modals if mobile keyboard open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,5 +68,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Refactor text search desktop list view [#764](https://github.com/azavea/echo-locator/pull/764)
 - Fix neighborhood detail and wizard UX bugs [#762](https://github.com/azavea/echo-locator/pull/762)
 - Fix various modal & autocomplete UX issues [#766](https://github.com/azavea/echo-locator/pull/766)
+- Offset modals if mobile keyboard open [#774](https://github.com/azavea/echo-locator/pull/774)
 
 ### Removed

--- a/src/frontend/src/components/base/Modal/Modal.tsx
+++ b/src/frontend/src/components/base/Modal/Modal.tsx
@@ -4,6 +4,7 @@ import {
     ModalOverlay as AriaModalOverlay,
     type ModalOverlayProps as AriaModalOverlayBaseProps,
 } from "react-aria-components";
+import useMobileKeyboardOffset from "src/hooks/useMobileKeyboardOffset";
 import { modalOverlayStyles, modalStyles } from "./Modal.styles";
 
 export type ModalWidth = "small" | "medium" | "large";
@@ -36,17 +37,25 @@ export const ModalOverlay = (props: AriaModalOverlayProps) => (
     />
 );
 
-export const Modal = (props: AriaModalProps) => (
-    <AriaModal
-        {...props}
-        className={({ isEntering, isExiting }) =>
-            modalStyles({
-                isEntering,
-                isExiting,
-                size: props.size,
-                overideVerticalCenter: props.overideVerticalCenter,
-                className: props.className as string,
-            })
-        }
-    />
-);
+export const Modal = (props: AriaModalProps) => {
+    const keyboardOffset = useMobileKeyboardOffset();
+    return (
+        <AriaModal
+            {...props}
+            // Overrides all vertical centering in modalStyles
+            // if mobile keyboard is open to prevent overlap
+            style={{
+                transform: `translateY(-${keyboardOffset / 2}px)`,
+            }}
+            className={({ isEntering, isExiting }) =>
+                modalStyles({
+                    isEntering,
+                    isExiting,
+                    size: props.size,
+                    overideVerticalCenter: props.overideVerticalCenter,
+                    className: props.className as string,
+                })
+            }
+        />
+    );
+};

--- a/src/frontend/src/hooks/useMobileKeyboardOffset.ts
+++ b/src/frontend/src/hooks/useMobileKeyboardOffset.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+const useMobileKeyboardOffset = (): number => {
+    const [offset, setOffset] = useState(0);
+
+    useEffect(() => {
+        const handleResize = () => {
+            const vh = window.visualViewport?.height || window.innerHeight;
+            const fullHeight = window.innerHeight;
+            const keyboardHeight = fullHeight - vh;
+            setOffset(keyboardHeight);
+        };
+
+        window.visualViewport?.addEventListener("resize", handleResize);
+        return () =>
+            window.visualViewport?.removeEventListener("resize", handleResize);
+    }, []);
+
+    return offset;
+};
+
+export default useMobileKeyboardOffset;


### PR DESCRIPTION
## Overview

Adds a custom hook to conditionally update the vertical center of modals if the visual viewport changes height (ie when the iOS keyboard opens). This fix should prevent the iOS mobile keyboard from overlapping small non-scrollable modals and hiding text inputs.

### Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] Run `./scripts/format` to lint, format, and fix the application source code.
- [x] CI passes after rebase

### Demo


https://github.com/user-attachments/assets/bdac0c41-f80b-457b-b5e6-b36ff045e210



https://github.com/user-attachments/assets/7093e2ec-9e0a-497f-b208-48882c3bddc0

## Testing Instructions

 * For reliable testing open iPhone 16 or 17 simulator ([I used Xcode Simulator](https://developer.apple.com/documentation/safari-developer-tools/installing-xcode-and-simulators))
 * Checkout branch and `scripts/server`
 * Open localhost in iPhone simulator Safari and click "Sign In" button
 * Focus the text input and confirm mobile keyboard appears (I needed to manually select I/O > Toggle Software Keyboard from Xcode menu)
 * Confirm on mobile keyboard toggling that login modal shifts up in vertical height and is no longer blocked by keyboard
 * Hide keyboard and confirm modal returns to vertically center alignment
 * Confirm no regressions with modal centering throughout app
 * Navigate to open trips modal and select "Add new trip". Focus the text input and enable to keyboard and confirm modal similarly shifts center up so the text input is unblocked.
 * Confirm no alignment issues when autocomplete appears
 * Confirm no regressions with modal centering through app in desktop view


Resolves #771 
