### PR TITLE
Prevent users from unselecting all regions in filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,5 +75,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Offset modals if mobile keyboard open [#774](https://github.com/azavea/echo-locator/pull/774)
 - Clean up following data update [#777](https://github.com/azavea/echo-locator/pull/777)
 - Update boston school choice link [#778](https://github.com/azavea/echo-locator/pull/778)
+- Prevent users from unselecting all regions in filters [#794](https://github.com/azavea/echo-locator/pull/794)
 
 ### Removed

--- a/src/frontend/src/components/EditFiltersModal.tsx
+++ b/src/frontend/src/components/EditFiltersModal.tsx
@@ -62,22 +62,21 @@ const EditFiltersModal = ({ isMobile = false }) => {
     const [filtersBuffer, setFiltersBuffer] = useState<FiltersState>(filters);
 
     const regionsFilterSelected = (isSelected: boolean, region: string) => {
-        const updatedRegionsFilter = [...filtersBuffer.regions];
-        if (isSelected) {
-            updatedRegionsFilter.push(region);
-        } else {
-            const regionIndex = updatedRegionsFilter.indexOf(region);
-            if (regionIndex > -1) {
-                updatedRegionsFilter.splice(regionIndex, 1);
+        setFiltersBuffer(prevBufferState => {
+            const updatedRegionsFilter = new Set(prevBufferState.regions);
+            if (isSelected) {
+                updatedRegionsFilter.add(region);
+            } else {
+                updatedRegionsFilter.delete(region);
             }
-        }
-        // Prevent unselecting all regions
-        if (updatedRegionsFilter.length === 0) {
-            return;
-        }
-        setFiltersBuffer({
-            ...filtersBuffer,
-            regions: updatedRegionsFilter,
+            // Prevent unselecting all regions
+            if (updatedRegionsFilter.size === 0) {
+                return prevBufferState;
+            }
+            return {
+                ...prevBufferState,
+                regions: [...updatedRegionsFilter],
+            };
         });
     };
 
@@ -176,6 +175,11 @@ const EditFiltersModal = ({ isMobile = false }) => {
                                     key={index}
                                     size="small"
                                     variant="ghost"
+                                    isDisabled={
+                                        // prevent un-selecting last region
+                                        filtersBuffer.regions.length === 1 &&
+                                        filtersBuffer.regions.includes(name)
+                                    }
                                 >
                                     <div className="flex flex-row gap-3">
                                         <div

--- a/src/frontend/src/components/EditFiltersModal.tsx
+++ b/src/frontend/src/components/EditFiltersModal.tsx
@@ -71,6 +71,10 @@ const EditFiltersModal = ({ isMobile = false }) => {
                 updatedRegionsFilter.splice(regionIndex, 1);
             }
         }
+        // Prevent unselecting all regions
+        if (updatedRegionsFilter.length === 0) {
+            return;
+        }
         setFiltersBuffer({
             ...filtersBuffer,
             regions: updatedRegionsFilter,
@@ -159,7 +163,7 @@ const EditFiltersModal = ({ isMobile = false }) => {
                             }
                         />
                         <AriaCheckboxGroup
-                            defaultValue={filtersBuffer.regions}
+                            value={filtersBuffer.regions}
                             aria-label={t("filterModal.regionsFilterLabel")}
                             className="flex flex-col gap-5"
                         >


### PR DESCRIPTION
## Overview

Add guardrails to prevent users from unselecting all region options in the Profile modal.

### Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] Run `./scripts/format` to lint, format, and fix the application source code.
- [x] CI passes after rebase

### Demo

https://github.com/user-attachments/assets/ca64b6b3-e47e-468d-a2c8-4dd70bd88800


## Testing Instructions

 * `scripts/server`
 * Login and open the Profile modal
 * Under the Filter Regions sections attempt to unselect all region checkboxes and confirm cannot unselect last
 * Exit modal and confirm region filter works as expected
 * Open modal again and select more regions, confirm can now unselect last checkbox
 * Confirm regions filter continues to work with variety of region selections / no scenario allows you to unselect all checkboxes


Resolves #787 
