### PR TITLE
Add remaining spanish and mandarin translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add transit routing architecture ADR [#804](https://github.com/azavea/echo-locator/pull/804)
 - Add neighborhood csv submission instructions [#801](https://github.com/azavea/echo-locator/pull/801)
 - Add Spanish and Mandarin translations [#807](https://github.com/azavea/echo-locator/pull/807)
+- Add final Spanish and Mandarin translations [#807](https://github.com/azavea/echo-locator/pull/822)
 
 ### Changed
 

--- a/src/frontend/public/locales/es/translation.json
+++ b/src/frontend/public/locales/es/translation.json
@@ -37,19 +37,19 @@
         "subtitle": "Las recomendaciones se basan en tu perfil y el viaje seleccionado.",
         "topTen": "10 Mejores",
         "bestRecTitle": "Recomendaciones mejor valoradas",
-        "recTitle": "Recommended",
-        "otherTitle": "Other recommended neighborhoods",
+        "recTitle": "Recomendado",
+        "otherTitle": "Otros vecindarios recomendados",
         "otherTitleLegend": "Otro",
         "tooFarTitle": "No coincide",
-        "tooFarDisclaimer": "These neighborhoods are excluded by the filters set in your profile",
+        "tooFarDisclaimer": "Estos vecindarios están excluidos por los filtros establecidos en tu perfil.",
         "groupedCountZipCodes": "códigos postales",
         "groupedLoadMore": "Mostrar más",
         "eccBenefits": "Beneficios ECC",
         "min": "minutos",
-        "over2Hours": "Over 2 hr"
+        "over2Hours": "Más de 2 horas"
     },
-    "photoCredit": "Photo by {{artist}}. ",
-    "photoSource": "Source.",
+    "photoCredit": "Foto de {{artist}}. ",
+    "photoSource": "Origen.",
     "neighborhoodDetail": {
         "addToFavorites": "Agregar a favoritos",
         "moveCountText": "¡{{count}} titulares de vales ya se mudaron aquí!",
@@ -64,7 +64,7 @@
             "header": "Beneficios de ECHO",
             "bodyText": "Asistencia financiera para el depósito de seguridad, tarifas del agente, gastos de mudanza y más."
         },
-        "schoolChoice": "School choice options",
+        "schoolChoice": "Opciones de elección de escuelas",
         "schoolsSafetyCard": {
             "header": "Escuelas y Seguridad",
             "schools": "Escuelas",
@@ -110,14 +110,14 @@
             },
             "step3": {
                 "stepNumber": "PASO 3",
-                "header": "Found a unit? Use the Affordability Calculator to check if it’s in budget",
-                "bodyText": "All Calculations are subject to a final BHA determination.",
-                "linkSubtext": "Open Affordability Calculator"
+                "header": "¿Encontraste una unidad? Usa la Calculadora de Asequibilidad para verificar si está dentro de tu presupuesto",
+                "bodyText": "Todos los cálculos están sujetos a la determinación final de BHA.",
+                "linkSubtext": "Abrir Calculadora de Asequibilidad"
             },
             "step4": {
                 "stepNumber": "PASO 4",
                 "header": "Agenda una visita y contacta a tu Coordinador de ECHO",
-                "bodyText": "Please have the unit address and Property Owner’s information ready.",
+                "bodyText": "Asegúrate de tener disponible la dirección de la unidad y los datos del propietario.",
                 "coordinatorLink": "Contacta a tu coordinador"
             },
             "unitsModal": {
@@ -131,7 +131,7 @@
     },
     "yourTrips": {
         "heading": "Sus viajes",
-        "subheading": "Commute times are estimates. Your actual commute times may vary based on your new address.",
+        "subheading": "La duración de viaje es aproximada y puede cambiar según la ubicación de tu nueva dirección.",
         "busAndTrain": "Autobús/Tren",
         "car": "Automóvil",
         "touchPrompt": "Selecciona un viaje para ver direcciones en el mapa",
@@ -178,14 +178,14 @@
                 "description": "Usamos esta información para recomendar vecindarios cerca de los lugares que visita con frecuencia.",
                 "addATrip": "Agregar un viaje",
                 "addAnotherTrip": "Agregar otro viaje",
-                "error": "You have destinations that are not valid, please remove and try again."
+                "error": "Tienes destinos que no son válidos, por favor elimínalos e inténtalo de nuevo."
             },
             "addNewTripModal": {
-                "question": "Add new trip",
+                "question": "Agrega otro viaje",
                 "purposeLabel": "¿Qué tipo de lugar es?",
                 "locationLabel": "¿Dónde?",
                 "locationPlaceholder": "Ingrese una dirección",
-                "finish": "Add trip"
+                "finish": "Agrega un viaje"
             },
             "button": {
                 "continue": "Continuar",
@@ -212,7 +212,7 @@
         "regionsFilterHeading": "Filtrar por región",
         "regionsFilterSubHeading": "Selecciona todas las regiones de tu interés",
         "otherFilterHeading": "Otros filtros",
-        "regionMapCaption": "Based on a map by",
+        "regionMapCaption": "Basado en el mapa de",
         "echoLink": "Aprenda acerca de ECHO",
         "regionsFilterLabel": "Filtrar por región",
         "eccFilter": "Sólo se recomienda Expanded Choice Communities (Más Opciones de Comunidades) (ECC)",
@@ -230,7 +230,7 @@
     "searchModalDescription": "Escriba el nombre de un vecindario para encontrarlo en el mapa",
     "searchModalPlaceholder": "Buscar vecindarios",
     "comparePage": {
-        "title": "Favorite Neighborhoods",
+        "title": "Vecindarios Favoritos",
         "subtitle": "Tus favoritos",
         "introDescription": "Agrega vecindarios a tus favoritos para que aparezcan en la comparación."
     }

--- a/src/frontend/public/locales/zh/translation.json
+++ b/src/frontend/public/locales/zh/translation.json
@@ -1,14 +1,14 @@
 {
     "discover": "发现",
     "compare": "对比",
-    "favorites": "Favorites",
+    "favorites": "最喜愛的",
     "logout": "退出",
-    "filtersButton": "Profile",
+    "filtersButton": "個人檔案",
     "transitModesSimple": {
-        "peak": "express public transit",
-        "offPeak": "express public transit",
-        "peakNoExpress": "public transit",
-        "offPeakNoExpress": "public transit",
+        "peak": "快速公共交通",
+        "offPeak": "快速公共交通",
+        "peakNoExpress": "公共交通",
+        "offPeakNoExpress": "公共交通",
         "car": "汽車"
     },
     "map": "地圖",
@@ -37,19 +37,19 @@
         "subtitle": "推薦是根據您的個人檔案和所選行程而提供。",
         "topTen": "前 10 名",
         "bestRecTitle": "最高排名的推薦",
-        "recTitle": "Recommended",
-        "otherTitle": "Other recommended neighborhoods",
+        "recTitle": "推薦",
+        "otherTitle": "其他推薦的社區",
         "otherTitleLegend": "其他",
         "tooFarTitle": "沒有相符的",
-        "tooFarDisclaimer": "These neighborhoods are excluded by the filters set in your profile",
+        "tooFarDisclaimer": "根據您個人檔案設定的篩選條件，這些社區已被排除在外",
         "groupedCountZipCodes": "個郵政編",
         "groupedLoadMore": "載入更多",
         "eccBenefits": "擴大選擇社區（ECC）補助",
         "min": "分鐘",
-        "over2Hours": "Over 2 hr"
+        "over2Hours": "超過2小時"
     },
-    "photoCredit": "Photo by {{artist}}. ",
-    "photoSource": "Source.",
+    "photoCredit": "由      提供的照片 {{artist}}. ",
+    "photoSource": "來源",
     "neighborhoodDetail": {
         "addToFavorites": "加入收藏",
         "moveCountText": "已有 {{count}} 名房屋租賃券持有者搬到這裡！",
@@ -64,7 +64,7 @@
             "header": "ECHO 補助",
             "bodyText": "經濟援助以支付保證金、仲介費、搬遷費用等。"
         },
-        "schoolChoice": "School choice options",
+        "schoolChoice": "學校選擇方案",
         "schoolsSafetyCard": {
             "header": "學校與安全",
             "schools": "學校",
@@ -110,14 +110,14 @@
             },
             "step3": {
                 "stepNumber": "步驟 3",
-                "header": "Found a unit? Use the Affordability Calculator to check if it’s in budget",
-                "bodyText": "All Calculations are subject to a final BHA determination.",
-                "linkSubtext": "Open Affordability Calculator"
+                "header": "找到單位嗎？使用負擔能力計算器查明是否符合預算",
+                "bodyText": "所有計算結果均以波房局（BHA）的最終決定為準。",
+                "linkSubtext": "開啟負擔能力計算器"
             },
             "step4": {
                 "stepNumber": "步驟 4",
                 "header": "安排參觀，並聯絡您的 ECHO 協調員",
-                "bodyText": "Please have the unit address and Property Owner’s information ready.",
+                "bodyText": "請先準備該單位地址及業主的資料。",
                 "coordinatorLink": "聯絡您的協調員"
             },
             "unitsModal": {
@@ -131,8 +131,8 @@
     },
     "yourTrips": {
         "heading": "您的行程",
-        "subheading": "Commute times are estimates. Your actual commute times may vary based on your new address.",
-        "busAndTrain": "Bus & Train",
+        "subheading": "通勤時間為估計時間。實際通勤時間可能會因您的新地址而有所不同。",
+        "busAndTrain": "巴士及地鐡",
         "car": "汽車",
         "touchPrompt": "選擇行程以在地圖上查看路線",
         "editTrips": "編輯您的行程",
@@ -178,14 +178,14 @@
                 "description": "我們會使用這些資料,推薦您經常前往的地方鄰近的社區。",
                 "addATrip": "添加一個行程",
                 "addAnotherTrip": "增加另一個行程",
-                "error": "You have destinations that are not valid, please remove and try again."
+                "error": "您輸入的目的地不正確，請删除後再試一次。"
             },
             "addNewTripModal": {
-                "question": "Add new trip",
+                "question": "增加另一個行程",
                 "purposeLabel": "那是什麼類型的場所?",
                 "locationLabel": "在哪裡？",
                 "locationPlaceholder": "請輸入地址",
-                "finish": "Add trip"
+                "finish": "增加一個行程"
             },
             "button": {
                 "continue": "继续",
@@ -199,7 +199,7 @@
         "bodyText": "使用上方的按鈕編輯您的設定並新增篩選條件",
         "showMyRecommendations": "顯示我的推薦",
         "listNeighborhoods": "列出所有社區",
-        "showTopTen": "Show Top 10",
+        "showTopTen": "顯示前10 名",
         "next": "下一頁",
         "details": "詳細資訊",
         "prev": "前一頁"
@@ -212,7 +212,7 @@
         "regionsFilterHeading": "按區域篩選",
         "regionsFilterSubHeading": "選擇您感興趣的所有區域",
         "otherFilterHeading": "其他篩選條件",
-        "regionMapCaption": "Based on a map by",
+        "regionMapCaption": "根據      提供的地圖",
         "echoLink": "了解更多關於 ECHO 的資訊",
         "regionsFilterLabel": "按區域篩選",
         "eccFilter": "僅推薦 擴大選擇社區（ECC）",
@@ -230,7 +230,7 @@
     "searchModalDescription": "輸入社區名稱以在地圖上尋找",
     "searchModalPlaceholder": "搜尋社區",
     "comparePage": {
-        "title": "Favorite Neighborhoods",
+        "title": "最喜愛的社區",
         "subtitle": "您的收藏",
         "introDescription": "將社區加入您的收藏，使其顯示在比較中。"
     }

--- a/src/frontend/src/reducers/neighborhoods/selectors/neighborhoodsSortedWithRoutes.ts
+++ b/src/frontend/src/reducers/neighborhoods/selectors/neighborhoodsSortedWithRoutes.ts
@@ -95,7 +95,7 @@ export default createSelector(
                 // However, we don't want to exclude non-routable neighborhoods
                 // from recommendations entirely as they may be a valid options for someone.
                 // For this reason, add all neighborhoods to recommended list by default.
-                    recommendedNeighborhoodsList.push(result);
+                recommendedNeighborhoodsList.push(result);
             });
         const rankedRecommendedNeighborhoods = orderBy(
             recommendedNeighborhoodsList,


### PR DESCRIPTION
## Overview

Adds the rest of the spanish and mandarin translations that where not covered by #807 

The source for the translations are here: 
- [Chinese](https://docs.google.com/document/d/1KL2YJLLSq1BYvtCUqUj9POKPa45GYBLO/edit#heading=h.yh4lnjaln8eq)
- [Spanish](https://docs.google.com/document/d/1V9V6ULaVIl5vsUQb353TuyNVNfDYtdTO/edit#heading=h.199wgccpangk)

### Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following
      [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] Run `./scripts/format` to lint, format, and fix the application source code.
- [x] CI passes after rebase

### Demo

**english**
<img width="1504" height="813" alt="image" src="https://github.com/user-attachments/assets/20da9eee-4ee2-4e42-8d4e-21ad8a9d83e2" />

**spanish**
<img width="1504" height="813" alt="image" src="https://github.com/user-attachments/assets/9405b815-f537-47e1-9173-401ab596a24c" />

**chinese**
<img width="1504" height="813" alt="image" src="https://github.com/user-attachments/assets/9bd80259-1b10-42c9-9b92-e6a32540f090" />

## Testing Instructions

 * I already pushed these changes up to a test branch so you just need to go onto staging and check to make sure that the translations have been applied.
 * Toggle the language in the top right
 * There are many places to check but one is on the discover page, click on any neighborhood in your top 10, then in the resulting modal, scroll down to "your trips" then click on "edit your trips" and ensure that all of the text in the resulting modal is in the appropriate language

Resolves #809 
