### PR TITLE
Fix incorrect topTen tag in preview cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Refactor text search desktop list view [#764](https://github.com/azavea/echo-locator/pull/764)
 - Fix neighborhood detail and wizard UX bugs [#762](https://github.com/azavea/echo-locator/pull/762)
 - Fix various modal & autocomplete UX issues [#766](https://github.com/azavea/echo-locator/pull/766)
+- Fix incorrect topTen tag in preview cards [#795](https://github.com/azavea/echo-locator/pull/795)
 - Offset modals if mobile keyboard open [#774](https://github.com/azavea/echo-locator/pull/774)
 - Clean up following data update [#777](https://github.com/azavea/echo-locator/pull/777)
 

--- a/src/frontend/src/pages/Discover/Map/NeighborhoodDetailPreviewPopup.tsx
+++ b/src/frontend/src/pages/Discover/Map/NeighborhoodDetailPreviewPopup.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router";
 import selectNeighborhoodZipcodeMap from "reducers/neighborhoods/selectors/selectNeighborhoodZipcodeMap";
 import { selectActiveDestination } from "reducers/userProfile/userSlice";
 import NeighborhoodCard from "src/components/NeighborhoodCard/NeighborhoodCard";
+import { selectRankedNeighborhoodsLists } from "src/reducers/neighborhoods/neighborhoodsSlice";
 import { useAppSelector } from "store/store";
 
 export interface DetailPreviewPopupProps extends PopupOptions {
@@ -17,6 +18,7 @@ const NeighborhoodDetailPreviewPopup = ({
     zipcode,
 }: DetailPreviewPopupProps) => {
     const navigate = useNavigate();
+    const { topTen } = useAppSelector(selectRankedNeighborhoodsLists);
     const neighborhoodDetailsMap = useAppSelector(selectNeighborhoodZipcodeMap);
     const activeDestination = useAppSelector(selectActiveDestination);
 
@@ -28,7 +30,7 @@ const NeighborhoodDetailPreviewPopup = ({
         formatNeighborhoodDataByViewType(
             neighborhoodDetailsMap[zipcode],
             activeDestination,
-            true
+            topTen.includes(zipcode)
         );
 
     const detailClick = () => {


### PR DESCRIPTION
## Overview

Fixes the "top ten" tag appearing for all desktop map preview cards. Now only the neighborhoods actually in the top ten recommendations have the "top ten" tag.

### Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] Run `./scripts/format` to lint, format, and fix the application source code.
- [x] CI passes after rebase

### Demo



https://github.com/user-attachments/assets/9399e50b-ebb7-42a3-ad86-7443eda7fbeb


## Testing Instructions

 * `scripts/server`
 * Login and view the homepage in desktop mode
 * Hover over different neighborhoods and confirm only the top ten neighborhoods in the recommendation list have the "top ten" tag
 * Adjust filters or trips and confirm as recommendations list updates the top ten tag in each neighborhood hover preview card accurately displays the "top ten" tag


Resolves #784 
