### PR TITLE
Update boston school choice link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,5 +72,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix various modal & autocomplete UX issues [#766](https://github.com/azavea/echo-locator/pull/766)
 - Offset modals if mobile keyboard open [#774](https://github.com/azavea/echo-locator/pull/774)
 - Clean up following data update [#777](https://github.com/azavea/echo-locator/pull/777)
+- Update boston school choice link [#778](https://github.com/azavea/echo-locator/pull/778)
 
 ### Removed

--- a/src/frontend/src/constants.ts
+++ b/src/frontend/src/constants.ts
@@ -119,7 +119,6 @@ export const MAPBOX_GEOCODING_API_BASE_URL =
     "https://api.mapbox.com/search/geocode/v6/forward";
 
 export const CAMBRIDGE_SCHOOL_CHOICE_LINK = "https://www.cpsd.us/";
-export const BOSTON_SCHOOL_CHOICE_LINK =
-    "https://discover.bostonpublicschools.org/";
+export const BOSTON_SCHOOL_CHOICE_LINK = "https://bostonpublicschools.org/";
 export const AFFORDABILITY_CALCULATOR_URL =
     "https://www.bostonhousing.org/en/Section-8-Leased-Housing/How-Rent-is-Set/Can-I-afford-this-apartment-Use-our-new-Rent-Esti.aspx";


### PR DESCRIPTION
## Overview

The previous site has been renamed without a redirect and appears broken on click. Update to use the main boston public schools website.

### Checklist

- [ ] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] Run `./scripts/format` to lint, format, and fix the application source code.
- [ ] CI passes after rebase


## Testing Instructions

 * Login to staging and select a boston neighborhood from the recommendations list
 * Click the boston school choice link and confirm update boston pubic schools website opens in new tab
