### PR TITLE
Allow un-routable neighborhoods to be recommended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Refactor networks data state to support place comparisons [#699](https://github.com/azavea/echo-locator/pull/699)
 - Refactor user authentication APIs [#718](https://github.com/azavea/echo-locator/pull/718)
 - Implement units design changes [#776](https://github.com/azavea/echo-locator/pull/776)
+- Allow un-routable neighborhoods to be recommended [#806](https://github.com/azavea/echo-locator/pull/806)
 
 ### Fixed
 

--- a/src/frontend/src/reducers/neighborhoods/selectors/neighborhoodsSortedWithRoutes.ts
+++ b/src/frontend/src/reducers/neighborhoods/selectors/neighborhoodsSortedWithRoutes.ts
@@ -10,7 +10,6 @@ import pullAt from "lodash/pullAt";
 import {
     BOOST_DOWNTOWN_RESULT_PLACE,
     DOWNTOWN_AREAS,
-    MAX_TRAVEL_TIME,
     RESULTS_WITH_DOWNTOWN,
 } from "../../../constants";
 import { createSelector } from "@reduxjs/toolkit";
@@ -91,13 +90,12 @@ export default createSelector(
                     n
                 );
 
-                const isRoutable =
-                    (useTransit && segments.length) || !useTransit;
-                if (isRoutable && time < MAX_TRAVEL_TIME) {
+                // A neighborhood is not technically "routable" if:
+                // (useTransit and !segments.length) OR time >= MAX_TRAVEL_TIME
+                // However, we don't want to exclude non-routable neighborhoods
+                // from recommendations entirely as they may be a valid options for someone.
+                // For this reason, add all neighborhoods to recommended list by default.
                     recommendedNeighborhoodsList.push(result);
-                } else {
-                    tooFarNeighborhoodsList.push(result);
-                }
             });
         const rankedRecommendedNeighborhoods = orderBy(
             recommendedNeighborhoodsList,

--- a/src/frontend/src/reducers/neighborhoods/utils/createNeighborhoodWeightedScore.ts
+++ b/src/frontend/src/reducers/neighborhoods/utils/createNeighborhoodWeightedScore.ts
@@ -46,7 +46,7 @@ export const createNeighborhoodWeightedScore = (
     // Routable neighborhoods outside the max travel time window filtered into separate list.
     // Smaller travel time is better; larger timeWeight is better (reverse range).
     const timeWeight =
-        time < MAX_TRAVEL_TIME ? scale(time, 0, MAX_TRAVEL_TIME, 1, 0) : 1;
+        time < MAX_TRAVEL_TIME ? scale(time, 0, MAX_TRAVEL_TIME, 1, 0) : 0;
     // Weight schools either by percentile binned into quarters if given max importance,
     // or otherwise weight by quintile.
     let educationWeight;


### PR DESCRIPTION
## Overview

We are no longer using a neighborhoods "routability" as a constraint to be recommended. A neighborhood that has a 2+ hour commute by car or transit can now be recommended as well as neighborhoods that may not have transit routing but are close enough to walk.

- All neighborhoods are now added to the recommended list by default and still sorted by score
- If a user select any filter settings, ECC or region, then neighborhoods that don't fit that configuration are moved to the "not a match" list
- There are no changes to the legend text and the "not a match" list description will be updated in follow up work.

### Checklist

- [x] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] Run `./scripts/format` to lint, format, and fix the application source code.
- [x] CI passes after rebase

### Demo
Neighborhood close to destination but previously un-routable and un-recommended. With updates now recommended:
<img width="1774" height="937" alt="Screenshot 2026-03-06 at 5 58 34 PM" src="https://github.com/user-attachments/assets/bea1cc37-b688-400e-94ba-dca0d8139808" />

## Testing Instructions

 * `scripts/server`
 * Login and set travel configurations to transit
 * Set destination to 700 Boylston St
 * Confirm all neighborhoods are now recommended
 * Confirm Boston - Back Bay one of the top neighborhoods (if commute time is very important)
 * Adjust importance settings and confirm neighborhoods list updates
 * Adjust variable filters and confirm neighborhoods appropriately move to the "not a match" list


Resolves #805
